### PR TITLE
Fix CLI sync, Telegram error handling, and memU max_tokens

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -997,6 +997,7 @@ class AgentEngine:
         channel: str | None = None,
         model: str | None = None,
         internal: bool = False,
+        images: list[dict[str, Any]] | None = None,
     ) -> str:
         """Run the agent for a user message and return the final text response.
 
@@ -1004,6 +1005,8 @@ class AgentEngine:
             internal: If True, the user_message is a system-generated trigger
                       (e.g., background task completion) and won't be stored in
                       DB or shown in the UI.
+            images: Optional list of image dicts with keys ``type``,
+                    ``media_type``, and ``data`` (base64-encoded).
         """
         if self.sessions.is_running(session_id):
             raise RuntimeError(f"Session {session_id} is already running")
@@ -1020,7 +1023,7 @@ class AgentEngine:
             try:
                 return await self._run_inner(
                     session_id, user_message, source, channel, model,
-                    internal=internal,
+                    internal=internal, images=images,
                 )
             finally:
                 self.sessions.mark_not_running(session_id)
@@ -1040,6 +1043,7 @@ class AgentEngine:
         channel: str | None,
         model: str | None,
         internal: bool = False,
+        images: list[dict[str, Any]] | None = None,
     ) -> str:
         # Ensure session exists in DB
         await self.sessions.get_or_create(session_id, source=source)
@@ -1066,9 +1070,13 @@ class AgentEngine:
                     self._generate_session_title(session_id, user_message),
                 )
 
-            # Store user message in DB
+            # Store user message in DB (note attached images for display)
+            db_text = user_message
+            if images:
+                suffix = f"\n[{len(images)} image(s) attached]"
+                db_text = (user_message + suffix) if user_message else suffix.strip()
             await self.sessions.add_message(
-                session_id, "user", user_message, channel=channel,
+                session_id, "user", db_text, channel=channel,
             )
 
         full_response_text = ""
@@ -1097,7 +1105,31 @@ class AgentEngine:
             )
 
             # Send message — the client preserves conversation history internally
-            await client.query(user_message)
+            if images:
+                # Build multi-modal content blocks (text + images)
+                content_blocks: list[dict[str, Any]] = []
+                if user_message:
+                    content_blocks.append({"type": "text", "text": user_message})
+                for img in images:
+                    content_blocks.append({
+                        "type": "image",
+                        "source": {
+                            "type": img["type"],
+                            "media_type": img["media_type"],
+                            "data": img["data"],
+                        },
+                    })
+
+                async def _image_prompt():
+                    yield {
+                        "type": "user",
+                        "message": {"role": "user", "content": content_blocks},
+                        "parent_tool_use_id": None,
+                    }
+
+                await client.query(_image_prompt())
+            else:
+                await client.query(user_message)
 
             async for message in client.receive_response():
                 if isinstance(message, AssistantMessage):

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1104,6 +1104,11 @@ class AgentEngine:
                 session_id, source, model, fork_from=fork_from,
             )
 
+            # Check for deferred /stop that arrived while we were setting up
+            if self.sessions.pop_stop_request(session_id):
+                logger.info("Stop requested before agent turn — aborting session %s", session_id)
+                return ""
+
             # Send message — the client preserves conversation history internally
             if images:
                 # Build multi-modal content blocks (text + images)

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1008,11 +1008,25 @@ class AgentEngine:
             images: Optional list of image dicts with keys ``type``,
                     ``media_type``, and ``data`` (base64-encoded).
         """
+        # If the session is still running (e.g. /stop cleanup in progress),
+        # wait briefly instead of failing immediately.
         if self.sessions.is_running(session_id):
-            raise RuntimeError(f"Session {session_id} is already running")
+            for _ in range(10):
+                await asyncio.sleep(0.3)
+                if not self.sessions.is_running(session_id):
+                    break
+            else:
+                raise RuntimeError(f"Session {session_id} is already running")
 
         broadcaster.start_buffering(session_id)
         async with self._semaphore:
+            # Clear any stale deferred-stop flag left over from a *previous*
+            # turn.  If /stop arrived while the old turn was still cleaning up
+            # (mark_not_running hadn't run yet), the flag lingers and would
+            # immediately kill this brand-new turn.  Flags set *during* this
+            # turn's client init are unaffected — they're created after
+            # mark_running below.
+            self.sessions.pop_stop_request(session_id)
             self.sessions.mark_running(session_id)
             # Notify all connected clients that this session started running
             await broadcaster.broadcast("__global__", {
@@ -1241,20 +1255,8 @@ class AgentEngine:
                 if full_response_text
                 else "[Stopped by user]"
             )
-            # Merge available tool results
-            self._merge_tool_results(tool_calls_log, tool_results_map)
-            await self.sessions.add_message(
-                session_id, "assistant", partial,
-                channel=channel,
-                thinking=thinking_text if thinking_text else None,
-                tool_calls=tool_calls_log if tool_calls_log else None,
-                blocks=ordered_blocks if ordered_blocks else None,
-            )
-            await broadcaster.broadcast(session_id, {
-                "type": "stopped", "session_id": session_id,
-            })
-            # Memorize before discarding client
-            await self._memorize_session(session_id)
+
+            # --- Critical cleanup first (must succeed for resume) ----------
             # Persist sdk_session_id so the session can be resumed later.
             # For new sessions the DB still has NULL because mark_active()
             # was called before the SDK emitted any messages.
@@ -1267,6 +1269,27 @@ class AgentEngine:
             client = self.sessions.remove_client(session_id)
             if client:
                 await self._safe_disconnect(client)
+
+            # --- Non-critical: save message, broadcast, memorize -----------
+            try:
+                self._merge_tool_results(tool_calls_log, tool_results_map)
+                await self.sessions.add_message(
+                    session_id, "assistant", partial,
+                    channel=channel,
+                    thinking=thinking_text if thinking_text else None,
+                    tool_calls=tool_calls_log if tool_calls_log else None,
+                    blocks=ordered_blocks if ordered_blocks else None,
+                )
+                await broadcaster.broadcast(session_id, {
+                    "type": "stopped", "session_id": session_id,
+                })
+            except Exception as cleanup_err:
+                logger.warning(
+                    "Non-critical stop cleanup failed for %s: %s",
+                    session_id, cleanup_err,
+                )
+            # Memorize in background — don't block the stop path
+            asyncio.create_task(self._memorize_session(session_id))
             return partial
 
         except Exception as e:

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1246,7 +1246,8 @@ class AgentEngine:
             })
             # Memorize before discarding client
             await self._memorize_session(session_id)
-            # Keep sdk_session_id for resume — stop is user-initiated
+            # mark_stopped only sets status — sdk_session_id (if any)
+            # stays in the DB from when the client was created/resumed.
             await self.sessions.mark_stopped(session_id)
             unregister_handler(session_id)
             client = self.sessions.remove_client(session_id)

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1137,6 +1137,15 @@ class AgentEngine:
                 await client.query(user_message)
 
             async for message in client.receive_response():
+                # Early-capture sdk_session_id from first message that
+                # carries it so it survives /stop cancellation (ResultMessage
+                # — the normal source — never arrives when the turn is
+                # interrupted).
+                if not sdk_session_id:
+                    msg_sid = getattr(message, "session_id", None)
+                    if msg_sid:
+                        sdk_session_id = msg_sid
+
                 if isinstance(message, AssistantMessage):
                     # Extract parent_tool_use_id — set when this message
                     # comes from a sub-agent (Task) rather than the main agent
@@ -1246,8 +1255,13 @@ class AgentEngine:
             })
             # Memorize before discarding client
             await self._memorize_session(session_id)
-            # mark_stopped only sets status — sdk_session_id (if any)
-            # stays in the DB from when the client was created/resumed.
+            # Persist sdk_session_id so the session can be resumed later.
+            # For new sessions the DB still has NULL because mark_active()
+            # was called before the SDK emitted any messages.
+            if sdk_session_id:
+                await self.db.update_session_fields(
+                    session_id, {"sdk_session_id": sdk_session_id},
+                )
             await self.sessions.mark_stopped(session_id)
             unregister_handler(session_id)
             client = self.sessions.remove_client(session_id)

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -339,18 +339,19 @@ class SessionManager:
             return False
 
     async def stop_session(self, session_id: str) -> bool:
-        """Stop a running session.
+        """Stop the current turn of a running session.
 
-        Sends SDK interrupt first (tells the CLI to stop the current turn),
-        then always cancels the asyncio task so ``_run_inner`` exits via
-        ``CancelledError``.  The interrupt is best-effort — even if it fails,
-        the task cancellation guarantees ``_run_inner`` won't hang.
+        Sends SDK interrupt first — this gracefully ends the current turn
+        while keeping the client alive for the next message.  Falls back
+        to asyncio task cancellation (which disconnects the client) only
+        if the interrupt doesn't complete within a timeout.
         """
-        # Try SDK interrupt first (tells CLI to stop gracefully)
         client = self._clients.get(session_id)
+        interrupted = False
         if client:
             try:
                 await client.interrupt()
+                interrupted = True
                 logger.info("Interrupted SDK client for session %s", session_id)
             except Exception as e:
                 logger.warning(
@@ -358,14 +359,26 @@ class SessionManager:
                     session_id, e,
                 )
 
-        # Always cancel the asyncio task so _run_inner exits.
-        # interrupt() only signals the CLI — it doesn't guarantee that
-        # receive_response() will stop (e.g. if the CLI doesn't send a
-        # ResultMessage after interrupt, the loop hangs forever).
         task = self._running_tasks.get(session_id)
         if task and not task.done():
+            if interrupted:
+                # Give interrupt time to complete the turn gracefully.
+                # When it works, receive_response() yields a ResultMessage,
+                # _run_inner exits via the normal path, and the client
+                # stays alive for the next message.
+                done, _ = await asyncio.wait({task}, timeout=5.0)
+                if done:
+                    logger.info(
+                        "Session %s stopped gracefully via interrupt",
+                        session_id,
+                    )
+                    return True
+
+            # Interrupt failed or timed out — force cancel.
+            # The CancelledError handler in _run_inner disconnects the
+            # client since its state is inconsistent.
             task.cancel()
-            logger.info("Cancelled task for session %s", session_id)
+            logger.info("Cancelled task for session %s (interrupt timed out)", session_id)
             return True
 
         # Session is running but client/task not registered yet — set a

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -60,6 +60,9 @@ class SessionManager:
         # Running task tracking
         self._running_tasks: dict[str, asyncio.Task] = {}
         self._running_sessions: set[str] = set()
+        # Stop-requested flag: set when /stop arrives before the SDK client
+        # is registered.  _run_inner() checks this after creating the client.
+        self._stop_requested: set[str] = set()
         # Serialize status transitions
         self._transition_lock = asyncio.Lock()
         # Callback for memorizing session before close/archive/delete.
@@ -323,11 +326,24 @@ class SessionManager:
         """Return the set of currently running session IDs."""
         return set(self._running_sessions)
 
+    def request_stop(self, session_id: str) -> None:
+        """Set a deferred stop flag (checked by _run_inner after client init)."""
+        self._stop_requested.add(session_id)
+
+    def pop_stop_request(self, session_id: str) -> bool:
+        """Return True and clear if a stop was requested for *session_id*."""
+        try:
+            self._stop_requested.remove(session_id)
+            return True
+        except KeyError:
+            return False
+
     async def stop_session(self, session_id: str) -> bool:
         """Stop a running session.
 
         Uses SDK client.interrupt() first for clean stop, falls back to
-        asyncio task cancellation.  Returns True if something was stopped.
+        asyncio task cancellation, then deferred stop flag if the client
+        hasn't been created yet.  Returns True if something was stopped.
         """
         # Try SDK interrupt first (cleanly stops the current turn)
         client = self._clients.get(session_id)
@@ -347,6 +363,13 @@ class SessionManager:
         if task and not task.done():
             task.cancel()
             logger.info("Cancelled task for session %s", session_id)
+            return True
+
+        # Session is running but client/task not registered yet — set a
+        # deferred stop flag that _run_inner() will check after client init.
+        if self.is_running(session_id):
+            self.request_stop(session_id)
+            logger.info("Deferred stop requested for session %s", session_id)
             return True
 
         return False

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -341,24 +341,27 @@ class SessionManager:
     async def stop_session(self, session_id: str) -> bool:
         """Stop a running session.
 
-        Uses SDK client.interrupt() first for clean stop, falls back to
-        asyncio task cancellation, then deferred stop flag if the client
-        hasn't been created yet.  Returns True if something was stopped.
+        Sends SDK interrupt first (tells the CLI to stop the current turn),
+        then always cancels the asyncio task so ``_run_inner`` exits via
+        ``CancelledError``.  The interrupt is best-effort — even if it fails,
+        the task cancellation guarantees ``_run_inner`` won't hang.
         """
-        # Try SDK interrupt first (cleanly stops the current turn)
+        # Try SDK interrupt first (tells CLI to stop gracefully)
         client = self._clients.get(session_id)
         if client:
             try:
                 await client.interrupt()
                 logger.info("Interrupted SDK client for session %s", session_id)
-                return True
             except Exception as e:
                 logger.warning(
-                    "SDK interrupt failed for %s: %s, falling back to cancel",
+                    "SDK interrupt failed for %s: %s",
                     session_id, e,
                 )
 
-        # Fallback: cancel the asyncio task
+        # Always cancel the asyncio task so _run_inner exits.
+        # interrupt() only signals the CLI — it doesn't guarantee that
+        # receive_response() will stop (e.g. if the CLI doesn't send a
+        # ResultMessage after interrupt, the loop hangs forever).
         task = self._running_tasks.get(session_id)
         if task and not task.done():
             task.cancel()
@@ -372,7 +375,7 @@ class SessionManager:
             logger.info("Deferred stop requested for session %s", session_id)
             return True
 
-        return False
+        return client is not None  # interrupt was sent even if no task
 
     # ------------------------------------------------------------------ #
     #  Fork & resume                                                       #

--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -1623,6 +1623,24 @@ async def _ask_user_impl(args: dict, session_id: str) -> dict:
         return {"content": [{"type": "text", "text": f"Failed to ask question: {e}"}]}
 
 
+async def _react_impl(args: dict, session_id: str) -> dict:
+    """Core implementation for the react tool."""
+    if not _engine:
+        return {"content": [{"type": "text", "text": "Engine not available."}]}
+
+    emoji = args["emoji"]
+
+    try:
+        success = await _engine.router.set_reaction(session_id, emoji)
+        if success:
+            return {"content": [{"type": "text", "text": f"Reaction set: {emoji}"}]}
+        else:
+            return {"content": [{"type": "text", "text": "Cannot set reaction: no message context or channel does not support reactions."}]}
+    except Exception as e:
+        logger.error("react tool failed: %s", e)
+        return {"content": [{"type": "text", "text": f"Failed to set reaction: {e}"}]}
+
+
 _nerve_asgi_app = None  # Cached mini FastAPI app for in-process API calls
 
 
@@ -1740,6 +1758,20 @@ async def notify(args: dict) -> dict:
 
 
 @tool(
+    "react",
+    "Set an emoji reaction on the user's last message. "
+    "Use to acknowledge messages, express emotions, or respond non-verbally. "
+    "Works on channels that support reactions (e.g., Telegram).",
+    {
+        "emoji": {"type": "string", "description": "Emoji to react with (e.g., '👍', '❤', '🔥', '😂')"},
+    },
+)
+async def react_tool(args: dict) -> dict:
+    """Set a reaction (fallback — uses deprecated global)."""
+    return await _react_impl(args, _current_session_id)
+
+
+@tool(
     "ask_user",
     "Ask the user a question via async notification. "
     "Returns immediately — when the user answers, their reply is "
@@ -1795,11 +1827,15 @@ _ASK_USER_SCHEMA = {
     "priority": {"type": "string", "description": "Priority: 'low', 'normal', 'high', 'urgent'. Default: 'normal'", "default": "normal"},
 }
 
+_REACT_SCHEMA = {
+    "emoji": {"type": "string", "description": "Emoji to react with (e.g., '👍', '❤', '🔥', '😂')"},
+}
+
 
 def create_session_mcp_server(session_id: str):
-    """Create an MCP server with session_id bound for notification tools.
+    """Create an MCP server with session_id bound for session-scoped tools.
 
-    Each session gets its own MCP server instance so notify/ask_user
+    Each session gets its own MCP server instance so notify/ask_user/react
     tools always reference the correct session — no shared global needed.
     """
 
@@ -1825,8 +1861,19 @@ def create_session_mcp_server(session_id: str):
         # session_id captured from enclosing scope — race-free
         return await _ask_user_impl(args, session_id)
 
+    @tool(
+        "react",
+        "Set an emoji reaction on the user's last message. "
+        "Use to acknowledge messages, express emotions, or respond non-verbally. "
+        "Works on channels that support reactions (e.g., Telegram).",
+        _REACT_SCHEMA,
+    )
+    async def session_react(args: dict) -> dict:
+        # session_id captured from enclosing scope — race-free
+        return await _react_impl(args, session_id)
+
     # Shared tools (don't need session context) + session-scoped tools
-    shared_tools = [t for t in ALL_TOOLS if t.name not in ("notify", "ask_user")]
-    all_tools = shared_tools + [session_notify, session_ask_user]
+    shared_tools = [t for t in ALL_TOOLS if t.name not in ("notify", "ask_user", "react")]
+    all_tools = shared_tools + [session_notify, session_ask_user, session_react]
 
     return create_sdk_mcp_server(name="nerve", version="1.0.0", tools=all_tools)

--- a/nerve/channels/base.py
+++ b/nerve/channels/base.py
@@ -27,6 +27,7 @@ class ChannelCapability(Flag):
     MARKDOWN = auto()           # Renders markdown natively
     INTERACTIVE = auto()        # Can route interactive tool responses back (AskUserQuestion, etc.)
     TYPING_INDICATOR = auto()   # Can show "typing…" status
+    REACTIONS = auto()          # Can set emoji reactions on messages
 
 
 @dataclass(frozen=True)
@@ -139,6 +140,17 @@ class BaseChannel(abc.ABC):
         """Show typing indicator.
 
         Only called if channel declares TYPING_INDICATOR capability.
+        """
+
+    # ------------------------------------------------------------------ #
+    #  Optional: reactions support                                          #
+    #  Only called if channel declares ChannelCapability.REACTIONS.         #
+    # ------------------------------------------------------------------ #
+
+    async def set_reaction(self, target: str, message_id: int, emoji: str) -> None:
+        """Set an emoji reaction on a message.
+
+        Only called if channel declares REACTIONS capability.
         """
 
     # ------------------------------------------------------------------ #

--- a/nerve/channels/router.py
+++ b/nerve/channels/router.py
@@ -48,6 +48,9 @@ class ChannelRouter:
         self._channels: dict[str, BaseChannel] = {}
         # Active stream adapters: (channel_name, target) -> StreamAdapter
         self._adapters: dict[tuple[str, str], StreamAdapter] = {}
+        # Per-session inbound message context (for reaction support)
+        # Maps session_id -> {channel_name, target, message_id}
+        self._message_context: dict[str, dict[str, Any]] = {}
 
     # ------------------------------------------------------------------ #
     #  Channel registry                                                    #
@@ -102,6 +105,15 @@ class ChannelRouter:
                 msg.channel_key, source=msg.channel_name,
             )
 
+        # Store message context for reaction support
+        msg_id = msg.metadata.get("message_id") if msg.metadata else None
+        if msg_id is not None:
+            self._message_context[session_id] = {
+                "channel_name": msg.channel_name,
+                "target": msg.sender_id,
+                "message_id": msg_id,
+            }
+
         # Show typing indicator if supported
         if ChannelCapability.TYPING_INDICATOR in channel.capabilities:
             try:
@@ -145,6 +157,27 @@ class ChannelRouter:
             await self._teardown_streaming(
                 channel.name, msg.sender_id, session_id,
             )
+
+    # ------------------------------------------------------------------ #
+    #  Reactions                                                            #
+    # ------------------------------------------------------------------ #
+
+    async def set_reaction(self, session_id: str, emoji: str) -> bool:
+        """Set a reaction on the last inbound message for a session.
+
+        Returns True if the reaction was set, False if no context or
+        the channel does not support reactions.
+        """
+        ctx = self._message_context.get(session_id)
+        if not ctx:
+            return False
+
+        channel = self._channels.get(ctx["channel_name"])
+        if not channel or ChannelCapability.REACTIONS not in channel.capabilities:
+            return False
+
+        await channel.set_reaction(ctx["target"], ctx["message_id"], emoji)
+        return True
 
     # ------------------------------------------------------------------ #
     #  Interactive tool response routing                                    #

--- a/nerve/channels/router.py
+++ b/nerve/channels/router.py
@@ -117,15 +117,30 @@ class ChannelRouter:
         # Extract images from metadata (e.g. Telegram photos)
         images = msg.metadata.get("images") if msg.metadata else None
 
-        try:
-            response = await self.engine.run(
+        # Wrap in a Task so stop_session() can cancel it (otherwise
+        # channels that ``await engine.run()`` directly — like Telegram —
+        # have no cancellable task and /stop only sends an SDK interrupt
+        # which may hang indefinitely).
+        task = asyncio.create_task(
+            self.engine.run(
                 session_id=session_id,
                 user_message=msg.text,
                 source=msg.channel_name,
                 channel=msg.channel_name,
                 images=images,
             )
+        )
+        self.engine.register_task(session_id, task)
+        try:
+            response = await task
             return response
+        except asyncio.CancelledError:
+            # /stop cancelled the task — _run_inner already handled
+            # cleanup (persisted sdk_session_id, marked stopped, etc.).
+            # Return whatever partial response was captured.
+            if task.done() and not task.cancelled():
+                return task.result()
+            return ""
         finally:
             await self._teardown_streaming(
                 channel.name, msg.sender_id, session_id,

--- a/nerve/channels/router.py
+++ b/nerve/channels/router.py
@@ -114,12 +114,16 @@ class ChannelRouter:
             channel, msg.sender_id, session_id,
         )
 
+        # Extract images from metadata (e.g. Telegram photos)
+        images = msg.metadata.get("images") if msg.metadata else None
+
         try:
             response = await self.engine.run(
                 session_id=session_id,
                 user_message=msg.text,
                 source=msg.channel_name,
                 channel=msg.channel_name,
+                images=images,
             )
             return response
         finally:

--- a/nerve/channels/stream_adapter.py
+++ b/nerve/channels/stream_adapter.py
@@ -44,6 +44,11 @@ class StreamAdapter:
         self._last_edit: float = 0.0
         self._edit_lock = asyncio.Lock()
 
+        # Tool label grouping (collapse consecutive same-tool calls)
+        self._last_tool_name: str | None = None
+        self._tool_run_count: int = 0
+        self._tool_label_start: int = 0
+
         # Precompute capability checks
         self._supports_streaming = (
             ChannelCapability.STREAMING in channel.capabilities
@@ -72,7 +77,15 @@ class StreamAdapter:
         elif msg_type == "tool_use":
             tool_name = message.get("tool", "unknown")
             if self._supports_streaming and self._supports_edit:
-                self._buffer += f"\n`[tool: {tool_name}]`\n"
+                if tool_name == self._last_tool_name:
+                    self._tool_run_count += 1
+                    self._buffer = self._buffer[:self._tool_label_start]
+                    self._buffer += f"\n`[tool: {tool_name}] x{self._tool_run_count}`\n"
+                else:
+                    self._last_tool_name = tool_name
+                    self._tool_run_count = 1
+                    self._tool_label_start = len(self._buffer)
+                    self._buffer += f"\n`[tool: {tool_name}]`\n"
 
         elif msg_type == "done":
             await self._handle_done()
@@ -92,6 +105,7 @@ class StreamAdapter:
     # ------------------------------------------------------------------ #
 
     async def _handle_token(self, content: str) -> None:
+        self._last_tool_name = None  # Reset tool grouping
         self._buffer += content
 
         if not self._supports_streaming or not self._supports_edit:

--- a/nerve/channels/stream_adapter.py
+++ b/nerve/channels/stream_adapter.py
@@ -48,7 +48,7 @@ class StreamAdapter:
         self._last_tool_name: str | None = None
         self._tool_run_count: int = 0
         self._tool_label_start: int = 0
-        self._tool_label_prefix: str = "\n"
+        self._tool_label_prefix: str = "\n\n"
 
         # Precompute capability checks
         self._supports_streaming = (
@@ -87,7 +87,7 @@ class StreamAdapter:
                     self._last_tool_name = tool_name
                     self._tool_run_count = 1
                     self._tool_label_start = len(self._buffer)
-                    self._tool_label_prefix = "" if after_tool else "\n"
+                    self._tool_label_prefix = "" if after_tool else "\n\n"
                     self._buffer += f"{self._tool_label_prefix}`[{tool_name}]`\n"
 
         elif msg_type == "done":

--- a/nerve/channels/stream_adapter.py
+++ b/nerve/channels/stream_adapter.py
@@ -48,6 +48,7 @@ class StreamAdapter:
         self._last_tool_name: str | None = None
         self._tool_run_count: int = 0
         self._tool_label_start: int = 0
+        self._tool_label_prefix: str = "\n"
 
         # Precompute capability checks
         self._supports_streaming = (
@@ -80,12 +81,14 @@ class StreamAdapter:
                 if tool_name == self._last_tool_name:
                     self._tool_run_count += 1
                     self._buffer = self._buffer[:self._tool_label_start]
-                    self._buffer += f"\n`[tool: {tool_name}] x{self._tool_run_count}`\n"
+                    self._buffer += f"{self._tool_label_prefix}`[{tool_name}] x{self._tool_run_count}`\n"
                 else:
+                    after_tool = self._last_tool_name is not None
                     self._last_tool_name = tool_name
                     self._tool_run_count = 1
                     self._tool_label_start = len(self._buffer)
-                    self._buffer += f"\n`[tool: {tool_name}]`\n"
+                    self._tool_label_prefix = "" if after_tool else "\n"
+                    self._buffer += f"{self._tool_label_prefix}`[{tool_name}]`\n"
 
         elif msg_type == "done":
             await self._handle_done()
@@ -105,6 +108,9 @@ class StreamAdapter:
     # ------------------------------------------------------------------ #
 
     async def _handle_token(self, content: str) -> None:
+        if self._last_tool_name is not None:
+            # Transitioning from tool block to text — add blank line separator
+            self._buffer += "\n"
         self._last_tool_name = None  # Reset tool grouping
         self._buffer += content
 

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -186,6 +186,7 @@ class TelegramChannel(BaseChannel):
             ChannelCapability.SEND_TEXT
             | ChannelCapability.MARKDOWN
             | ChannelCapability.TYPING_INDICATOR
+            | ChannelCapability.REACTIONS
         )
         if self.config.telegram.stream_mode == "partial":
             caps |= ChannelCapability.STREAMING
@@ -512,6 +513,20 @@ class TelegramChannel(BaseChannel):
         )
 
     # ------------------------------------------------------------------ #
+    #  Reactions: set emoji on a message                                    #
+    # ------------------------------------------------------------------ #
+
+    async def set_reaction(self, target: str, message_id: int, emoji: str) -> None:
+        """Set an emoji reaction on a Telegram message."""
+        if self._app is None:
+            return
+        await self._app.bot.set_message_reaction(
+            chat_id=int(target),
+            message_id=message_id,
+            reaction=[emoji],
+        )
+
+    # ------------------------------------------------------------------ #
     #  Message cache (for reaction context)                                #
     # ------------------------------------------------------------------ #
 
@@ -705,12 +720,16 @@ class TelegramChannel(BaseChannel):
             f" [{len(images)} image(s)]" if images else "",
         )
 
+        metadata: dict[str, Any] = {"message_id": update.message.message_id}
+        if images:
+            metadata["images"] = images
+
         msg = InboundMessage(
             channel_name="telegram",
             channel_key=f"telegram:{chat_id}",
             sender_id=str(chat_id),
             text=text,
-            metadata={"images": images} if images else {},
+            metadata=metadata,
         )
 
         try:
@@ -740,12 +759,27 @@ class TelegramChannel(BaseChannel):
         chat_id = reaction_update.chat.id
         message_id = reaction_update.message_id
 
-        # Extract new emoji reactions
+        # Extract new emoji reactions (standard + premium custom emoji)
         emojis = []
+        custom_ids = []
         for r in reaction_update.new_reaction:
             emoji = getattr(r, "emoji", None)
             if emoji:
                 emojis.append(emoji)
+            else:
+                custom_id = getattr(r, "custom_emoji_id", None)
+                if custom_id:
+                    custom_ids.append(custom_id)
+
+        # Resolve premium custom emoji IDs to their base emoji
+        if custom_ids:
+            try:
+                stickers = await self._app.bot.get_custom_emoji_stickers(custom_ids)
+                for sticker in stickers:
+                    emojis.append(sticker.emoji or f"[premium:{sticker.custom_emoji_id}]")
+            except Exception as e:
+                logger.warning("Failed to resolve custom emoji: %s", e)
+                emojis.extend(f"[premium:{cid}]" for cid in custom_ids)
 
         if not emojis:
             # Reaction removed — ignore for now
@@ -835,12 +869,16 @@ class TelegramChannel(BaseChannel):
             (text[:80] + "..." if len(text) > 80 else text) if text else "(none)",
         )
 
+        metadata: dict[str, Any] = {"message_id": updates[0].message.message_id}
+        if images:
+            metadata["images"] = images
+
         msg = InboundMessage(
             channel_name="telegram",
             channel_key=f"telegram:{chat_id}",
             sender_id=str(chat_id),
             text=text,
-            metadata={"images": images} if images else {},
+            metadata=metadata,
         )
 
         try:

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -420,6 +420,9 @@ class TelegramChannel(BaseChannel):
                 parse_mode=ParseMode.HTML,
             )
         except Exception as exc:
+            exc_str = str(exc)
+            if "message is not modified" in exc_str.lower():
+                return  # Already up-to-date — don't clobber with plain text
             logger.warning("edit_message HTML failed: %s", exc)
             # Fallback: send without formatting if HTML parsing fails
             try:

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -8,6 +8,7 @@ Session management is delegated to ChannelRouter.
 from __future__ import annotations
 
 import asyncio
+import base64
 import html as _html
 import logging
 import re
@@ -119,6 +120,9 @@ class TelegramChannel(BaseChannel):
         self._watchdog_task: asyncio.Task | None = None
         self._stopping = False
         self._last_update_time: float = 0.0  # monotonic, set on any incoming update
+        # Media group (album) collection: group_id -> list of updates
+        self._media_groups: dict[str, list[Update]] = {}
+        self._media_group_tasks: dict[str, asyncio.Task] = {}
 
     def set_notification_service(self, service) -> None:
         """Wire the notification service for callback query handling."""
@@ -175,7 +179,10 @@ class TelegramChannel(BaseChannel):
         app.add_handler(CommandHandler("new", self._handle_new_session))
         app.add_handler(CommandHandler("reply", self._handle_reply))
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-        app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message))
+        app.add_handler(MessageHandler(
+            (filters.TEXT | filters.PHOTO) & ~filters.COMMAND,
+            self._handle_message,
+        ))
         app.add_error_handler(self._handle_error)
 
         return app
@@ -537,16 +544,48 @@ class TelegramChannel(BaseChannel):
     #  Message handler — construct InboundMessage and delegate             #
     # ------------------------------------------------------------------ #
 
+    async def _extract_image(self, message: Any) -> dict[str, str] | None:
+        """Download and base64-encode an image from a Telegram message."""
+        if message.photo:
+            # Telegram provides multiple resolutions; pick the largest
+            photo = message.photo[-1]
+            tg_file = await photo.get_file()
+            data = await tg_file.download_as_bytearray()
+            return {
+                "type": "base64",
+                "media_type": "image/jpeg",
+                "data": base64.b64encode(bytes(data)).decode("utf-8"),
+            }
+        return None
+
     async def _handle_message(self, update: Update, context: Any) -> None:
-        """Handle incoming text messages — delegate to router."""
+        """Handle incoming text and photo messages — delegate to router."""
         self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
+
+        # Media group (album) — collect all parts before processing
+        if update.message.media_group_id:
+            await self._collect_media_group(update)
+            return
+
         chat_id = update.effective_chat.id
-        text = update.message.text
+        text = update.message.text or update.message.caption or ""
+
+        # Extract image if present
+        images: list[dict[str, str]] = []
+        image = await self._extract_image(update.message)
+        if image:
+            images.append(image)
+
+        if not text and not images:
+            return
+
         logger.info(
-            "Telegram message from %s: %s",
-            chat_id, text[:80] + ("..." if len(text) > 80 else ""),
+            "Telegram message from %s: %s%s",
+            chat_id,
+            (text[:80] + ("..." if len(text) > 80 else "")) if text else "(no text)",
+            f" [{len(images)} image(s)]" if images else "",
         )
 
         msg = InboundMessage(
@@ -554,6 +593,7 @@ class TelegramChannel(BaseChannel):
             channel_key=f"telegram:{chat_id}",
             sender_id=str(chat_id),
             text=text,
+            metadata={"images": images} if images else {},
         )
 
         try:
@@ -562,6 +602,77 @@ class TelegramChannel(BaseChannel):
             logger.error("Agent error for chat %s: %s", chat_id, e, exc_info=True)
             try:
                 await update.message.reply_text(f"Error: {e}")
+            except Exception:
+                logger.error("Failed to send error reply to chat %s", chat_id)
+
+    # ------------------------------------------------------------------ #
+    #  Media group (album) collection                                     #
+    # ------------------------------------------------------------------ #
+
+    async def _collect_media_group(self, update: Update) -> None:
+        """Buffer a media-group message; schedule processing after a short delay."""
+        group_id = update.message.media_group_id
+        if group_id not in self._media_groups:
+            self._media_groups[group_id] = []
+        self._media_groups[group_id].append(update)
+
+        # Reset the timer — wait for remaining album parts
+        task = self._media_group_tasks.get(group_id)
+        if task:
+            task.cancel()
+        self._media_group_tasks[group_id] = asyncio.create_task(
+            self._process_media_group(group_id),
+        )
+
+    async def _process_media_group(self, group_id: str) -> None:
+        """Wait briefly for all album parts, then send as one message."""
+        await asyncio.sleep(0.5)
+
+        updates = self._media_groups.pop(group_id, [])
+        self._media_group_tasks.pop(group_id, None)
+        if not updates:
+            return
+
+        chat_id = updates[0].effective_chat.id
+
+        # Caption is usually on the first message only
+        text = ""
+        for u in updates:
+            caption = u.message.text or u.message.caption or ""
+            if caption:
+                text = caption
+                break
+
+        # Download all images
+        images: list[dict[str, str]] = []
+        for u in updates:
+            image = await self._extract_image(u.message)
+            if image:
+                images.append(image)
+
+        if not text and not images:
+            return
+
+        logger.info(
+            "Telegram media group from %s: %d image(s), caption: %s",
+            chat_id, len(images),
+            (text[:80] + "..." if len(text) > 80 else text) if text else "(none)",
+        )
+
+        msg = InboundMessage(
+            channel_name="telegram",
+            channel_key=f"telegram:{chat_id}",
+            sender_id=str(chat_id),
+            text=text,
+            metadata={"images": images} if images else {},
+        )
+
+        try:
+            await self.router.handle_message(msg)
+        except Exception as e:
+            logger.error("Agent error for chat %s: %s", chat_id, e, exc_info=True)
+            try:
+                await updates[0].message.reply_text(f"Error: {e}")
             except Exception:
                 logger.error("Failed to send error reply to chat %s", chat_id)
 

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -8,7 +8,9 @@ Session management is delegated to ChannelRouter.
 from __future__ import annotations
 
 import asyncio
+import html as _html
 import logging
+import re
 import socket
 import time
 from typing import Any, TYPE_CHECKING
@@ -48,6 +50,57 @@ _TCP_KEEPALIVE_OPTS = (
     (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
     (socket.SOL_TCP, socket.TCP_KEEPCNT, 3),
 )
+
+
+def _md_to_tg_html(text: str) -> str:
+    """Convert standard Markdown to Telegram-compatible HTML.
+
+    Telegram's legacy ``ParseMode.MARKDOWN`` only supports ``*bold*``,
+    but LLMs emit ``**bold**`` (standard Markdown).  This converts the
+    common constructs to HTML so we can use ``ParseMode.HTML`` instead,
+    which is more predictable and doesn't choke on special characters.
+
+    Handles: ``**bold**``, ``*italic*``, `` `code` ``, code fences,
+    and ``[text](url)``.  Unmatched markers pass through as-is.
+    """
+    protected: list[str] = []
+
+    def _protect(replacement: str) -> str:
+        idx = len(protected)
+        protected.append(replacement)
+        return f"\x00{idx}\x00"
+
+    # -- protect constructs that contain chars we'd otherwise escape --
+
+    # Code fences: ```lang\n...\n```
+    def _fence(m: re.Match) -> str:
+        return _protect(f"<pre>{_html.escape(m.group(2))}</pre>")
+    text = re.sub(r"```(\w*)\n?(.*?)```", _fence, text, flags=re.DOTALL)
+
+    # Inline code: `...`
+    def _code(m: re.Match) -> str:
+        return _protect(f"<code>{_html.escape(m.group(1))}</code>")
+    text = re.sub(r"`([^`]+)`", _code, text)
+
+    # Markdown links: [text](url)
+    def _link(m: re.Match) -> str:
+        label = _html.escape(m.group(1))
+        url = m.group(2)
+        return _protect(f'<a href="{url}">{label}</a>')
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", _link, text)
+
+    # -- escape remaining HTML entities --
+    text = _html.escape(text, quote=False)
+
+    # -- inline formatting --
+    text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+    text = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<i>\1</i>", text)
+
+    # -- restore protected spans --
+    for i, repl in enumerate(protected):
+        text = text.replace(f"\x00{i}\x00", repl)
+
+    return text
 
 
 class TelegramChannel(BaseChannel):
@@ -322,11 +375,18 @@ class TelegramChannel(BaseChannel):
         # Split long messages
         for i in range(0, len(text), MAX_MSG_LEN):
             chunk = text[i:i + MAX_MSG_LEN]
-            await self._app.bot.send_message(
-                chat_id=chat_id,
-                text=chunk,
-                parse_mode=ParseMode.MARKDOWN,
-            )
+            html_chunk = _md_to_tg_html(chunk)
+            try:
+                await self._app.bot.send_message(
+                    chat_id=chat_id,
+                    text=html_chunk,
+                    parse_mode=ParseMode.HTML,
+                )
+            except Exception:
+                await self._app.bot.send_message(
+                    chat_id=chat_id,
+                    text=chunk,
+                )
 
     def format_response(self, text: str) -> str:
         """Truncate for Telegram if needed."""
@@ -351,20 +411,24 @@ class TelegramChannel(BaseChannel):
         if self._app is None:
             return
         chat_id = int(target)
+        html_text = _md_to_tg_html(text)
         try:
             await self._app.bot.edit_message_text(
                 chat_id=chat_id,
                 message_id=int(message_id),
-                text=text,
-                parse_mode=ParseMode.MARKDOWN,
+                text=html_text,
+                parse_mode=ParseMode.HTML,
             )
         except Exception:
-            # Fallback: send without markdown if parsing fails
-            await self._app.bot.edit_message_text(
-                chat_id=chat_id,
-                message_id=int(message_id),
-                text=text,
-            )
+            # Fallback: send without formatting if HTML parsing fails
+            try:
+                await self._app.bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=int(message_id),
+                    text=text,
+                )
+            except Exception:
+                pass
 
     async def send_typing(self, target: str) -> None:
         """Show typing indicator."""

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -351,11 +351,20 @@ class TelegramChannel(BaseChannel):
         if self._app is None:
             return
         chat_id = int(target)
-        await self._app.bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=int(message_id),
-            text=text,
-        )
+        try:
+            await self._app.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=int(message_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        except Exception:
+            # Fallback: send without markdown if parsing fails
+            await self._app.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=int(message_id),
+                text=text,
+            )
 
     async def send_typing(self, target: str) -> None:
         """Show typing indicator."""

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any, TYPE_CHECKING
 
 from telegram import Update
@@ -35,9 +36,12 @@ MAX_MSG_LEN = 4096
 EDIT_INTERVAL = 1.5
 # Polling watchdog settings
 WATCHDOG_INTERVAL = 30  # seconds between health checks
+WATCHDOG_HEARTBEAT_INTERVAL = 10  # log heartbeat every N checks (~5 min)
+STALE_THRESHOLD = 600  # seconds without any update before active probe
 MAX_RESTART_ATTEMPTS = 10  # consecutive failures before entering cooldown
 RESTART_BACKOFF_BASE = 5  # seconds, doubles each attempt, capped at 300s
 COOLDOWN_INTERVAL = 300  # seconds to wait after exhausting restart attempts
+PROBE_TIMEOUT = 10  # seconds for bot.get_me() active health check
 
 
 class TelegramChannel(BaseChannel):
@@ -55,6 +59,7 @@ class TelegramChannel(BaseChannel):
         self._notification_service = None  # Set after service is created
         self._watchdog_task: asyncio.Task | None = None
         self._stopping = False
+        self._last_update_time: float = 0.0  # monotonic, set on any incoming update
 
     def set_notification_service(self, service) -> None:
         """Wire the notification service for callback query handling."""
@@ -113,6 +118,7 @@ class TelegramChannel(BaseChannel):
         await self._app.initialize()
         await self._app.start()
         await self._app.updater.start_polling(drop_pending_updates=True)
+        self._last_update_time = time.monotonic()
         logger.info("Telegram bot started polling")
 
         # Launch watchdog to auto-restart polling if it silently dies
@@ -140,15 +146,20 @@ class TelegramChannel(BaseChannel):
     async def _run_watchdog(self) -> None:
         """Monitor polling health and auto-restart if it dies.
 
-        python-telegram-bot's polling runs as an internal asyncio task.
-        If that task crashes, the Updater.running flag stays True (it's
-        only cleared by an explicit stop() call), so we inspect the
-        actual task object to detect silent deaths.
+        Three layers of health checking:
+        1. Task alive? — is the internal polling asyncio task still running
+        2. Updater flag — does PTB think it's polling
+        3. Active probe — can we actually reach Telegram's API (bot.get_me)
+
+        The active probe fires when we haven't received any update in
+        STALE_THRESHOLD seconds, catching cases where the task is alive
+        but the connection is silently hung.
 
         Never gives up permanently — after exhausting rapid restart
         attempts, enters a cooldown period and then tries again.
         """
         restart_count = 0
+        check_count = 0
         while not self._stopping:
             try:
                 await asyncio.sleep(WATCHDOG_INTERVAL)
@@ -158,8 +169,23 @@ class TelegramChannel(BaseChannel):
             if self._app is None or self._stopping:
                 break
 
+            check_count += 1
+
+            # Heartbeat log so we know the watchdog itself is alive
+            if check_count % WATCHDOG_HEARTBEAT_INTERVAL == 0:
+                elapsed = (
+                    f"{time.monotonic() - self._last_update_time:.0f}s ago"
+                    if self._last_update_time > 0
+                    else "never"
+                )
+                logger.info(
+                    "Telegram watchdog heartbeat: check #%d, "
+                    "last_update=%s, restarts=%d",
+                    check_count, elapsed, restart_count,
+                )
+
             try:
-                alive = self._is_polling_alive()
+                alive = await self._is_polling_healthy()
             except Exception as e:
                 logger.error(
                     "Watchdog health check failed: %s", e, exc_info=True,
@@ -175,7 +201,7 @@ class TelegramChannel(BaseChannel):
                 restart_count = 0
                 continue
 
-            # Polling is dead
+            # Polling is dead or unresponsive
             restart_count += 1
             if restart_count > MAX_RESTART_ATTEMPTS:
                 logger.warning(
@@ -189,12 +215,12 @@ class TelegramChannel(BaseChannel):
                     break
                 if self._stopping:
                     break
-                restart_count = 1  # reset counter, start a fresh round
+                restart_count = 1
                 logger.info("Telegram polling: cooldown over, resuming restart attempts")
 
             delay = min(RESTART_BACKOFF_BASE * (2 ** (restart_count - 1)), 300)
             logger.warning(
-                "Telegram polling died — restarting in %ds (attempt %d/%d)",
+                "Telegram polling dead — restarting in %ds (attempt %d/%d)",
                 delay, restart_count, MAX_RESTART_ATTEMPTS,
             )
 
@@ -208,6 +234,7 @@ class TelegramChannel(BaseChannel):
 
             try:
                 await self._restart_polling()
+                self._last_update_time = time.monotonic()
                 logger.info(
                     "Telegram polling restarted successfully (attempt %d/%d)",
                     restart_count, MAX_RESTART_ATTEMPTS,
@@ -217,23 +244,23 @@ class TelegramChannel(BaseChannel):
                     "Telegram polling restart failed: %s", e, exc_info=True,
                 )
 
-    def _is_polling_alive(self) -> bool:
-        """Check whether the Telegram polling loop is still running.
+    async def _is_polling_healthy(self) -> bool:
+        """Multi-layer health check for Telegram polling.
 
-        We check two things:
-        1. Updater.running flag (catches explicit stops)
-        2. The internal __polling_task (catches silent crashes where
-           the task died but _running was never cleared)
+        Layer 1: Is the updater flag set?
+        Layer 2: Is the internal polling task still running?
+        Layer 3: If stale (no updates for STALE_THRESHOLD), actively
+                 probe the API with bot.get_me() to detect hung connections.
         """
         if not self._app or not self._app.updater:
             return False
 
-        # Check 1: updater thinks it's not running → definitely dead
+        # Layer 1: updater thinks it's not running → definitely dead
         if not self._app.updater.running:
+            logger.warning("Telegram watchdog: updater.running is False")
             return False
 
-        # Check 2: internal polling task crashed silently
-        # PTB v22 stores it as __polling_task (name-mangled)
+        # Layer 2: internal polling task crashed silently
         polling_task: asyncio.Task | None = getattr(
             self._app.updater, "_Updater__polling_task", None,
         )
@@ -243,9 +270,47 @@ class TelegramChannel(BaseChannel):
             except (asyncio.CancelledError, asyncio.InvalidStateError):
                 exc = None
             logger.warning(
-                "Telegram polling task is dead (exception: %s)", exc,
+                "Telegram watchdog: polling task is dead (exception: %s)", exc,
             )
             return False
+
+        # Layer 3: if no updates received recently, probe the API
+        now = time.monotonic()
+        if self._last_update_time > 0:
+            stale_seconds = now - self._last_update_time
+        else:
+            # Never received an update — use time since start
+            stale_seconds = now - self._last_update_time if self._last_update_time else STALE_THRESHOLD + 1
+
+        if stale_seconds > STALE_THRESHOLD:
+            logger.info(
+                "Telegram watchdog: no updates for %.0fs, running active probe",
+                stale_seconds,
+            )
+            try:
+                me = await asyncio.wait_for(
+                    self._app.bot.get_me(), timeout=PROBE_TIMEOUT,
+                )
+                if me:
+                    # API is reachable — polling task might just have no messages
+                    # That's fine, reset the timer to avoid spamming probes
+                    logger.info(
+                        "Telegram watchdog: active probe OK (bot: @%s)",
+                        me.username,
+                    )
+                    self._last_update_time = now
+                    return True
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Telegram watchdog: active probe timed out after %ds",
+                    PROBE_TIMEOUT,
+                )
+                return False
+            except Exception as e:
+                logger.warning(
+                    "Telegram watchdog: active probe failed: %s", e,
+                )
+                return False
 
         return True
 
@@ -338,8 +403,13 @@ class TelegramChannel(BaseChannel):
     #  Command handlers — delegate to router for session management        #
     # ------------------------------------------------------------------ #
 
+    def _touch(self) -> None:
+        """Record that we received an update from Telegram."""
+        self._last_update_time = time.monotonic()
+
     async def _handle_start(self, update: Update, context: Any) -> None:
         """Handle /start command."""
+        self._touch()
         user_id = update.effective_user.id
         if not self._is_authorized(user_id):
             logger.warning("Unauthorized /start from user %d", user_id)
@@ -351,6 +421,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_session(self, update: Update, context: Any) -> None:
         """Handle /session <id> — switch active session."""
+        self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
         chat_id = update.effective_chat.id
@@ -376,6 +447,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_sessions(self, update: Update, context: Any) -> None:
         """Handle /sessions — list sessions."""
+        self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
 
@@ -391,6 +463,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_new_session(self, update: Update, context: Any) -> None:
         """Handle /new [title] — create and switch to a new session."""
+        self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
         chat_id = update.effective_chat.id
@@ -410,6 +483,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_message(self, update: Update, context: Any) -> None:
         """Handle incoming text messages — delegate to router."""
+        self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
         chat_id = update.effective_chat.id
@@ -441,6 +515,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_error(self, update: object, context: Any) -> None:
         """Log errors from the Telegram bot polling/handler pipeline."""
+        self._touch()
         logger.error(
             "Telegram update error: %s (update=%s)",
             context.error, update, exc_info=context.error,
@@ -452,6 +527,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_callback_query(self, update: Update, context: Any) -> None:
         """Handle inline keyboard button presses for notification questions."""
+        self._touch()
         query = update.callback_query
         if not query or not query.data:
             return
@@ -494,6 +570,7 @@ class TelegramChannel(BaseChannel):
 
     async def _handle_reply(self, update: Update, context: Any) -> None:
         """Handle /reply <text> — answer the most recent pending question."""
+        self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
         if not context.args:

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -539,7 +539,12 @@ class TelegramChannel(BaseChannel):
         # Stop the current session before creating a new one
         prev = await self.router.get_last_session(channel_key)
         if prev:
-            await self.router.engine.stop_session(prev)
+            stopped = await self.router.engine.stop_session(prev)
+            if stopped:
+                await update.message.reply_text(
+                    f"Stopped session `{prev}`.",
+                    parse_mode=ParseMode.MARKDOWN,
+                )
 
         title = " ".join(context.args) if context.args else None
         session_id = await self.router.create_session(

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -7,6 +7,7 @@ Session management is delegated to ChannelRouter.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, TYPE_CHECKING
 
@@ -32,6 +33,11 @@ logger = logging.getLogger(__name__)
 MAX_MSG_LEN = 4096
 # Minimum interval between message edits (seconds) to avoid rate limits
 EDIT_INTERVAL = 1.5
+# Polling watchdog settings
+WATCHDOG_INTERVAL = 30  # seconds between health checks
+MAX_RESTART_ATTEMPTS = 10  # consecutive failures before entering cooldown
+RESTART_BACKOFF_BASE = 5  # seconds, doubles each attempt, capped at 300s
+COOLDOWN_INTERVAL = 300  # seconds to wait after exhausting restart attempts
 
 
 class TelegramChannel(BaseChannel):
@@ -47,6 +53,8 @@ class TelegramChannel(BaseChannel):
         self._app: Application | None = None
         self._allowed_users: set[int] = set(config.telegram.allowed_users)
         self._notification_service = None  # Set after service is created
+        self._watchdog_task: asyncio.Task | None = None
+        self._stopping = False
 
     def set_notification_service(self, service) -> None:
         """Wire the notification service for callback query handling."""
@@ -85,6 +93,7 @@ class TelegramChannel(BaseChannel):
             logger.warning("Telegram bot token not configured")
             return
 
+        self._stopping = False
         self._app = (
             Application.builder()
             .token(self.config.telegram.bot_token)
@@ -106,11 +115,155 @@ class TelegramChannel(BaseChannel):
         await self._app.updater.start_polling(drop_pending_updates=True)
         logger.info("Telegram bot started polling")
 
+        # Launch watchdog to auto-restart polling if it silently dies
+        self._watchdog_task = asyncio.create_task(
+            self._run_watchdog(), name="telegram-polling-watchdog",
+        )
+
     async def stop(self) -> None:
+        self._stopping = True
+        if self._watchdog_task and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+            try:
+                await self._watchdog_task
+            except asyncio.CancelledError:
+                pass
         if self._app:
             await self._app.updater.stop()
             await self._app.stop()
             await self._app.shutdown()
+
+    # ------------------------------------------------------------------ #
+    #  Polling watchdog — detect silent crashes and auto-restart           #
+    # ------------------------------------------------------------------ #
+
+    async def _run_watchdog(self) -> None:
+        """Monitor polling health and auto-restart if it dies.
+
+        python-telegram-bot's polling runs as an internal asyncio task.
+        If that task crashes, the Updater.running flag stays True (it's
+        only cleared by an explicit stop() call), so we inspect the
+        actual task object to detect silent deaths.
+
+        Never gives up permanently — after exhausting rapid restart
+        attempts, enters a cooldown period and then tries again.
+        """
+        restart_count = 0
+        while not self._stopping:
+            try:
+                await asyncio.sleep(WATCHDOG_INTERVAL)
+            except asyncio.CancelledError:
+                break
+
+            if self._app is None or self._stopping:
+                break
+
+            try:
+                alive = self._is_polling_alive()
+            except Exception as e:
+                logger.error(
+                    "Watchdog health check failed: %s", e, exc_info=True,
+                )
+                continue
+
+            if alive:
+                if restart_count > 0:
+                    logger.info(
+                        "Telegram polling healthy after %d restart(s)",
+                        restart_count,
+                    )
+                restart_count = 0
+                continue
+
+            # Polling is dead
+            restart_count += 1
+            if restart_count > MAX_RESTART_ATTEMPTS:
+                logger.warning(
+                    "Telegram polling: exhausted %d restart attempts — "
+                    "entering cooldown (%ds) before retrying",
+                    MAX_RESTART_ATTEMPTS, COOLDOWN_INTERVAL,
+                )
+                try:
+                    await asyncio.sleep(COOLDOWN_INTERVAL)
+                except asyncio.CancelledError:
+                    break
+                if self._stopping:
+                    break
+                restart_count = 1  # reset counter, start a fresh round
+                logger.info("Telegram polling: cooldown over, resuming restart attempts")
+
+            delay = min(RESTART_BACKOFF_BASE * (2 ** (restart_count - 1)), 300)
+            logger.warning(
+                "Telegram polling died — restarting in %ds (attempt %d/%d)",
+                delay, restart_count, MAX_RESTART_ATTEMPTS,
+            )
+
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                break
+
+            if self._stopping:
+                break
+
+            try:
+                await self._restart_polling()
+                logger.info(
+                    "Telegram polling restarted successfully (attempt %d/%d)",
+                    restart_count, MAX_RESTART_ATTEMPTS,
+                )
+            except Exception as e:
+                logger.error(
+                    "Telegram polling restart failed: %s", e, exc_info=True,
+                )
+
+    def _is_polling_alive(self) -> bool:
+        """Check whether the Telegram polling loop is still running.
+
+        We check two things:
+        1. Updater.running flag (catches explicit stops)
+        2. The internal __polling_task (catches silent crashes where
+           the task died but _running was never cleared)
+        """
+        if not self._app or not self._app.updater:
+            return False
+
+        # Check 1: updater thinks it's not running → definitely dead
+        if not self._app.updater.running:
+            return False
+
+        # Check 2: internal polling task crashed silently
+        # PTB v22 stores it as __polling_task (name-mangled)
+        polling_task: asyncio.Task | None = getattr(
+            self._app.updater, "_Updater__polling_task", None,
+        )
+        if polling_task is not None and polling_task.done():
+            try:
+                exc = polling_task.exception()
+            except (asyncio.CancelledError, asyncio.InvalidStateError):
+                exc = None
+            logger.warning(
+                "Telegram polling task is dead (exception: %s)", exc,
+            )
+            return False
+
+        return True
+
+    async def _restart_polling(self) -> None:
+        """Stop the updater cleanly, then start a fresh polling loop."""
+        if self._app is None:
+            return
+
+        # stop() sets _running=False and cancels the dead task
+        try:
+            await self._app.updater.stop()
+        except Exception as e:
+            logger.debug("Updater stop during restart: %s", e)
+
+        await asyncio.sleep(1)
+
+        # Don't drop pending updates on restart — we might have missed some
+        await self._app.updater.start_polling(drop_pending_updates=False)
 
     # ------------------------------------------------------------------ #
     #  Outbound: send complete message                                     #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -99,6 +99,7 @@ class TelegramChannel(BaseChannel):
         self._app.add_handler(CommandHandler("reply", self._handle_reply))
         self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
         self._app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message))
+        self._app.add_error_handler(self._handle_error)
 
         await self._app.initialize()
         await self._app.start()
@@ -259,19 +260,38 @@ class TelegramChannel(BaseChannel):
         if not self._is_authorized(update.effective_user.id):
             return
         chat_id = update.effective_chat.id
+        text = update.message.text
+        logger.info(
+            "Telegram message from %s: %s",
+            chat_id, text[:80] + ("..." if len(text) > 80 else ""),
+        )
 
         msg = InboundMessage(
             channel_name="telegram",
             channel_key=f"telegram:{chat_id}",
             sender_id=str(chat_id),
-            text=update.message.text,
+            text=text,
         )
 
         try:
             await self.router.handle_message(msg)
         except Exception as e:
-            logger.error("Agent error: %s", e)
-            await update.message.reply_text(f"Error: {e}")
+            logger.error("Agent error for chat %s: %s", chat_id, e, exc_info=True)
+            try:
+                await update.message.reply_text(f"Error: {e}")
+            except Exception:
+                logger.error("Failed to send error reply to chat %s", chat_id)
+
+    # ------------------------------------------------------------------ #
+    #  Error handler                                                       #
+    # ------------------------------------------------------------------ #
+
+    async def _handle_error(self, update: object, context: Any) -> None:
+        """Log errors from the Telegram bot polling/handler pipeline."""
+        logger.error(
+            "Telegram update error: %s (update=%s)",
+            context.error, update, exc_info=context.error,
+        )
 
     # ------------------------------------------------------------------ #
     #  Notification callback handlers                                      #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import socket
 import time
 from typing import Any, TYPE_CHECKING
 
@@ -34,16 +35,19 @@ logger = logging.getLogger(__name__)
 MAX_MSG_LEN = 4096
 # Minimum interval between message edits (seconds) to avoid rate limits
 EDIT_INTERVAL = 1.5
-# Polling watchdog settings
-WATCHDOG_INTERVAL = 30  # seconds between health checks
-WATCHDOG_HEARTBEAT_INTERVAL = 10  # log heartbeat every N checks (~5 min)
-STALE_THRESHOLD = 300  # seconds without any update before active probe
-FORCE_RESTART_THRESHOLD = 900  # seconds stale → force restart regardless of probe
-MAX_RESTART_ATTEMPTS = 10  # consecutive failures before entering cooldown
-RESTART_BACKOFF_BASE = 5  # seconds, doubles each attempt, capped at 300s
-COOLDOWN_INTERVAL = 300  # seconds to wait after exhausting restart attempts
-PROBE_TIMEOUT = 10  # seconds for bot.get_me() active health check
-RESTART_STOP_TIMEOUT = 15  # seconds to wait for updater.stop() before giving up
+# Watchdog: check every 30s, log heartbeat every ~5 min
+WATCHDOG_INTERVAL = 30
+WATCHDOG_HEARTBEAT_EVERY = 10
+
+# TCP keepalive: prevent NAT/firewall from silently dropping the
+# long-poll connection.  These values tell the OS to send a keepalive
+# probe after 60s idle, retry every 10s, give up after 3 failures.
+_TCP_KEEPALIVE_OPTS = (
+    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    (socket.SOL_TCP, socket.TCP_KEEPIDLE, 60),
+    (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
+    (socket.SOL_TCP, socket.TCP_KEEPCNT, 3),
+)
 
 
 class TelegramChannel(BaseChannel):
@@ -94,6 +98,35 @@ class TelegramChannel(BaseChannel):
     #  Lifecycle                                                           #
     # ------------------------------------------------------------------ #
 
+    def _build_application(self) -> Application:
+        """Build a PTB Application with robust connection settings."""
+        builder = (
+            Application.builder()
+            .token(self.config.telegram.bot_token)
+            # TCP keepalive on the polling connection — prevents NAT/firewall
+            # from silently dropping the long-poll connection
+            .get_updates_socket_options(_TCP_KEEPALIVE_OPTS)
+            # Separate connection pool for polling vs sending, so a stuck
+            # outbound request can't starve the polling connection
+            .get_updates_connection_pool_size(1)
+            .get_updates_read_timeout(10)
+            .get_updates_connect_timeout(10)
+            .get_updates_pool_timeout(1.0)
+        )
+        app = builder.build()
+
+        # Register handlers
+        app.add_handler(CommandHandler("start", self._handle_start))
+        app.add_handler(CommandHandler("session", self._handle_session))
+        app.add_handler(CommandHandler("sessions", self._handle_sessions))
+        app.add_handler(CommandHandler("new", self._handle_new_session))
+        app.add_handler(CommandHandler("reply", self._handle_reply))
+        app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+        app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message))
+        app.add_error_handler(self._handle_error)
+
+        return app
+
     async def start(self) -> None:
         """Start the Telegram bot."""
         if not self.config.telegram.bot_token:
@@ -101,29 +134,20 @@ class TelegramChannel(BaseChannel):
             return
 
         self._stopping = False
-        self._app = (
-            Application.builder()
-            .token(self.config.telegram.bot_token)
-            .build()
-        )
-
-        # Register handlers
-        self._app.add_handler(CommandHandler("start", self._handle_start))
-        self._app.add_handler(CommandHandler("session", self._handle_session))
-        self._app.add_handler(CommandHandler("sessions", self._handle_sessions))
-        self._app.add_handler(CommandHandler("new", self._handle_new_session))
-        self._app.add_handler(CommandHandler("reply", self._handle_reply))
-        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-        self._app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message))
-        self._app.add_error_handler(self._handle_error)
+        self._app = self._build_application()
 
         await self._app.initialize()
         await self._app.start()
-        await self._app.updater.start_polling(drop_pending_updates=True)
+        await self._app.updater.start_polling(
+            drop_pending_updates=True,
+            # Retry initial connection indefinitely — don't give up on
+            # transient network errors during startup
+            bootstrap_retries=-1,
+        )
         self._last_update_time = time.monotonic()
-        logger.info("Telegram bot started polling")
+        logger.info("Telegram bot started polling (with TCP keepalive)")
 
-        # Launch watchdog to auto-restart polling if it silently dies
+        # Launch watchdog for monitoring + recovery
         self._watchdog_task = asyncio.create_task(
             self._run_watchdog(), name="telegram-polling-watchdog",
         )
@@ -142,28 +166,17 @@ class TelegramChannel(BaseChannel):
             await self._app.shutdown()
 
     # ------------------------------------------------------------------ #
-    #  Polling watchdog — detect silent crashes and auto-restart           #
+    #  Watchdog — monitor both Updater and Application health              #
     # ------------------------------------------------------------------ #
 
     async def _run_watchdog(self) -> None:
-        """Monitor polling health and auto-restart if it dies.
+        """Monitor Telegram bot health and log diagnostics.
 
-        Four layers of health checking:
-        1. Updater flag — does PTB think it's polling?
-        2. Task alive — is the internal polling asyncio task still running?
-        3. Stale + probe — no handler called in 5 min? Probe with get_me().
-           If probe fails → restart. If probe works → maybe just quiet.
-        4. Force restart — stale for 15 min regardless of probe results.
-           Catches hung connections where the task is alive but stuck.
-
-        On restart: tries clean updater.stop() with a 15s timeout.
-        If stop() hangs (stuck connection), rebuilds the entire PTB
-        Application from scratch.
-
-        Never gives up permanently — after exhausting rapid restart
-        attempts, enters a cooldown period and then tries again.
+        Checks BOTH the Updater (fetches updates from Telegram) AND the
+        Application (processes updates from queue → handlers).  Previous
+        versions only checked the Updater, missing cases where the
+        Application's update-processing task crashed silently.
         """
-        restart_count = 0
         check_count = 0
         while not self._stopping:
             try:
@@ -175,234 +188,126 @@ class TelegramChannel(BaseChannel):
                 break
 
             check_count += 1
+            status = self._get_health_status()
 
-            # Heartbeat log so we know the watchdog itself is alive
-            if check_count % WATCHDOG_HEARTBEAT_INTERVAL == 0:
-                elapsed = (
-                    f"{time.monotonic() - self._last_update_time:.0f}s ago"
-                    if self._last_update_time > 0
-                    else "never"
-                )
+            # Periodic heartbeat
+            if check_count % WATCHDOG_HEARTBEAT_EVERY == 0:
                 logger.info(
-                    "Telegram watchdog heartbeat: check #%d, "
-                    "last_update=%s, restarts=%d",
-                    check_count, elapsed, restart_count,
+                    "Telegram watchdog: %s (check #%d, last_update=%s, queue=%d)",
+                    status["summary"], check_count,
+                    status["last_update_ago"], status["queue_size"],
                 )
 
-            try:
-                alive = await self._is_polling_healthy()
-            except Exception as e:
-                logger.error(
-                    "Watchdog health check failed: %s", e, exc_info=True,
-                )
-                continue
-
-            if alive:
-                if restart_count > 0:
-                    logger.info(
-                        "Telegram polling healthy after %d restart(s)",
-                        restart_count,
-                    )
-                restart_count = 0
-                continue
-
-            # Polling is dead or unresponsive
-            restart_count += 1
-            if restart_count > MAX_RESTART_ATTEMPTS:
+            if not status["healthy"]:
                 logger.warning(
-                    "Telegram polling: exhausted %d restart attempts — "
-                    "entering cooldown (%ds) before retrying",
-                    MAX_RESTART_ATTEMPTS, COOLDOWN_INTERVAL,
+                    "Telegram bot unhealthy: %s (queue=%d, last_update=%s) — rebuilding",
+                    status["summary"], status["queue_size"],
+                    status["last_update_ago"],
                 )
                 try:
-                    await asyncio.sleep(COOLDOWN_INTERVAL)
-                except asyncio.CancelledError:
-                    break
-                if self._stopping:
-                    break
-                restart_count = 1
-                logger.info("Telegram polling: cooldown over, resuming restart attempts")
+                    await self._rebuild()
+                    logger.info("Telegram bot rebuilt successfully")
+                except Exception as e:
+                    logger.error("Telegram bot rebuild failed: %s", e, exc_info=True)
 
-            delay = min(RESTART_BACKOFF_BASE * (2 ** (restart_count - 1)), 300)
-            logger.warning(
-                "Telegram polling dead — restarting in %ds (attempt %d/%d)",
-                delay, restart_count, MAX_RESTART_ATTEMPTS,
-            )
+    def _get_health_status(self) -> dict:
+        """Check health of both Updater and Application."""
+        now = time.monotonic()
+        stale_sec = now - self._last_update_time if self._last_update_time > 0 else 0
+        last_ago = f"{stale_sec:.0f}s ago" if self._last_update_time > 0 else "never"
 
-            try:
-                await asyncio.sleep(delay)
-            except asyncio.CancelledError:
-                break
+        result = {
+            "healthy": True,
+            "summary": "ok",
+            "last_update_ago": last_ago,
+            "queue_size": 0,
+        }
 
-            if self._stopping:
-                break
+        if not self._app:
+            result.update(healthy=False, summary="no Application")
+            return result
 
-            try:
-                await self._restart_polling()
-                self._last_update_time = time.monotonic()
-                logger.info(
-                    "Telegram polling restarted successfully (attempt %d/%d)",
-                    restart_count, MAX_RESTART_ATTEMPTS,
-                )
-            except Exception as e:
-                logger.error(
-                    "Telegram polling restart failed: %s", e, exc_info=True,
-                )
+        # --- Check update queue ---
+        # If updates pile up in the queue, the Application isn't consuming them
+        try:
+            result["queue_size"] = self._app.update_queue.qsize()
+        except Exception:
+            pass
 
-    async def _is_polling_healthy(self) -> bool:
-        """Multi-layer health check for Telegram polling.
+        # --- Check Updater (the part that fetches from Telegram) ---
+        updater = self._app.updater
+        if not updater or not updater.running:
+            result.update(healthy=False, summary="updater not running")
+            return result
 
-        Layer 1: Is the updater flag set?
-        Layer 2: Is the internal polling task still running?
-        Layer 3: Staleness — no handler called for STALE_THRESHOLD?
-                 Probe API with get_me() to distinguish "no messages"
-                 from "connection hung." But get_me() uses a new connection,
-                 so it can succeed even with a hung polling connection.
-        Layer 4: Force restart after FORCE_RESTART_THRESHOLD regardless —
-                 if we've been stale that long, something is wrong even
-                 if get_me() works.
-        """
-        if not self._app or not self._app.updater:
-            return False
-
-        # Layer 1: updater thinks it's not running → definitely dead
-        if not self._app.updater.running:
-            logger.warning("Telegram watchdog: updater.running is False")
-            return False
-
-        # Layer 2: internal polling task crashed silently
         polling_task: asyncio.Task | None = getattr(
-            self._app.updater, "_Updater__polling_task", None,
+            updater, "_Updater__polling_task", None,
         )
         if polling_task is not None and polling_task.done():
+            exc = None
             try:
                 exc = polling_task.exception()
             except (asyncio.CancelledError, asyncio.InvalidStateError):
-                exc = None
-            logger.warning(
-                "Telegram watchdog: polling task is dead (exception: %s)", exc,
+                pass
+            result.update(
+                healthy=False,
+                summary=f"polling task dead (exception: {exc})",
             )
-            return False
+            return result
 
-        # Layer 3 & 4: staleness checks
-        now = time.monotonic()
-        stale_seconds = now - self._last_update_time if self._last_update_time > 0 else now
-
-        if stale_seconds <= STALE_THRESHOLD:
-            return True  # fresh enough, definitely healthy
-
-        # Layer 4: been stale way too long → force restart, don't even probe
-        if stale_seconds > FORCE_RESTART_THRESHOLD:
-            logger.warning(
-                "Telegram watchdog: no updates for %.0fs (> %ds) — "
-                "forcing restart (connection likely hung)",
-                stale_seconds, FORCE_RESTART_THRESHOLD,
-            )
-            return False
-
-        # Layer 3: stale but not critically — probe API to check
-        logger.info(
-            "Telegram watchdog: no updates for %.0fs, running active probe",
-            stale_seconds,
+        # --- Check Application (the part that processes updates → handlers) ---
+        fetcher_task: asyncio.Task | None = getattr(
+            self._app, "_Application__update_fetcher_task", None,
         )
-        try:
-            me = await asyncio.wait_for(
-                self._app.bot.get_me(), timeout=PROBE_TIMEOUT,
+        if fetcher_task is not None and fetcher_task.done():
+            exc = None
+            try:
+                exc = fetcher_task.exception()
+            except (asyncio.CancelledError, asyncio.InvalidStateError):
+                pass
+            result.update(
+                healthy=False,
+                summary=f"update fetcher task dead (exception: {exc})",
             )
-            if me:
-                # API reachable on a fresh connection. Polling *might* be fine
-                # (just no messages), or the polling connection might be hung
-                # while the API itself works. We give it the benefit of the
-                # doubt here — Layer 4 catches it if staleness continues.
-                logger.info(
-                    "Telegram watchdog: active probe OK (bot: @%s), "
-                    "will force-restart at %ds stale",
-                    me.username, FORCE_RESTART_THRESHOLD,
-                )
-                return True
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Telegram watchdog: active probe timed out after %ds — "
-                "API unreachable",
-                PROBE_TIMEOUT,
+            return result
+
+        # --- Check for backed-up queue (Application alive but not consuming) ---
+        if result["queue_size"] > 10:
+            result.update(
+                healthy=False,
+                summary=f"update queue backed up ({result['queue_size']} pending)",
             )
-            return False
-        except Exception as e:
-            logger.warning(
-                "Telegram watchdog: active probe failed: %s", e,
-            )
-            return False
+            return result
 
-        return True
+        return result
 
-    async def _restart_polling(self) -> None:
-        """Stop the updater cleanly, then start a fresh polling loop.
-
-        If the clean stop hangs (e.g. stuck connection), we time out and
-        rebuild the entire Application from scratch as a last resort.
-        """
-        if self._app is None:
-            return
-
-        # Try a clean stop with a timeout — stop() can hang if the
-        # polling connection is stuck at the TCP level
-        try:
-            await asyncio.wait_for(
-                self._app.updater.stop(), timeout=RESTART_STOP_TIMEOUT,
-            )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Telegram updater.stop() hung for %ds — rebuilding Application",
-                RESTART_STOP_TIMEOUT,
-            )
-            await self._rebuild_application()
-            return
-        except Exception as e:
-            logger.debug("Updater stop during restart: %s", e)
-
-        await asyncio.sleep(1)
-
-        # Don't drop pending updates on restart — we might have missed some
-        await self._app.updater.start_polling(drop_pending_updates=False)
-
-    async def _rebuild_application(self) -> None:
-        """Nuclear option: tear down and rebuild the entire PTB Application.
-
-        Used when updater.stop() hangs and we can't cleanly restart polling.
-        """
+    async def _rebuild(self) -> None:
+        """Tear down and rebuild the entire PTB Application."""
         old_app = self._app
-
-        # Build a fresh Application with the same config
-        self._app = (
-            Application.builder()
-            .token(self.config.telegram.bot_token)
-            .build()
-        )
-
-        # Re-register all handlers
-        self._app.add_handler(CommandHandler("start", self._handle_start))
-        self._app.add_handler(CommandHandler("session", self._handle_session))
-        self._app.add_handler(CommandHandler("sessions", self._handle_sessions))
-        self._app.add_handler(CommandHandler("new", self._handle_new_session))
-        self._app.add_handler(CommandHandler("reply", self._handle_reply))
-        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
-        self._app.add_handler(
-            MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message),
-        )
-        self._app.add_error_handler(self._handle_error)
+        self._app = self._build_application()
 
         await self._app.initialize()
         await self._app.start()
-        await self._app.updater.start_polling(drop_pending_updates=False)
+        await self._app.updater.start_polling(
+            drop_pending_updates=False,
+            bootstrap_retries=-1,
+        )
+        self._last_update_time = time.monotonic()
 
-        logger.info("Telegram Application rebuilt from scratch")
-
-        # Best-effort cleanup of the old app (don't await — it might hang)
+        # Best-effort cleanup of the old app
         if old_app:
+            try:
+                await asyncio.wait_for(old_app.updater.stop(), timeout=5)
+            except Exception:
+                pass
+            try:
+                await asyncio.wait_for(old_app.stop(), timeout=5)
+            except Exception:
+                pass
             try:
                 await asyncio.wait_for(old_app.shutdown(), timeout=5)
             except Exception:
-                logger.debug("Old Application cleanup failed (expected)")
+                pass
 
     # ------------------------------------------------------------------ #
     #  Outbound: send complete message                                     #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -104,6 +104,48 @@ def _md_to_tg_html(text: str) -> str:
     return text
 
 
+def _format_reply_context(message: Any) -> str:
+    """Extract reply-to context and quote from a Telegram message.
+
+    Returns a prefix string like:
+        [Reply to assistant: "original text here"]
+        [Quoted: "selected portion"]
+
+    Returns empty string if the message is not a reply.
+    """
+    reply = getattr(message, "reply_to_message", None)
+    if not reply:
+        return ""
+
+    parts: list[str] = []
+
+    # Determine sender label
+    from_user = getattr(reply, "from_user", None)
+    if from_user and getattr(from_user, "is_bot", False):
+        sender = "assistant"
+    elif from_user:
+        sender = getattr(from_user, "first_name", None) or "user"
+    else:
+        sender = "user"
+
+    # Original message text
+    original = getattr(reply, "text", None) or getattr(reply, "caption", None) or ""
+    if original:
+        display = original if len(original) <= 500 else original[:500] + "…"
+        parts.append(f'[Reply to {sender}: "{display}"]')
+    else:
+        parts.append(f"[Reply to {sender}'s message]")
+
+    # Quote (manually selected text)
+    quote = getattr(message, "quote", None)
+    if quote:
+        quote_text = getattr(quote, "text", None)
+        if quote_text:
+            parts.append(f'[Quoted: "{quote_text}"]')
+
+    return "\n".join(parts)
+
+
 class TelegramChannel(BaseChannel):
     """Telegram bot channel.
 
@@ -609,6 +651,11 @@ class TelegramChannel(BaseChannel):
         chat_id = update.effective_chat.id
         text = update.message.text or update.message.caption or ""
 
+        # Prepend reply-to context and quote (if replying to a message)
+        reply_context = _format_reply_context(update.message)
+        if reply_context:
+            text = f"{reply_context}\n\n{text}" if text else reply_context
+
         # Extract image if present
         images: list[dict[str, str]] = []
         image = await self._extract_image(update.message)
@@ -679,6 +726,11 @@ class TelegramChannel(BaseChannel):
             if caption:
                 text = caption
                 break
+
+        # Prepend reply-to context (album reply info is on the first message)
+        reply_context = _format_reply_context(updates[0].message)
+        if reply_context:
+            text = f"{reply_context}\n\n{text}" if text else reply_context
 
         # Download all images
         images: list[dict[str, str]] = []

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -37,11 +37,13 @@ EDIT_INTERVAL = 1.5
 # Polling watchdog settings
 WATCHDOG_INTERVAL = 30  # seconds between health checks
 WATCHDOG_HEARTBEAT_INTERVAL = 10  # log heartbeat every N checks (~5 min)
-STALE_THRESHOLD = 600  # seconds without any update before active probe
+STALE_THRESHOLD = 300  # seconds without any update before active probe
+FORCE_RESTART_THRESHOLD = 900  # seconds stale → force restart regardless of probe
 MAX_RESTART_ATTEMPTS = 10  # consecutive failures before entering cooldown
 RESTART_BACKOFF_BASE = 5  # seconds, doubles each attempt, capped at 300s
 COOLDOWN_INTERVAL = 300  # seconds to wait after exhausting restart attempts
 PROBE_TIMEOUT = 10  # seconds for bot.get_me() active health check
+RESTART_STOP_TIMEOUT = 15  # seconds to wait for updater.stop() before giving up
 
 
 class TelegramChannel(BaseChannel):
@@ -146,14 +148,17 @@ class TelegramChannel(BaseChannel):
     async def _run_watchdog(self) -> None:
         """Monitor polling health and auto-restart if it dies.
 
-        Three layers of health checking:
-        1. Task alive? — is the internal polling asyncio task still running
-        2. Updater flag — does PTB think it's polling
-        3. Active probe — can we actually reach Telegram's API (bot.get_me)
+        Four layers of health checking:
+        1. Updater flag — does PTB think it's polling?
+        2. Task alive — is the internal polling asyncio task still running?
+        3. Stale + probe — no handler called in 5 min? Probe with get_me().
+           If probe fails → restart. If probe works → maybe just quiet.
+        4. Force restart — stale for 15 min regardless of probe results.
+           Catches hung connections where the task is alive but stuck.
 
-        The active probe fires when we haven't received any update in
-        STALE_THRESHOLD seconds, catching cases where the task is alive
-        but the connection is silently hung.
+        On restart: tries clean updater.stop() with a 15s timeout.
+        If stop() hangs (stuck connection), rebuilds the entire PTB
+        Application from scratch.
 
         Never gives up permanently — after exhausting rapid restart
         attempts, enters a cooldown period and then tries again.
@@ -249,8 +254,13 @@ class TelegramChannel(BaseChannel):
 
         Layer 1: Is the updater flag set?
         Layer 2: Is the internal polling task still running?
-        Layer 3: If stale (no updates for STALE_THRESHOLD), actively
-                 probe the API with bot.get_me() to detect hung connections.
+        Layer 3: Staleness — no handler called for STALE_THRESHOLD?
+                 Probe API with get_me() to distinguish "no messages"
+                 from "connection hung." But get_me() uses a new connection,
+                 so it can succeed even with a hung polling connection.
+        Layer 4: Force restart after FORCE_RESTART_THRESHOLD regardless —
+                 if we've been stale that long, something is wrong even
+                 if get_me() works.
         """
         if not self._app or not self._app.updater:
             return False
@@ -274,54 +284,79 @@ class TelegramChannel(BaseChannel):
             )
             return False
 
-        # Layer 3: if no updates received recently, probe the API
+        # Layer 3 & 4: staleness checks
         now = time.monotonic()
-        if self._last_update_time > 0:
-            stale_seconds = now - self._last_update_time
-        else:
-            # Never received an update — use time since start
-            stale_seconds = now - self._last_update_time if self._last_update_time else STALE_THRESHOLD + 1
+        stale_seconds = now - self._last_update_time if self._last_update_time > 0 else now
 
-        if stale_seconds > STALE_THRESHOLD:
-            logger.info(
-                "Telegram watchdog: no updates for %.0fs, running active probe",
-                stale_seconds,
+        if stale_seconds <= STALE_THRESHOLD:
+            return True  # fresh enough, definitely healthy
+
+        # Layer 4: been stale way too long → force restart, don't even probe
+        if stale_seconds > FORCE_RESTART_THRESHOLD:
+            logger.warning(
+                "Telegram watchdog: no updates for %.0fs (> %ds) — "
+                "forcing restart (connection likely hung)",
+                stale_seconds, FORCE_RESTART_THRESHOLD,
             )
-            try:
-                me = await asyncio.wait_for(
-                    self._app.bot.get_me(), timeout=PROBE_TIMEOUT,
+            return False
+
+        # Layer 3: stale but not critically — probe API to check
+        logger.info(
+            "Telegram watchdog: no updates for %.0fs, running active probe",
+            stale_seconds,
+        )
+        try:
+            me = await asyncio.wait_for(
+                self._app.bot.get_me(), timeout=PROBE_TIMEOUT,
+            )
+            if me:
+                # API reachable on a fresh connection. Polling *might* be fine
+                # (just no messages), or the polling connection might be hung
+                # while the API itself works. We give it the benefit of the
+                # doubt here — Layer 4 catches it if staleness continues.
+                logger.info(
+                    "Telegram watchdog: active probe OK (bot: @%s), "
+                    "will force-restart at %ds stale",
+                    me.username, FORCE_RESTART_THRESHOLD,
                 )
-                if me:
-                    # API is reachable — polling task might just have no messages
-                    # That's fine, reset the timer to avoid spamming probes
-                    logger.info(
-                        "Telegram watchdog: active probe OK (bot: @%s)",
-                        me.username,
-                    )
-                    self._last_update_time = now
-                    return True
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "Telegram watchdog: active probe timed out after %ds",
-                    PROBE_TIMEOUT,
-                )
-                return False
-            except Exception as e:
-                logger.warning(
-                    "Telegram watchdog: active probe failed: %s", e,
-                )
-                return False
+                return True
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Telegram watchdog: active probe timed out after %ds — "
+                "API unreachable",
+                PROBE_TIMEOUT,
+            )
+            return False
+        except Exception as e:
+            logger.warning(
+                "Telegram watchdog: active probe failed: %s", e,
+            )
+            return False
 
         return True
 
     async def _restart_polling(self) -> None:
-        """Stop the updater cleanly, then start a fresh polling loop."""
+        """Stop the updater cleanly, then start a fresh polling loop.
+
+        If the clean stop hangs (e.g. stuck connection), we time out and
+        rebuild the entire Application from scratch as a last resort.
+        """
         if self._app is None:
             return
 
-        # stop() sets _running=False and cancels the dead task
+        # Try a clean stop with a timeout — stop() can hang if the
+        # polling connection is stuck at the TCP level
         try:
-            await self._app.updater.stop()
+            await asyncio.wait_for(
+                self._app.updater.stop(), timeout=RESTART_STOP_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Telegram updater.stop() hung for %ds — rebuilding Application",
+                RESTART_STOP_TIMEOUT,
+            )
+            await self._rebuild_application()
+            return
         except Exception as e:
             logger.debug("Updater stop during restart: %s", e)
 
@@ -329,6 +364,45 @@ class TelegramChannel(BaseChannel):
 
         # Don't drop pending updates on restart — we might have missed some
         await self._app.updater.start_polling(drop_pending_updates=False)
+
+    async def _rebuild_application(self) -> None:
+        """Nuclear option: tear down and rebuild the entire PTB Application.
+
+        Used when updater.stop() hangs and we can't cleanly restart polling.
+        """
+        old_app = self._app
+
+        # Build a fresh Application with the same config
+        self._app = (
+            Application.builder()
+            .token(self.config.telegram.bot_token)
+            .build()
+        )
+
+        # Re-register all handlers
+        self._app.add_handler(CommandHandler("start", self._handle_start))
+        self._app.add_handler(CommandHandler("session", self._handle_session))
+        self._app.add_handler(CommandHandler("sessions", self._handle_sessions))
+        self._app.add_handler(CommandHandler("new", self._handle_new_session))
+        self._app.add_handler(CommandHandler("reply", self._handle_reply))
+        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+        self._app.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message),
+        )
+        self._app.add_error_handler(self._handle_error)
+
+        await self._app.initialize()
+        await self._app.start()
+        await self._app.updater.start_polling(drop_pending_updates=False)
+
+        logger.info("Telegram Application rebuilt from scratch")
+
+        # Best-effort cleanup of the old app (don't await — it might hang)
+        if old_app:
+            try:
+                await asyncio.wait_for(old_app.shutdown(), timeout=5)
+            except Exception:
+                logger.debug("Old Application cleanup failed (expected)")
 
     # ------------------------------------------------------------------ #
     #  Outbound: send complete message                                     #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -160,6 +160,9 @@ class TelegramChannel(BaseChannel):
         builder = (
             Application.builder()
             .token(self.config.telegram.bot_token)
+            # Process updates concurrently so /stop can interrupt a running
+            # message handler instead of being queued behind it.
+            .concurrent_updates(True)
             # TCP keepalive on the polling connection — prevents NAT/firewall
             # from silently dropping the long-poll connection
             .get_updates_socket_options(_TCP_KEEPALIVE_OPTS)
@@ -177,6 +180,7 @@ class TelegramChannel(BaseChannel):
         app.add_handler(CommandHandler("session", self._handle_session))
         app.add_handler(CommandHandler("sessions", self._handle_sessions))
         app.add_handler(CommandHandler("new", self._handle_new_session))
+        app.add_handler(CommandHandler("stop", self._handle_stop))
         app.add_handler(CommandHandler("reply", self._handle_reply))
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
         app.add_handler(MessageHandler(
@@ -539,6 +543,28 @@ class TelegramChannel(BaseChannel):
             f"New session: `{session_id}`" + (f" — {title}" if title else ""),
             parse_mode=ParseMode.MARKDOWN,
         )
+
+    async def _handle_stop(self, update: Update, context: Any) -> None:
+        """Handle /stop — stop the currently running session."""
+        self._touch()
+        if not self._is_authorized(update.effective_user.id):
+            return
+        chat_id = update.effective_chat.id
+        channel_key = f"telegram:{chat_id}"
+
+        session_id = await self.router.get_last_session(channel_key)
+        if not session_id:
+            await update.message.reply_text("No active session.")
+            return
+
+        stopped = await self.router.engine.stop_session(session_id)
+        if stopped:
+            await update.message.reply_text(
+                f"Stopped session `{session_id}`.",
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        else:
+            await update.message.reply_text("Nothing running to stop.")
 
     # ------------------------------------------------------------------ #
     #  Message handler — construct InboundMessage and delegate             #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import collections
 import html as _html
 import logging
 import re
@@ -18,7 +19,7 @@ from typing import Any, TYPE_CHECKING
 
 from telegram import Update
 from telegram.constants import ChatAction, ParseMode
-from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, filters
+from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, MessageReactionHandler, filters
 
 from nerve.channels.base import (
     BaseChannel,
@@ -165,6 +166,11 @@ class TelegramChannel(BaseChannel):
         # Media group (album) collection: group_id -> list of updates
         self._media_groups: dict[str, list[Update]] = {}
         self._media_group_tasks: dict[str, asyncio.Task] = {}
+        # Message cache for reaction context: message_id -> (chat_id, text_snippet)
+        self._message_cache: collections.OrderedDict[int, tuple[int, str]] = (
+            collections.OrderedDict()
+        )
+        self._message_cache_max = 200
 
     def set_notification_service(self, service) -> None:
         """Wire the notification service for callback query handling."""
@@ -229,6 +235,7 @@ class TelegramChannel(BaseChannel):
             (filters.TEXT | filters.PHOTO) & ~filters.COMMAND,
             self._handle_message,
         ))
+        app.add_handler(MessageReactionHandler(self._handle_reaction))
         app.add_error_handler(self._handle_error)
 
         return app
@@ -249,6 +256,10 @@ class TelegramChannel(BaseChannel):
             # Retry initial connection indefinitely — don't give up on
             # transient network errors during startup
             bootstrap_retries=-1,
+            # Explicitly request all update types — the default set excludes
+            # message_reaction, and auto-detection only works via
+            # Application.run_polling(), not Updater.start_polling().
+            allowed_updates=Update.ALL_TYPES,
         )
         self._last_update_time = time.monotonic()
         logger.info("Telegram bot started polling (with TCP keepalive)")
@@ -397,6 +408,7 @@ class TelegramChannel(BaseChannel):
         await self._app.updater.start_polling(
             drop_pending_updates=False,
             bootstrap_retries=-1,
+            allowed_updates=Update.ALL_TYPES,
         )
         self._last_update_time = time.monotonic()
 
@@ -430,16 +442,17 @@ class TelegramChannel(BaseChannel):
             chunk = text[i:i + MAX_MSG_LEN]
             html_chunk = _md_to_tg_html(chunk)
             try:
-                await self._app.bot.send_message(
+                sent = await self._app.bot.send_message(
                     chat_id=chat_id,
                     text=html_chunk,
                     parse_mode=ParseMode.HTML,
                 )
             except Exception:
-                await self._app.bot.send_message(
+                sent = await self._app.bot.send_message(
                     chat_id=chat_id,
                     text=chunk,
                 )
+            self._cache_message(sent.message_id, chat_id, chunk)
 
     def format_response(self, text: str) -> str:
         """Truncate for Telegram if needed."""
@@ -486,6 +499,8 @@ class TelegramChannel(BaseChannel):
                 )
             except Exception:
                 pass
+        # Update cache with the latest text (streaming overwrites placeholder)
+        self._cache_message(int(message_id), int(target), text)
 
     async def send_typing(self, target: str) -> None:
         """Show typing indicator."""
@@ -495,6 +510,21 @@ class TelegramChannel(BaseChannel):
             chat_id=int(target),
             action=ChatAction.TYPING,
         )
+
+    # ------------------------------------------------------------------ #
+    #  Message cache (for reaction context)                                #
+    # ------------------------------------------------------------------ #
+
+    def _cache_message(self, message_id: int, chat_id: int, text: str) -> None:
+        """Store a message snippet in the LRU cache for reaction lookups."""
+        snippet = text[:200] if text else ""
+        if not snippet:
+            return
+        self._message_cache[message_id] = (chat_id, snippet)
+        # Move to end (most recent) and evict oldest if over limit
+        self._message_cache.move_to_end(message_id)
+        while len(self._message_cache) > self._message_cache_max:
+            self._message_cache.popitem(last=False)
 
     # ------------------------------------------------------------------ #
     #  Auth                                                                #
@@ -651,6 +681,9 @@ class TelegramChannel(BaseChannel):
         chat_id = update.effective_chat.id
         text = update.message.text or update.message.caption or ""
 
+        # Cache for reaction lookups (raw text, before reply-context prefix)
+        self._cache_message(update.message.message_id, chat_id, text)
+
         # Prepend reply-to context and quote (if replying to a message)
         reply_context = _format_reply_context(update.message)
         if reply_context:
@@ -688,6 +721,60 @@ class TelegramChannel(BaseChannel):
                 await update.message.reply_text(f"Error: {e}")
             except Exception:
                 logger.error("Failed to send error reply to chat %s", chat_id)
+
+    # ------------------------------------------------------------------ #
+    #  Reaction handler                                                    #
+    # ------------------------------------------------------------------ #
+
+    async def _handle_reaction(self, update: Update, context: Any) -> None:
+        """Handle message reaction updates — forward as text to router."""
+        self._touch()
+        reaction_update = update.message_reaction
+        if reaction_update is None:
+            return
+
+        user = reaction_update.user
+        if user is None or not self._is_authorized(user.id):
+            return
+
+        chat_id = reaction_update.chat.id
+        message_id = reaction_update.message_id
+
+        # Extract new emoji reactions
+        emojis = []
+        for r in reaction_update.new_reaction:
+            emoji = getattr(r, "emoji", None)
+            if emoji:
+                emojis.append(emoji)
+
+        if not emojis:
+            # Reaction removed — ignore for now
+            return
+
+        emoji_str = " ".join(emojis)
+
+        # Look up original message text from cache
+        cached = self._message_cache.get(message_id)
+        if cached:
+            _, original_text = cached
+            text = f'[Reaction: {emoji_str} on message: "{original_text}"]'
+        else:
+            text = f"[Reaction: {emoji_str}]"
+
+        logger.info("Telegram reaction from %s: %s (msg %d)", chat_id, emoji_str, message_id)
+
+        msg = InboundMessage(
+            channel_name="telegram",
+            channel_key=f"telegram:{chat_id}",
+            sender_id=str(chat_id),
+            text=text,
+            metadata={},
+        )
+
+        try:
+            await self.router.handle_message(msg)
+        except Exception as e:
+            logger.error("Agent error for reaction in chat %s: %s", chat_id, e, exc_info=True)
 
     # ------------------------------------------------------------------ #
     #  Media group (album) collection                                     #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -529,15 +529,21 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text("\n".join(lines), parse_mode=ParseMode.MARKDOWN)
 
     async def _handle_new_session(self, update: Update, context: Any) -> None:
-        """Handle /new [title] — create and switch to a new session."""
+        """Handle /new [title] — stop current session, create and switch to a new one."""
         self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
         chat_id = update.effective_chat.id
+        channel_key = f"telegram:{chat_id}"
+
+        # Stop the current session before creating a new one
+        prev = await self.router.get_last_session(channel_key)
+        if prev:
+            await self.router.engine.stop_session(prev)
 
         title = " ".join(context.args) if context.args else None
         session_id = await self.router.create_session(
-            f"telegram:{chat_id}", title=title, source="telegram",
+            channel_key, title=title, source="telegram",
         )
         await update.message.reply_text(
             f"New session: `{session_id}`" + (f" — {title}" if title else ""),

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -419,7 +419,8 @@ class TelegramChannel(BaseChannel):
                 text=html_text,
                 parse_mode=ParseMode.HTML,
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning("edit_message HTML failed: %s", exc)
             # Fallback: send without formatting if HTML parsing fails
             try:
                 await self._app.bot.edit_message_text(

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -330,7 +330,13 @@ def stop(ctx: click.Context) -> None:
 @main.command()
 @click.pass_context
 def restart(ctx: click.Context) -> None:
-    """Restart the Nerve daemon."""
+    """Restart the Nerve daemon.
+
+    Spawns a detached helper process that stops the old daemon and starts a
+    new one.  This ensures restarts work even when triggered from *inside*
+    the running daemon (e.g. via the Telegram bot / agent), because the
+    helper runs in its own session and survives the parent's death.
+    """
     config = ctx.obj["config"]
     config_dir = Path(ctx.obj["config_dir"])
 
@@ -342,32 +348,76 @@ def restart(ctx: click.Context) -> None:
         ctx.exit(rc)
         return
 
-    running, pid = _get_daemon_status()
+    # Build the command that `start` would use to launch the daemon.
+    verbose = ctx.obj["verbose"]
+    nerve_bin = sys.argv[0]
+    start_cmd_parts = [sys.executable, nerve_bin, "-c", str(config_dir)]
+    if verbose:
+        start_cmd_parts.append("-v")
+    start_cmd_parts.extend(["start", "--foreground"])
+
+    running, old_pid = _get_daemon_status()
+
+    # Spawn a detached helper that: waits for old PID to exit, then starts
+    # a new daemon.  Written as an inline Python script so we don't need an
+    # external shell script on disk.
+    helper_script = (
+        "import os, signal, subprocess, sys, time\n"
+        f"old_pid = {old_pid if running else 'None'}\n"
+        f"pid_file = {str(PID_FILE)!r}\n"
+        f"log_file = {str(LOG_FILE)!r}\n"
+        f"start_cmd = {start_cmd_parts!r}\n"
+        "if old_pid is not None:\n"
+        "    try:\n"
+        "        os.kill(old_pid, signal.SIGTERM)\n"
+        "    except ProcessLookupError:\n"
+        "        pass\n"
+        "    for _ in range(30):\n"
+        "        time.sleep(0.5)\n"
+        "        try:\n"
+        "            os.kill(old_pid, 0)\n"
+        "        except ProcessLookupError:\n"
+        "            break\n"
+        "    else:\n"
+        "        try:\n"
+        "            os.kill(old_pid, signal.SIGKILL)\n"
+        "            time.sleep(0.5)\n"
+        "        except ProcessLookupError:\n"
+        "            pass\n"
+        "    # Remove stale PID file\n"
+        "    try:\n"
+        "        os.unlink(pid_file)\n"
+        "    except FileNotFoundError:\n"
+        "        pass\n"
+        "time.sleep(0.5)\n"
+        "log_fd = open(log_file, 'a')\n"
+        "proc = subprocess.Popen(\n"
+        "    start_cmd,\n"
+        "    stdout=log_fd,\n"
+        "    stderr=log_fd,\n"
+        "    stdin=subprocess.DEVNULL,\n"
+        "    start_new_session=True,\n"
+        ")\n"
+        "log_fd.close()\n"
+        "time.sleep(1)\n"
+        "if proc.poll() is not None:\n"
+        "    sys.exit(1)\n"
+    )
+
+    log_fd = open(LOG_FILE, "a")
+    subprocess.Popen(
+        [sys.executable, "-c", helper_script],
+        stdout=log_fd,
+        stderr=log_fd,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    log_fd.close()
+
     if running:
-        click.echo(f"Stopping Nerve (PID {pid})...")
-        os.kill(pid, signal.SIGTERM)
-
-        # Wait for shutdown
-        for _ in range(30):
-            time.sleep(0.5)
-            if not _is_running(pid):
-                break
-        else:
-            click.echo("Graceful shutdown timed out, sending SIGKILL...")
-            try:
-                os.kill(pid, signal.SIGKILL)
-                time.sleep(0.5)
-            except ProcessLookupError:
-                pass
-
-        _remove_pid()
-        click.echo("Nerve stopped")
-
-    # Brief pause before restart
-    time.sleep(0.5)
-
-    # Start again — invoke start command
-    ctx.invoke(start)
+        click.echo(f"Restarting Nerve (PID {old_pid})... new instance will start shortly.")
+    else:
+        click.echo("Starting Nerve... new instance will start shortly.")
 
 
 @main.command()

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -91,13 +91,13 @@ async def lifespan(app: FastAPI):
     set_notification_service(notification_service)
 
     # Start Telegram bot if enabled
-    telegram_task = None
+    telegram_channel = None
     if config.telegram.enabled and config.telegram.bot_token:
         from nerve.channels.telegram import TelegramChannel
-        telegram = TelegramChannel(config, _engine.router)
-        telegram.set_notification_service(notification_service)
-        _engine.register_channel(telegram)
-        telegram_task = asyncio.create_task(telegram.start())
+        telegram_channel = TelegramChannel(config, _engine.router)
+        telegram_channel.set_notification_service(notification_service)
+        _engine.register_channel(telegram_channel)
+        await telegram_channel.start()
         logger.info("Telegram bot started")
 
     # Start cron service
@@ -195,8 +195,8 @@ async def lifespan(app: FastAPI):
     # Shutdown
     if cron_task:
         await cron_task.stop()
-    if telegram_task:
-        telegram_task.cancel()
+    if telegram_channel:
+        await telegram_channel.stop()
     await _engine.shutdown()
     await close_db()
     if proxy_service:

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -187,16 +187,19 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    # Shutdown: stop telegram FIRST, before cancelling background tasks.
+    # Background task cancellation propagates through anyio cancel scopes
+    # (Starlette runs the lifespan in an anyio context), which can kill
+    # the telegram polling task before we get a chance to stop it cleanly.
+    if telegram_channel:
+        await telegram_channel.stop()
+    if cron_task:
+        await cron_task.stop()
+
     notify_expiry_task.cancel()
     idle_sweep_task.cancel()
     memorize_task.cancel()
     cleanup_task.cancel()
-
-    # Shutdown
-    if cron_task:
-        await cron_task.stop()
-    if telegram_channel:
-        await telegram_channel.stop()
     await _engine.shutdown()
     await close_db()
     if proxy_service:

--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -1121,6 +1121,10 @@ class MemUBridge:
                     prompt, *, max_tokens=None, system_prompt=None, temperature=0.2,
                     _orig=original_chat, _prof=profile,
                 ):
+                    # Anthropic API requires max_tokens >= 1; memU sometimes
+                    # omits it.  Default to 4096 to prevent 400 errors.
+                    if max_tokens is None:
+                        max_tokens = 4096
                     t0 = time.monotonic()
                     try:
                         return await asyncio.wait_for(

--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -1550,6 +1550,9 @@ class MemUBridge:
             return self._anthropic_client
         import anthropic
         base_url = self.config.anthropic_api_base_url.rstrip("/")
+        # Strip /v1/ suffix — Anthropic SDK prepends it internally.
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
         self._anthropic_client = anthropic.Anthropic(
             api_key=self.config.effective_api_key,
             base_url=base_url,

--- a/nerve/sources/registry.py
+++ b/nerve/sources/registry.py
@@ -7,7 +7,7 @@ as APScheduler jobs. Centralizes all source construction and config extraction.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from nerve.sources.runner import SourceRunner
 
@@ -34,12 +34,13 @@ def build_source_runners(
     ttl_days = config.sync.message_ttl_days
 
     # Build condense config from API credentials
-    condense_cfg: dict[str, str] | None = None
+    condense_cfg: dict[str, Any] | None = None
     if config.effective_api_key and config.memory.fast_model:
         condense_cfg = {
             "api_key": config.effective_api_key,
             "model": config.memory.fast_model,
             "base_url": config.anthropic_api_base_url,
+            "use_proxy": config.proxy.enabled,
         }
 
     # Telegram

--- a/nerve/sources/runner.py
+++ b/nerve/sources/runner.py
@@ -173,7 +173,12 @@ class SourceRunner:
     # ------------------------------------------------------------------
 
     async def _get_condense_client(self) -> Any | None:
-        """Get or create the shared AsyncAnthropic client for condensation."""
+        """Get or create the shared AsyncAnthropic client for condensation.
+
+        Returns None when proxy mode is active (uses httpx directly).
+        """
+        if self.condense_config.get("use_proxy"):
+            return None  # Proxy uses OpenAI-compatible httpx calls
         if self._condense_client is not None:
             return self._condense_client
         api_key = self.condense_config.get("api_key")
@@ -187,9 +192,43 @@ class SourceRunner:
         base_url = self.condense_config.get("base_url")
         kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url:
-            kwargs["base_url"] = base_url.rstrip("/")
+            # Strip /v1/ suffix — Anthropic SDK prepends it internally,
+            # so including it here causes /v1/v1/messages (404).
+            url = base_url.rstrip("/")
+            if url.endswith("/v1"):
+                url = url[:-3]
+            kwargs["base_url"] = url
         self._condense_client = anthropic.AsyncAnthropic(**kwargs)
         return self._condense_client
+
+    async def _condense_via_proxy(
+        self, content: str, model: str,
+    ) -> str:
+        """Condense content via the OpenAI-compatible proxy endpoint."""
+        import httpx
+
+        base_url = self.condense_config.get("base_url", "")
+        if not base_url.endswith("/"):
+            base_url += "/"
+        api_key = self.condense_config.get("api_key", "")
+
+        async with httpx.AsyncClient() as http_client:
+            resp = await http_client.post(
+                f"{base_url}chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "max_tokens": 1024,
+                    "messages": [{"role": "user", "content": content}],
+                },
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data["choices"][0]["message"]["content"]
 
     async def _condense_long_content(
         self, records: list[SourceRecord],
@@ -211,13 +250,21 @@ class SourceRunner:
         if not long_records:
             return records
 
-        client = await self._get_condense_client()
-        if not client:
-            return records
+        use_proxy = self.condense_config.get("use_proxy", False)
+
+        if not use_proxy:
+            client = await self._get_condense_client()
+            if not client:
+                return records
+        else:
+            client = None
+            if not self.condense_config.get("api_key"):
+                return records
 
         logger.info(
-            "Source %s: condensing %d/%d records with %s",
+            "Source %s: condensing %d/%d records with %s%s",
             self.source.source_name, len(long_records), len(records), model,
+            " (via proxy)" if use_proxy else "",
         )
         sem = asyncio.Semaphore(5)
 
@@ -225,22 +272,28 @@ class SourceRunner:
             async with sem:
                 original_len = len(record.content)
                 try:
-                    response = await asyncio.wait_for(
-                        client.messages.create(
-                            model=model,
-                            max_tokens=1024,
-                            messages=[{
-                                "role": "user",
-                                "content": (
-                                    f"{_CONDENSE_PROMPT}\n\n"
-                                    f"---\n\n"
-                                    f"{record.content}"
-                                ),
-                            }],
-                        ),
-                        timeout=30,
+                    prompt_content = (
+                        f"{_CONDENSE_PROMPT}\n\n"
+                        f"---\n\n"
+                        f"{record.content}"
                     )
-                    condensed = response.content[0].text
+                    if use_proxy:
+                        condensed = await self._condense_via_proxy(
+                            prompt_content, model,
+                        )
+                    else:
+                        response = await asyncio.wait_for(
+                            client.messages.create(
+                                model=model,
+                                max_tokens=1024,
+                                messages=[{
+                                    "role": "user",
+                                    "content": prompt_content,
+                                }],
+                            ),
+                            timeout=30,
+                        )
+                        condensed = response.content[0].text
                     record.content = condensed
                     logger.debug(
                         "Condensed %s: %d → %d chars",

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -544,11 +544,13 @@ class TestCredentialWaterfall:
         assert token == "sk-ant-oat01-test"
         assert source == "CLAUDE_CODE_OAUTH_TOKEN env var"
 
-    def test_resolve_claude_from_api_key_env(self) -> None:
+    def test_resolve_claude_from_api_key_env(self, tmp_path: Path) -> None:
         """ANTHROPIC_API_KEY should be last resort in waterfall."""
         env = {"ANTHROPIC_API_KEY": "sk-ant-api03-test"}
-        # Clear OAuth token to ensure it doesn't interfere
-        with patch.dict(os.environ, env, clear=False):
+        # Point credentials file at a non-existent path so the real one isn't found
+        fake_creds = tmp_path / "nonexistent" / ".credentials.json"
+        with patch.dict(os.environ, env, clear=False), \
+             patch("nerve.bootstrap.Path.expanduser", return_value=fake_creds):
             # Remove CLAUDE_CODE_OAUTH_TOKEN if set
             os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
             token, source, debug = _resolve_claude_credential()
@@ -569,10 +571,13 @@ class TestCredentialWaterfall:
         assert token == "sk-ant-oat01-file"
         assert "credentials.json" in source
 
-    def test_resolve_claude_none(self) -> None:
+    def test_resolve_claude_none(self, tmp_path: Path) -> None:
         """Should return empty when no credentials found."""
+        # Point credentials file at a non-existent path so the real one isn't found
+        fake_creds = tmp_path / "nonexistent" / ".credentials.json"
         with patch.dict(os.environ, {}, clear=True), \
-             patch("nerve.bootstrap.sys.platform", "linux"):
+             patch("nerve.bootstrap.sys.platform", "linux"), \
+             patch("nerve.bootstrap.Path.expanduser", return_value=fake_creds):
             token, source, debug = _resolve_claude_credential()
         assert token == ""
         assert source == "none"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -534,3 +534,68 @@ class TestSubsystemConfigWiring:
         assert len(runners) >= 1
         assert runners[0].condense_config["api_key"] == "sk-ant-real-key"
         assert "api.anthropic.com" in runners[0].condense_config["base_url"]
+
+
+class TestCondenseClientBaseUrl:
+    """Verify condense client strips /v1 suffix to avoid /v1/v1/messages."""
+
+    @pytest.mark.asyncio
+    async def test_condense_client_strips_v1_from_proxy_url(self) -> None:
+        """Proxy base_url includes /v1/ — SDK must not double it."""
+        from nerve.sources.runner import SourceRunner
+
+        runner = SourceRunner(
+            source=MagicMock(),
+            db=MagicMock(),
+            condense=True,
+            condense_config={
+                "api_key": "sk-test",
+                "model": "claude-haiku-4-5-20251001",
+                "base_url": "http://127.0.0.1:8317/v1/",
+            },
+        )
+        client = await runner._get_condense_client()
+        assert client is not None
+        base = str(client.base_url)
+        # Must NOT contain /v1/v1
+        assert "/v1/v1" not in base
+        # Must end with the proxy host (no /v1 path)
+        assert base.rstrip("/") == "http://127.0.0.1:8317"
+
+    @pytest.mark.asyncio
+    async def test_condense_client_strips_v1_from_direct_url(self) -> None:
+        """Direct API base_url also includes /v1/ — same fix applies."""
+        from nerve.sources.runner import SourceRunner
+
+        runner = SourceRunner(
+            source=MagicMock(),
+            db=MagicMock(),
+            condense=True,
+            condense_config={
+                "api_key": "sk-test",
+                "model": "claude-haiku-4-5-20251001",
+                "base_url": "https://api.anthropic.com/v1/",
+            },
+        )
+        client = await runner._get_condense_client()
+        assert client is not None
+        base = str(client.base_url)
+        assert "/v1/v1" not in base
+        assert base.rstrip("/") == "https://api.anthropic.com"
+
+    @pytest.mark.asyncio
+    async def test_condense_client_no_base_url(self) -> None:
+        """Without base_url, SDK uses its default — no crash."""
+        from nerve.sources.runner import SourceRunner
+
+        runner = SourceRunner(
+            source=MagicMock(),
+            db=MagicMock(),
+            condense=True,
+            condense_config={
+                "api_key": "sk-test",
+                "model": "claude-haiku-4-5-20251001",
+            },
+        )
+        client = await runner._get_condense_client()
+        assert client is not None


### PR DESCRIPTION
## Summary
- **CLI sync**: Fix broken `nerve sync` command after `IngestResult` refactor — update field names and remove stale `engine` argument from `build_source_runners`
- **Telegram channel**: Add global error handler, log incoming messages, and wrap error replies in try/except to prevent silent failures
- **memU bridge**: Default `max_tokens` to 4096 when omitted, preventing Anthropic API 400 errors

## Test plan
- [ ] Run `nerve sync` and verify it completes without errors
- [ ] Send a message via Telegram and confirm it's logged and processed
- [ ] Trigger an error in the Telegram handler and verify the error reply is sent (or gracefully logged if reply fails)
- [ ] Verify memU extraction works without explicitly passing `max_tokens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)