### PR TITLE
Session management, Telegram UX, and cron improvements

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -103,6 +103,7 @@ class AgentEngine:
         self._memory_bridge = None
         self._skill_manager: SkillManager | None = None
         self._memorize_lock = asyncio.Lock()
+        self._session_locks: dict[str, asyncio.Lock] = {}
         self._router = None  # ChannelRouter — lazy-initialized via .router property
         self._mcp_servers_cache = list(config.mcp_servers)  # hot-reloadable
         self._claude_code_plugins: list[dict[str, str]] = []  # plugin dirs
@@ -1008,46 +1009,40 @@ class AgentEngine:
             images: Optional list of image dicts with keys ``type``,
                     ``media_type``, and ``data`` (base64-encoded).
         """
-        # If the session is still running (e.g. /stop cleanup in progress),
-        # wait briefly instead of failing immediately.
-        if self.sessions.is_running(session_id):
-            for _ in range(10):
-                await asyncio.sleep(0.3)
-                if not self.sessions.is_running(session_id):
-                    break
-            else:
-                raise RuntimeError(f"Session {session_id} is already running")
-
-        broadcaster.start_buffering(session_id)
-        async with self._semaphore:
-            # Clear any stale deferred-stop flag left over from a *previous*
-            # turn.  If /stop arrived while the old turn was still cleaning up
-            # (mark_not_running hadn't run yet), the flag lingers and would
-            # immediately kill this brand-new turn.  Flags set *during* this
-            # turn's client init are unaffected — they're created after
-            # mark_running below.
-            self.sessions.pop_stop_request(session_id)
-            self.sessions.mark_running(session_id)
-            # Notify all connected clients that this session started running
-            await broadcaster.broadcast("__global__", {
-                "type": "session_running",
-                "session_id": session_id,
-                "is_running": True,
-            })
-            try:
-                return await self._run_inner(
-                    session_id, user_message, source, channel, model,
-                    internal=internal, images=images,
-                )
-            finally:
-                self.sessions.mark_not_running(session_id)
-                broadcaster.stop_buffering(session_id)
-                # Notify all connected clients that this session stopped
+        # Serialize runs per session — messages for the same session wait
+        # in order instead of failing with "already running".
+        lock = self._session_locks.setdefault(session_id, asyncio.Lock())
+        async with lock:
+            broadcaster.start_buffering(session_id)
+            async with self._semaphore:
+                # Clear any stale deferred-stop flag left over from a *previous*
+                # turn.  If /stop arrived while the old turn was still cleaning up
+                # (mark_not_running hadn't run yet), the flag lingers and would
+                # immediately kill this brand-new turn.  Flags set *during* this
+                # turn's client init are unaffected — they're created after
+                # mark_running below.
+                self.sessions.pop_stop_request(session_id)
+                self.sessions.mark_running(session_id)
+                # Notify all connected clients that this session started running
                 await broadcaster.broadcast("__global__", {
                     "type": "session_running",
                     "session_id": session_id,
-                    "is_running": False,
+                    "is_running": True,
                 })
+                try:
+                    return await self._run_inner(
+                        session_id, user_message, source, channel, model,
+                        internal=internal, images=images,
+                    )
+                finally:
+                    self.sessions.mark_not_running(session_id)
+                    broadcaster.stop_buffering(session_id)
+                    # Notify all connected clients that this session stopped
+                    await broadcaster.broadcast("__global__", {
+                        "type": "session_running",
+                        "session_id": session_id,
+                        "is_running": False,
+                    })
 
     async def _run_inner(
         self,

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1124,11 +1124,19 @@ class AgentEngine:
                 return ""
 
             # Send message — the client preserves conversation history internally
+            # Escape slash-prefixed messages so Claude Code CLI doesn't
+            # intercept them as built-in slash commands.  Registered bot
+            # commands (/stop, /new, etc.) are handled upstream — anything
+            # that reaches here should go straight to the LLM.
+            query_text = user_message
+            if query_text and query_text.startswith("/"):
+                query_text = "\u200b" + query_text
+
             if images:
                 # Build multi-modal content blocks (text + images)
                 content_blocks: list[dict[str, Any]] = []
-                if user_message:
-                    content_blocks.append({"type": "text", "text": user_message})
+                if query_text:
+                    content_blocks.append({"type": "text", "text": query_text})
                 for img in images:
                     content_blocks.append({
                         "type": "image",
@@ -1148,7 +1156,7 @@ class AgentEngine:
 
                 await client.query(_image_prompt())
             else:
-                await client.query(user_message)
+                await client.query(query_text)
 
             async for message in client.receive_response():
                 # Early-capture sdk_session_id from first message that

--- a/nerve/channels/base.py
+++ b/nerve/channels/base.py
@@ -131,6 +131,15 @@ class BaseChannel(abc.ABC):
         constraints.supports_message_edit is True.
         """
 
+    async def delete_message(self, target: str, message_id: str) -> None:
+        """Delete a previously sent message.
+
+        Used by StreamAdapter to remove the streaming placeholder after
+        sending the final message as a new message (to trigger notifications).
+        Only called if channel declares STREAMING capability and
+        constraints.supports_message_edit is True.
+        """
+
     # ------------------------------------------------------------------ #
     #  Optional: typing indicator                                          #
     #  Only called if channel declares ChannelCapability.TYPING_INDICATOR. #

--- a/nerve/channels/router.py
+++ b/nerve/channels/router.py
@@ -51,6 +51,13 @@ class ChannelRouter:
         # Per-session inbound message context (for reaction support)
         # Maps session_id -> {channel_name, target, message_id}
         self._message_context: dict[str, dict[str, Any]] = {}
+        # Per-session locks and pending queues for message batching.
+        # Messages arriving while a session is busy are queued and
+        # processed as a single combined turn once the current run ends.
+        self._session_locks: dict[str, asyncio.Lock] = {}
+        self._pending_batches: dict[
+            str, list[tuple[InboundMessage, asyncio.Future[str]]]
+        ] = {}
 
     # ------------------------------------------------------------------ #
     #  Channel registry                                                    #
@@ -80,12 +87,11 @@ class ChannelRouter:
     async def handle_message(self, msg: InboundMessage) -> str:
         """Process an inbound user message.
 
-        1. Resolve session (from explicit session_id or channel mapping)
-        2. Show typing indicator if supported
-        3. Set up streaming adapter for the response
-        4. Run the agent
-        5. Tear down streaming adapter
-        6. Return the final response text
+        Messages for the same session are serialized via a per-session lock.
+        If a session is already busy, arriving messages are queued and
+        processed together as a single batched turn once the current run
+        finishes.  This avoids "Session already running" errors and lets
+        rapid-fire or forwarded messages be handled as a group.
 
         Called by channel implementations when they receive a user message.
         """
@@ -96,7 +102,6 @@ class ChannelRouter:
         # Resolve session
         if msg.session_id:
             session_id = msg.session_id
-            # Ensure mapping is persisted
             await self.engine.sessions.set_active_session(
                 msg.channel_key, session_id,
             )
@@ -114,25 +119,71 @@ class ChannelRouter:
                 "message_id": msg_id,
             }
 
-        # Show typing indicator if supported
+        # If the session is busy, queue for batch processing instead of
+        # setting up a streaming adapter that would never be used.
+        lock = self._session_locks.setdefault(session_id, asyncio.Lock())
+        if lock.locked():
+            future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+            self._pending_batches.setdefault(session_id, []).append(
+                (msg, future),
+            )
+            return await future
+
+        async with lock:
+            try:
+                response = await self._run_single(channel, msg, session_id)
+            except (asyncio.CancelledError, Exception):
+                # Current run failed/cancelled — cancel all pending futures
+                self._cancel_pending(session_id)
+                raise
+
+            # Drain messages that arrived while we were busy
+            while pending := self._pending_batches.pop(session_id, None):
+                try:
+                    batch_response = await self._run_batch(
+                        channel, pending, session_id,
+                    )
+                except asyncio.CancelledError:
+                    for _, fut in pending:
+                        if not fut.done():
+                            fut.cancel()
+                    self._cancel_pending(session_id)
+                    raise
+                except Exception as exc:
+                    for _, fut in pending:
+                        if not fut.done():
+                            fut.set_exception(exc)
+                else:
+                    for _, fut in pending:
+                        if not fut.done():
+                            fut.set_result(batch_response)
+
+            return response
+
+    # ------------------------------------------------------------------ #
+    #  Internal run helpers                                                #
+    # ------------------------------------------------------------------ #
+
+    async def _run_single(
+        self,
+        channel: BaseChannel,
+        msg: InboundMessage,
+        session_id: str,
+    ) -> str:
+        """Run the engine for a single message with streaming."""
         if ChannelCapability.TYPING_INDICATOR in channel.capabilities:
             try:
                 await channel.send_typing(msg.sender_id)
             except Exception as e:
-                logger.debug("Typing indicator failed for %s: %s", msg.channel_name, e)
+                logger.debug(
+                    "Typing indicator failed for %s: %s", msg.channel_name, e,
+                )
 
-        # Set up streaming adapter
         adapter = await self._setup_streaming(
             channel, msg.sender_id, session_id,
         )
-
-        # Extract images from metadata (e.g. Telegram photos)
         images = msg.metadata.get("images") if msg.metadata else None
 
-        # Wrap in a Task so stop_session() can cancel it (otherwise
-        # channels that ``await engine.run()`` directly — like Telegram —
-        # have no cancellable task and /stop only sends an SDK interrupt
-        # which may hang indefinitely).
         task = asyncio.create_task(
             self.engine.run(
                 session_id=session_id,
@@ -144,12 +195,8 @@ class ChannelRouter:
         )
         self.engine.register_task(session_id, task)
         try:
-            response = await task
-            return response
+            return await task
         except asyncio.CancelledError:
-            # /stop cancelled the task — _run_inner already handled
-            # cleanup (persisted sdk_session_id, marked stopped, etc.).
-            # Return whatever partial response was captured.
             if task.done() and not task.cancelled():
                 return task.result()
             return ""
@@ -157,6 +204,73 @@ class ChannelRouter:
             await self._teardown_streaming(
                 channel.name, msg.sender_id, session_id,
             )
+
+    async def _run_batch(
+        self,
+        channel: BaseChannel,
+        pending: list[tuple[InboundMessage, asyncio.Future[str]]],
+        session_id: str,
+    ) -> str:
+        """Combine pending messages into one turn and run."""
+        last_msg = pending[-1][0]
+        sender_id = last_msg.sender_id
+
+        # Combine texts (each message on its own line)
+        combined_text = "\n\n".join(m.text for m, _ in pending)
+
+        # Combine images from all messages
+        all_images: list[dict[str, Any]] = []
+        for m, _ in pending:
+            imgs = m.metadata.get("images") if m.metadata else None
+            if imgs:
+                all_images.extend(imgs)
+
+        # Update reaction context to the last message in the batch
+        msg_id = last_msg.metadata.get("message_id") if last_msg.metadata else None
+        if msg_id is not None:
+            self._message_context[session_id] = {
+                "channel_name": last_msg.channel_name,
+                "target": sender_id,
+                "message_id": msg_id,
+            }
+
+        if ChannelCapability.TYPING_INDICATOR in channel.capabilities:
+            try:
+                await channel.send_typing(sender_id)
+            except Exception as e:
+                logger.debug(
+                    "Typing indicator failed for %s: %s",
+                    last_msg.channel_name, e,
+                )
+
+        adapter = await self._setup_streaming(channel, sender_id, session_id)
+
+        task = asyncio.create_task(
+            self.engine.run(
+                session_id=session_id,
+                user_message=combined_text,
+                source=last_msg.channel_name,
+                channel=last_msg.channel_name,
+                images=all_images or None,
+            )
+        )
+        self.engine.register_task(session_id, task)
+        try:
+            return await task
+        except asyncio.CancelledError:
+            if task.done() and not task.cancelled():
+                return task.result()
+            return ""
+        finally:
+            await self._teardown_streaming(
+                channel.name, sender_id, session_id,
+            )
+
+    def _cancel_pending(self, session_id: str) -> None:
+        """Cancel all pending futures for a session."""
+        for _, fut in self._pending_batches.pop(session_id, []):
+            if not fut.done():
+                fut.cancel()
 
     # ------------------------------------------------------------------ #
     #  Reactions                                                            #

--- a/nerve/channels/stream_adapter.py
+++ b/nerve/channels/stream_adapter.py
@@ -20,6 +20,8 @@ from nerve.channels.base import (
 
 logger = logging.getLogger(__name__)
 
+STREAMING_INDICATOR = "\n\n⏳"
+
 
 class StreamAdapter:
     """Translates StreamBroadcaster events into channel-specific output.
@@ -129,9 +131,10 @@ class StreamAdapter:
 
         async with self._edit_lock:
             try:
-                display = self._truncate(self._buffer)
+                indicator = STREAMING_INDICATOR
+                display = self._truncate(self._buffer, reserve=len(indicator))
                 await self.channel.edit_message(
-                    self.target, self._placeholder_id, display,
+                    self.target, self._placeholder_id, display + indicator,
                 )
                 self._last_edit = now
             except Exception:
@@ -139,15 +142,32 @@ class StreamAdapter:
 
     async def _handle_done(self) -> None:
         if self._supports_streaming and self._supports_edit and self._placeholder_id:
-            # Final edit with complete text
+            # Send final text as a new message (triggers notification),
+            # then delete the streaming placeholder.
             async with self._edit_lock:
+                text = self._buffer.strip() or "(no response)"
+                formatted = self.channel.format_response(text)
+                placeholder_id = self._placeholder_id
                 try:
-                    text = self._truncate(self._buffer).strip() or "(no response)"
-                    await self.channel.edit_message(
-                        self.target, self._placeholder_id, text,
-                    )
+                    await self.channel.send(OutboundMessage(
+                        target=self.target,
+                        text=formatted,
+                        session_id=self.session_id,
+                    ))
                 except Exception:
-                    pass
+                    # Send failed → fallback to final edit (keep placeholder)
+                    try:
+                        await self.channel.edit_message(
+                            self.target, placeholder_id, self._truncate(text),
+                        )
+                    except Exception:
+                        pass
+                    return
+                # Sent OK → delete placeholder
+                try:
+                    await self.channel.delete_message(self.target, placeholder_id)
+                except Exception:
+                    pass  # Duplicate is better than lost response
         elif not self._supports_streaming:
             # Non-streaming channel: send the accumulated response as one message
             if self._buffer.strip():
@@ -162,10 +182,23 @@ class StreamAdapter:
         error_text = f"Error: {error}"
         if self._supports_streaming and self._supports_edit and self._placeholder_id:
             async with self._edit_lock:
+                placeholder_id = self._placeholder_id
                 try:
-                    await self.channel.edit_message(
-                        self.target, self._placeholder_id, error_text,
-                    )
+                    await self.channel.send(OutboundMessage(
+                        target=self.target,
+                        text=error_text,
+                        session_id=self.session_id,
+                    ))
+                except Exception:
+                    try:
+                        await self.channel.edit_message(
+                            self.target, placeholder_id, error_text,
+                        )
+                    except Exception:
+                        pass
+                    return
+                try:
+                    await self.channel.delete_message(self.target, placeholder_id)
                 except Exception:
                     pass
         else:
@@ -190,8 +223,16 @@ class StreamAdapter:
     #  Helpers                                                             #
     # ------------------------------------------------------------------ #
 
-    def _truncate(self, text: str) -> str:
-        """Truncate text to max message length if constrained."""
-        if self._max_len and len(text) > self._max_len:
-            return text[:self._max_len]
+    def _truncate(self, text: str, reserve: int = 0) -> str:
+        """Truncate text to max message length if constrained.
+
+        Args:
+            reserve: Characters to reserve at the end (e.g. for streaming indicator).
+        """
+        limit = self._max_len
+        if not limit:
+            return text
+        effective = limit - reserve
+        if len(text) > effective:
+            return text[:effective]
         return text

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -14,6 +14,7 @@ import html as _html
 import logging
 import re
 import socket
+import subprocess
 import time
 from typing import Any, TYPE_CHECKING
 
@@ -230,6 +231,7 @@ class TelegramChannel(BaseChannel):
         app.add_handler(CommandHandler("sessions", self._handle_sessions))
         app.add_handler(CommandHandler("new", self._handle_new_session))
         app.add_handler(CommandHandler("stop", self._handle_stop))
+        app.add_handler(CommandHandler("restart", self._handle_restart))
         app.add_handler(CommandHandler("reply", self._handle_reply))
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
         app.add_handler(MessageHandler(
@@ -663,6 +665,20 @@ class TelegramChannel(BaseChannel):
             )
         else:
             await update.message.reply_text("Nothing running to stop.")
+
+    async def _handle_restart(self, update: Update, context: Any) -> None:
+        """Handle /restart — run ``nerve restart`` to restart the daemon."""
+        self._touch()
+        if not self._is_authorized(update.effective_user.id):
+            return
+        await update.message.reply_text("Restarting Nerve...")
+        logger.info("Restart requested by Telegram user %d", update.effective_user.id)
+        subprocess.Popen(
+            ["nerve", "restart"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
 
     # ------------------------------------------------------------------ #
     #  Message handler — construct InboundMessage and delegate             #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -15,6 +15,7 @@ import logging
 import re
 import socket
 import subprocess
+import sys
 import time
 from typing import Any, TYPE_CHECKING
 
@@ -674,7 +675,7 @@ class TelegramChannel(BaseChannel):
         await update.message.reply_text("Restarting Nerve...")
         logger.info("Restart requested by Telegram user %d", update.effective_user.id)
         subprocess.Popen(
-            ["nerve", "restart"],
+            [sys.executable, "-m", "nerve", "restart"],
             start_new_session=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -236,7 +236,7 @@ class TelegramChannel(BaseChannel):
         app.add_handler(CommandHandler("reply", self._handle_reply))
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
         app.add_handler(MessageHandler(
-            (filters.TEXT | filters.PHOTO) & ~filters.COMMAND,
+            filters.TEXT | filters.PHOTO | filters.COMMAND,
             self._handle_message,
         ))
         app.add_handler(MessageReactionHandler(self._handle_reaction))

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -233,6 +233,7 @@ class TelegramChannel(BaseChannel):
         app.add_handler(CommandHandler("new", self._handle_new_session))
         app.add_handler(CommandHandler("stop", self._handle_stop))
         app.add_handler(CommandHandler("restart", self._handle_restart))
+        app.add_handler(CommandHandler("doctor", self._handle_doctor))
         app.add_handler(CommandHandler("reply", self._handle_reply))
         app.add_handler(CallbackQueryHandler(self._handle_callback_query))
         app.add_handler(MessageHandler(
@@ -473,7 +474,7 @@ class TelegramChannel(BaseChannel):
         if self._app is None:
             return None
         chat_id = int(target)
-        msg = await self._app.bot.send_message(chat_id=chat_id, text="...")
+        msg = await self._app.bot.send_message(chat_id=chat_id, text="⏳")
         return str(msg.message_id)
 
     async def edit_message(self, target: str, message_id: str, text: str) -> None:
@@ -505,6 +506,17 @@ class TelegramChannel(BaseChannel):
                 pass
         # Update cache with the latest text (streaming overwrites placeholder)
         self._cache_message(int(message_id), int(target), text)
+
+    async def delete_message(self, target: str, message_id: str) -> None:
+        """Delete a previously sent message."""
+        if self._app is None:
+            return
+        try:
+            await self._app.bot.delete_message(
+                chat_id=int(target), message_id=int(message_id),
+            )
+        except Exception as exc:
+            logger.warning("delete_message failed: %s", exc)
 
     async def send_typing(self, target: str) -> None:
         """Show typing indicator."""
@@ -679,6 +691,18 @@ class TelegramChannel(BaseChannel):
             start_new_session=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+        )
+
+    async def _handle_doctor(self, update: Update, context: Any) -> None:
+        """Handle /doctor — run health checks and return the report."""
+        self._touch()
+        if not self._is_authorized(update.effective_user.id):
+            return
+        from nerve.cli import doctor_report
+        report = doctor_report(self.config)
+        await update.message.reply_text(
+            f"```\n{report}\n```",
+            parse_mode=ParseMode.MARKDOWN,
         )
 
     # ------------------------------------------------------------------ #

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -30,6 +30,7 @@ from nerve.config import load_config, set_config
 # Default PID file location
 PID_DIR = Path("~/.nerve").expanduser()
 PID_FILE = PID_DIR / "nerve.pid"
+CONFIG_DIR_FILE = PID_DIR / "config_dir"
 LOG_FILE = PID_DIR / "nerve.log"
 
 
@@ -68,9 +69,19 @@ def _is_running(pid: int) -> bool:
         return True  # Process exists but we can't signal it
 
 
-def _write_pid(pid: int) -> None:
+def _write_pid(pid: int, config_dir: Path | None = None) -> None:
     PID_DIR.mkdir(parents=True, exist_ok=True)
     PID_FILE.write_text(str(pid))
+    if config_dir is not None:
+        CONFIG_DIR_FILE.write_text(str(config_dir.resolve()))
+
+
+def _read_config_dir() -> Path | None:
+    """Read stored config directory. Returns None if not available."""
+    try:
+        return Path(CONFIG_DIR_FILE.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
 
 
 def _remove_pid() -> None:
@@ -240,7 +251,7 @@ def start(ctx: click.Context, foreground: bool) -> None:
 
     if foreground:
         # Run directly in this process
-        _write_pid(os.getpid())
+        _write_pid(os.getpid(), config_dir=config_dir)
         try:
             from nerve.gateway.server import run_server
             click.echo(f"Starting Nerve on {config.gateway.host}:{config.gateway.port}")
@@ -339,6 +350,12 @@ def restart(ctx: click.Context) -> None:
     """
     config = ctx.obj["config"]
     config_dir = Path(ctx.obj["config_dir"])
+
+    # Prefer the config dir stored by the running daemon — it's an absolute
+    # path that doesn't depend on the caller's CWD.
+    stored = _read_config_dir()
+    if stored is not None and stored.is_dir():
+        config_dir = stored
 
     # Docker mode: proxy to docker compose
     if _is_docker_mode(config):

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -511,42 +511,42 @@ def logs(ctx: click.Context) -> None:
             click.echo(line)
 
 
-@main.command()
-@click.pass_context
-def doctor(ctx: click.Context) -> None:
-    """Check config, DB, API keys, and connectivity."""
-    config = ctx.obj["config"]
-    errors = []
-    warnings = []
+def doctor_report(config) -> str:
+    """Run doctor checks and return the report as a plain-text string.
 
-    click.echo("Nerve Doctor")
-    click.echo("=" * 40)
+    Used by both the CLI ``nerve doctor`` command and the Telegram ``/doctor``
+    command so they share the same diagnostics.
+    """
+    lines: list[str] = []
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    lines.append("Nerve Doctor")
+    lines.append("=" * 40)
 
     # Daemon status
     running, pid = _get_daemon_status()
     if running:
-        click.echo(f"[OK] Daemon running (PID {pid})")
+        lines.append(f"[OK] Daemon running (PID {pid})")
     else:
-        click.echo("[--] Daemon not running")
+        lines.append("[--] Daemon not running")
 
     # Check workspace
     if config.workspace.exists():
-        click.echo(f"[OK] Workspace: {config.workspace}")
-        # Check workspace files against mode's manifest
+        lines.append(f"[OK] Workspace: {config.workspace}")
         mode = getattr(config, "mode", "personal")
         try:
             from nerve.workspace import get_expected_files
             expected = get_expected_files(mode)
             for f in expected:
                 if (config.workspace / f).exists():
-                    click.echo(f"  [OK] {f}")
+                    lines.append(f"  [OK] {f}")
                 else:
                     warnings.append(f"  [WARN] {f} not found (expected for {mode} mode)")
         except (FileNotFoundError, ValueError):
-            # Fallback if templates aren't available
             for f in ["SOUL.md", "IDENTITY.md", "MEMORY.md"]:
                 if (config.workspace / f).exists():
-                    click.echo(f"  [OK] {f}")
+                    lines.append(f"  [OK] {f}")
                 else:
                     warnings.append(f"  [WARN] {f} not found")
     else:
@@ -556,10 +556,10 @@ def doctor(ctx: click.Context) -> None:
     if config.proxy.enabled:
         binary = config.proxy.binary_path.expanduser()
         if binary.exists():
-            click.echo(f"[OK] CLIProxyAPI binary: {binary}")
+            lines.append(f"[OK] CLIProxyAPI binary: {binary}")
         else:
             warnings.append(f"[WARN] CLIProxyAPI binary not found (will download on start): {binary}")
-        click.echo(f"[OK] Proxy configured: {config.proxy.host}:{config.proxy.port}")
+        lines.append(f"[OK] Proxy configured: {config.proxy.host}:{config.proxy.port}")
         try:
             import httpx
             resp = httpx.get(
@@ -568,7 +568,7 @@ def doctor(ctx: click.Context) -> None:
                 timeout=3,
             )
             if resp.status_code == 200:
-                click.echo("[OK] Proxy is running and healthy")
+                lines.append("[OK] Proxy is running and healthy")
             else:
                 warnings.append(f"[WARN] Proxy returned status {resp.status_code}")
         except Exception:
@@ -577,58 +577,58 @@ def doctor(ctx: click.Context) -> None:
     # Check API keys
     if config.proxy.enabled:
         if config.anthropic_api_key:
-            click.echo(f"[--] Anthropic API key set (proxy takes precedence)")
+            lines.append("[--] Anthropic API key set (proxy takes precedence)")
         else:
-            click.echo("[--] Anthropic API key not set (using proxy)")
+            lines.append("[--] Anthropic API key not set (using proxy)")
     elif config.anthropic_api_key:
-        click.echo(f"[OK] Anthropic API key: ...{config.anthropic_api_key[-4:]}")
+        lines.append(f"[OK] Anthropic API key: ...{config.anthropic_api_key[-4:]}")
     else:
         errors.append("[ERR] Anthropic API key not set and proxy not enabled (config.local.yaml)")
 
     if config.openai_api_key:
-        click.echo(f"[OK] OpenAI API key: ...{config.openai_api_key[-4:]}")
+        lines.append(f"[OK] OpenAI API key: ...{config.openai_api_key[-4:]}")
     else:
         warnings.append("[WARN] OpenAI API key not set (needed for memU embeddings)")
 
     # Check Telegram
     if config.telegram.enabled:
         if config.telegram.bot_token:
-            click.echo(f"[OK] Telegram bot token: ...{config.telegram.bot_token[-4:]}")
+            lines.append(f"[OK] Telegram bot token: ...{config.telegram.bot_token[-4:]}")
         else:
             errors.append("[ERR] Telegram enabled but bot_token not set")
     else:
-        click.echo("[--] Telegram disabled")
+        lines.append("[--] Telegram disabled")
 
     # Check SSL
     if config.gateway.ssl.enabled:
         if config.gateway.ssl.cert and config.gateway.ssl.cert.exists():
-            click.echo(f"[OK] SSL cert: {config.gateway.ssl.cert}")
+            lines.append(f"[OK] SSL cert: {config.gateway.ssl.cert}")
         else:
             warnings.append("[WARN] SSL cert not found")
         if config.gateway.ssl.key and config.gateway.ssl.key.exists():
-            click.echo(f"[OK] SSL key: {config.gateway.ssl.key}")
+            lines.append(f"[OK] SSL key: {config.gateway.ssl.key}")
         else:
             warnings.append("[WARN] SSL key not found")
     else:
-        click.echo("[--] SSL not configured")
+        lines.append("[--] SSL not configured")
 
     # Check auth
     if config.auth.password_hash:
-        click.echo("[OK] Auth password hash configured")
+        lines.append("[OK] Auth password hash configured")
     else:
         warnings.append("[WARN] Auth password not set — running in dev mode (no auth)")
 
     if config.auth.jwt_secret:
-        click.echo("[OK] JWT secret configured")
+        lines.append("[OK] JWT secret configured")
     else:
         warnings.append("[WARN] JWT secret not set — running in dev mode")
 
     # Check DB
     db_path = Path("~/.nerve/nerve.db").expanduser()
     if db_path.exists():
-        click.echo(f"[OK] Database: {db_path} ({db_path.stat().st_size / 1024:.1f} KB)")
+        lines.append(f"[OK] Database: {db_path} ({db_path.stat().st_size / 1024:.1f} KB)")
     else:
-        click.echo(f"[--] Database will be created at: {db_path}")
+        lines.append(f"[--] Database will be created at: {db_path}")
 
     # Check cron files
     if config.cron.system_file.exists():
@@ -636,45 +636,55 @@ def doctor(ctx: click.Context) -> None:
             from nerve.cron.jobs import load_jobs
             system_jobs = load_jobs(config.cron.system_file)
             enabled = sum(1 for j in system_jobs if j.enabled)
-            click.echo(f"[OK] System crons: {config.cron.system_file} ({enabled}/{len(system_jobs)} enabled)")
+            lines.append(f"[OK] System crons: {config.cron.system_file} ({enabled}/{len(system_jobs)} enabled)")
         except Exception:
-            click.echo(f"[OK] System crons: {config.cron.system_file}")
+            lines.append(f"[OK] System crons: {config.cron.system_file}")
     else:
-        click.echo(f"[--] No system crons at: {config.cron.system_file}")
+        lines.append(f"[--] No system crons at: {config.cron.system_file}")
 
     if config.cron.jobs_file.exists():
         try:
             from nerve.cron.jobs import load_jobs as _load_jobs
             user_jobs = _load_jobs(config.cron.jobs_file)
             if user_jobs:
-                click.echo(f"[OK] User crons: {config.cron.jobs_file} ({len(user_jobs)} jobs)")
+                lines.append(f"[OK] User crons: {config.cron.jobs_file} ({len(user_jobs)} jobs)")
             else:
-                click.echo(f"[OK] User crons: {config.cron.jobs_file} (empty)")
+                lines.append(f"[OK] User crons: {config.cron.jobs_file} (empty)")
         except Exception:
-            click.echo(f"[OK] User crons: {config.cron.jobs_file}")
+            lines.append(f"[OK] User crons: {config.cron.jobs_file}")
     else:
-        click.echo(f"[--] No user crons at: {config.cron.jobs_file}")
+        lines.append(f"[--] No user crons at: {config.cron.jobs_file}")
 
     # Check external tools
     import shutil
     for tool_name in ["gog", "gh"]:
         if shutil.which(tool_name):
-            click.echo(f"[OK] {tool_name} CLI found")
+            lines.append(f"[OK] {tool_name} CLI found")
         else:
             warnings.append(f"[WARN] {tool_name} CLI not found (needed for sync)")
 
     # Summary
-    click.echo()
-    for w in warnings:
-        click.echo(w)
-    for e in errors:
-        click.echo(e)
+    lines.append("")
+    lines.extend(warnings)
+    lines.extend(errors)
 
     if errors:
-        click.echo(f"\n{len(errors)} error(s), {len(warnings)} warning(s)")
-        ctx.exit(1)
+        lines.append(f"\n{len(errors)} error(s), {len(warnings)} warning(s)")
     else:
-        click.echo(f"\nAll good! {len(warnings)} warning(s)")
+        lines.append(f"\nAll good! {len(warnings)} warning(s)")
+
+    return "\n".join(lines)
+
+
+@main.command()
+@click.pass_context
+def doctor(ctx: click.Context) -> None:
+    """Check config, DB, API keys, and connectivity."""
+    config = ctx.obj["config"]
+    report = doctor_report(config)
+    click.echo(report)
+    if "[ERR]" in report:
+        ctx.exit(1)
 
 
 @main.command()

--- a/nerve/cron/jobs.py
+++ b/nerve/cron/jobs.py
@@ -25,6 +25,7 @@ class CronJob:
     model: str = ""  # Override model; empty = use config default
     session_mode: str = "isolated"  # "isolated" (new session per run) or "persistent" (reuse context)
     context_rotate_hours: int = 24  # Hours before persistent context is rotated (0 = never)
+    context_rotate_at: str = ""  # Time of day to rotate (e.g. "04:00"); overrides hours-based rotation
     reminder_mode: bool = False  # Persistent only: send short reminder instead of full prompt on subsequent runs
     catchup: bool = True  # Fire once on startup if missed while server was down
     enabled: bool = True
@@ -42,6 +43,7 @@ class CronJob:
             model=d.get("model", ""),
             session_mode=d.get("session_mode", "isolated"),
             context_rotate_hours=int(d.get("context_rotate_hours", 24)),
+            context_rotate_at=d.get("context_rotate_at", ""),
             reminder_mode=bool(d.get("reminder_mode", False)),
             catchup=d.get("catchup", True),
             enabled=d.get("enabled", True),
@@ -92,6 +94,7 @@ def save_jobs(jobs: list[CronJob], jobs_file: Path) -> None:
             "model": job.model,
             "session_mode": job.session_mode,
             "context_rotate_hours": job.context_rotate_hours,
+            "context_rotate_at": job.context_rotate_at,
             "reminder_mode": job.reminder_mode,
             "catchup": job.catchup,
             "enabled": job.enabled,

--- a/nerve/cron/jobs.py
+++ b/nerve/cron/jobs.py
@@ -28,6 +28,8 @@ class CronJob:
     reminder_mode: bool = False  # Persistent only: send short reminder instead of full prompt on subsequent runs
     catchup: bool = True  # Fire once on startup if missed while server was down
     enabled: bool = True
+    skip_when_idle: list[str] = field(default_factory=list)  # Source names to check; skip run if no new messages
+    idle_consumer: str = "inbox"  # Consumer cursor name for the idle check
     metadata: dict = field(default_factory=dict)
 
     @classmethod
@@ -43,6 +45,8 @@ class CronJob:
             reminder_mode=bool(d.get("reminder_mode", False)),
             catchup=d.get("catchup", True),
             enabled=d.get("enabled", True),
+            skip_when_idle=d.get("skip_when_idle", []),
+            idle_consumer=d.get("idle_consumer", "inbox"),
             metadata=d.get("metadata", {}),
         )
 
@@ -91,6 +95,8 @@ def save_jobs(jobs: list[CronJob], jobs_file: Path) -> None:
             "reminder_mode": job.reminder_mode,
             "catchup": job.catchup,
             "enabled": job.enabled,
+            "skip_when_idle": job.skip_when_idle,
+            "idle_consumer": job.idle_consumer,
             "metadata": job.metadata,
         })
 

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -210,11 +210,15 @@ class CronService:
 
     async def _maybe_rotate_context(
         self, session_id: str, rotate_hours: int,
+        rotate_at: str = "",
     ) -> bool:
         """Check if a persistent cron session's context should be rotated.
 
         Rotation clears the sdk_session_id so the next run starts a fresh
         SDK client.  Old messages remain in the DB for memU search.
+
+        If rotate_at is set (e.g. "04:00"), rotation happens once per day
+        at that local time instead of using the hours-based approach.
 
         Returns True if rotation was performed.
         """
@@ -236,11 +240,35 @@ class CronService:
             )
             return False
 
-        age_hours = (
-            datetime.now(timezone.utc) - connected_at
-        ).total_seconds() / 3600
+        now = datetime.now(timezone.utc)
+        should_rotate = False
+        reason = ""
 
-        if age_hours < rotate_hours:
+        if rotate_at:
+            # Time-of-day rotation: rotate if session started before today's
+            # rotate_at and current time is past it.
+            try:
+                hour, minute = (int(x) for x in rotate_at.split(":"))
+            except (ValueError, TypeError):
+                logger.warning("Invalid context_rotate_at: %s", rotate_at)
+                return False
+
+            local_tz = datetime.now().astimezone().tzinfo
+            today_rotate = datetime.now(local_tz).replace(
+                hour=hour, minute=minute, second=0, microsecond=0,
+            )
+            today_rotate_utc = today_rotate.astimezone(timezone.utc)
+
+            if now >= today_rotate_utc and connected_at < today_rotate_utc:
+                should_rotate = True
+                reason = f"rotate_at={rotate_at}"
+        elif rotate_hours > 0:
+            age_hours = (now - connected_at).total_seconds() / 3600
+            if age_hours >= rotate_hours:
+                should_rotate = True
+                reason = f"age {age_hours:.1f}h >= {rotate_hours}h"
+
+        if not should_rotate:
             return False
 
         # Memorize current context before rotation (safety net)
@@ -252,8 +280,8 @@ class CronService:
         # Clear sdk_session_id + connected_at → next run starts fresh
         await self.engine.sessions.mark_idle(session_id, preserve_sdk_id=False)
         logger.info(
-            "Rotated context for persistent cron %s (age: %.1fh >= %dh)",
-            session_id, age_hours, rotate_hours,
+            "Rotated context for persistent cron %s (%s)",
+            session_id, reason,
         )
         return True
 
@@ -340,9 +368,10 @@ class CronService:
 
             if job.session_mode == "persistent":
                 # Persistent mode: reuse SDK context across runs
-                if job.context_rotate_hours > 0:
+                if job.context_rotate_at or job.context_rotate_hours > 0:
                     rotated = await self._maybe_rotate_context(
                         f"cron:{job.id}", job.context_rotate_hours,
+                        rotate_at=job.context_rotate_at,
                     )
 
                 # Determine prompt: full on first run, short reminder on subsequent

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -302,8 +302,35 @@ class CronService:
 
         return list(jobs_by_id.values())
 
+    async def _has_pending_messages(
+        self, consumer: str, sources: list[str],
+    ) -> bool:
+        """Check if any of the listed sources have unread messages.
+
+        Uses existing consumer cursor position vs source max rowid.
+        Does not advance any cursors.
+        """
+        for source in sources:
+            cursor_seq = await self.db.get_consumer_cursor(consumer, source)
+            max_seq = await self.db.get_source_max_rowid(source)
+            if max_seq > cursor_seq:
+                return True
+        return False
+
     async def _run_job_wrapper(self, job: CronJob) -> None:
         """Wrapper to run a cron job with logging."""
+        # Pre-check: skip if no new messages in monitored sources
+        if job.skip_when_idle:
+            has_pending = await self._has_pending_messages(
+                job.idle_consumer, job.skip_when_idle,
+            )
+            if not has_pending:
+                logger.info(
+                    "Skipping cron job %s: no new messages in %s",
+                    job.id, job.skip_when_idle,
+                )
+                return
+
         log_id = await self.db.log_cron_start(job.id)
         logger.info("Running cron job: %s (mode=%s)", job.id, job.session_mode)
 

--- a/nerve/db/migrations/v017_session_starred.py
+++ b/nerve/db/migrations/v017_session_starred.py
@@ -1,0 +1,16 @@
+"""V17: Add starred column to sessions table."""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        "ALTER TABLE sessions ADD COLUMN starred BOOLEAN NOT NULL DEFAULT 0"
+    )
+    logger.info("V17 migration: added sessions.starred column")

--- a/nerve/db/notifications.py
+++ b/nerve/db/notifications.py
@@ -47,6 +47,7 @@ class NotificationStore:
     async def list_notifications(
         self, status: str | None = None, type: str | None = None,
         session_id: str | None = None, limit: int = 50,
+        channel: str | None = None,
     ) -> list[dict]:
         conditions = []
         params: list = []
@@ -59,6 +60,11 @@ class NotificationStore:
         if session_id:
             conditions.append("n.session_id = ?")
             params.append(session_id)
+        if channel:
+            # Filter: only show notifications delivered to this channel
+            # channels_delivered is JSON like '["telegram"]' or '["web","telegram"]'
+            conditions.append("(n.channels_delivered IS NULL OR n.channels_delivered LIKE ?)")
+            params.append(f'%"{channel}"%')
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)
         async with self.db.execute(
@@ -122,10 +128,13 @@ class NotificationStore:
         await self.db.commit()
         return cursor.rowcount
 
-    async def count_pending_notifications(self) -> int:
-        async with self.db.execute(
-            "SELECT COUNT(*) FROM notifications WHERE status = 'pending'"
-        ) as cursor:
+    async def count_pending_notifications(self, channel: str | None = None) -> int:
+        sql = "SELECT COUNT(*) FROM notifications WHERE status = 'pending'"
+        params: tuple = ()
+        if channel:
+            sql += ' AND (channels_delivered IS NULL OR channels_delivered LIKE ?)'
+            params = (f'%"{channel}"%',)
+        async with self.db.execute(sql, params) as cursor:
             row = await cursor.fetchone()
             return row[0] if row else 0
 

--- a/nerve/db/sessions.py
+++ b/nerve/db/sessions.py
@@ -110,6 +110,7 @@ class SessionStore:
             "status", "sdk_session_id", "connected_at", "last_activity_at",
             "archived_at", "title", "message_count", "total_cost_usd",
             "parent_session_id", "forked_from_message", "last_memorized_at",
+            "starred",
         }
         set_clauses: list[str] = []
         params: list = []

--- a/nerve/gateway/routes.py
+++ b/nerve/gateway/routes.py
@@ -207,6 +207,24 @@ async def delete_session(session_id: str, user: dict = Depends(require_auth)):
     return {"deleted": True}
 
 
+@router.patch("/api/sessions/{session_id}")
+async def update_session(session_id: str, req: dict, user: dict = Depends(require_auth)):
+    """Update session fields (title, starred)."""
+    session = await _db.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    fields: dict = {}
+    if "title" in req:
+        fields["title"] = req["title"]
+    if "starred" in req:
+        fields["starred"] = 1 if req["starred"] else 0
+    if not fields:
+        raise HTTPException(status_code=400, detail="No valid fields to update")
+    await _db.update_session_fields(session_id, fields)
+    updated = await _db.get_session(session_id)
+    return updated
+
+
 @router.get("/api/sessions/{session_id}/status")
 async def session_status(session_id: str, user: dict = Depends(require_auth)):
     """Enhanced session status with lifecycle info."""
@@ -1463,8 +1481,9 @@ async def list_notifications(
         type=type or None,
         session_id=session_id or None,
         limit=min(limit, 200),
+        channel="web",
     )
-    pending_count = await _db.count_pending_notifications()
+    pending_count = await _db.count_pending_notifications(channel="web")
     return {"notifications": notifications, "pending_count": pending_count}
 
 

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -189,6 +189,16 @@ async def lifespan(app: FastAPI):
 
     logger.info("Nerve started on %s:%d", config.gateway.host, config.gateway.port)
 
+    # Send startup notification to the user
+    try:
+        await notification_service.send_notification(
+            session_id="system",
+            title=f"Nerve started (pid {os.getpid()})",
+            priority="low",
+        )
+    except Exception as e:
+        logger.error("Failed to send startup notification: %s", e)
+
     yield
 
     # Shutdown: stop telegram FIRST, before cancelling background tasks.

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -189,12 +189,14 @@ async def lifespan(app: FastAPI):
 
     logger.info("Nerve started on %s:%d", config.gateway.host, config.gateway.port)
 
-    # Send startup notification to the user
+    # Send startup notification to the user (Telegram only, silent)
     try:
         await notification_service.send_notification(
             session_id="system",
             title=f"Nerve started (pid {os.getpid()})",
             priority="low",
+            channels=["telegram"],
+            silent=True,
         )
     except Exception as e:
         logger.error("Failed to send startup notification: %s", e)

--- a/nerve/notifications/service.py
+++ b/nerve/notifications/service.py
@@ -40,8 +40,15 @@ class NotificationService:
         title: str,
         body: str = "",
         priority: str = "normal",
+        channels: list[str] | None = None,
+        silent: bool = False,
     ) -> str:
-        """Fire-and-forget notification. Returns notification_id."""
+        """Fire-and-forget notification. Returns notification_id.
+
+        Args:
+            channels: Override default notification channels (e.g. ["telegram"]).
+            silent: If True, deliver without sound (Telegram disable_notification).
+        """
         notification_id = f"notif-{uuid.uuid4().hex[:8]}"
 
         await self.db.create_notification(
@@ -55,6 +62,7 @@ class NotificationService:
 
         await self._fanout(
             notification_id, session_id, "notify", title, body, priority,
+            channels=channels, silent=silent,
         )
 
         return notification_id
@@ -208,9 +216,11 @@ class NotificationService:
         body: str,
         priority: str,
         options: list[str] | None = None,
+        channels: list[str] | None = None,
+        silent: bool = False,
     ) -> None:
         """Deliver notification to all configured channels in parallel."""
-        target_channels = self.config.notifications.channels
+        target_channels = channels or self.config.notifications.channels
 
         async def _deliver(channel_name: str) -> str | None:
             """Deliver to a single channel, return name on success."""
@@ -225,6 +235,7 @@ class NotificationService:
                     msg_id = await self._deliver_telegram(
                         notification_id, session_id, notif_type,
                         title, body, priority, options,
+                        silent=silent,
                     )
                     if msg_id:
                         await self.db.update_notification(
@@ -301,6 +312,7 @@ class NotificationService:
         body: str,
         priority: str,
         options: list[str] | None,
+        silent: bool = False,
     ) -> str | None:
         """Send notification to Telegram, with inline keyboard for questions."""
         bot = self._get_telegram_bot()
@@ -321,10 +333,13 @@ class NotificationService:
 
         if notif_type == "question" and options:
             return await self._send_telegram_inline(
-                chat_id, notification_id, text, options,
+                chat_id, notification_id, text, options, silent=silent,
             )
         else:
-            msg = await bot.send_message(chat_id=chat_id, text=text)
+            msg = await bot.send_message(
+                chat_id=chat_id, text=text,
+                disable_notification=silent,
+            )
             return str(msg.message_id)
 
     async def _send_telegram_inline(
@@ -333,6 +348,7 @@ class NotificationService:
         notification_id: str,
         text: str,
         options: list[str],
+        silent: bool = False,
     ) -> str | None:
         """Send Telegram message with inline keyboard buttons."""
         bot = self._get_telegram_bot()
@@ -357,6 +373,7 @@ class NotificationService:
             chat_id=chat_id,
             text=text,
             reply_markup=keyboard,
+            disable_notification=silent,
         )
 
         await self.db.update_notification(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -63,6 +63,8 @@ export const api = {
     }),
   deleteSession: (id: string) =>
     request<any>(`/sessions/${id}`, { method: 'DELETE' }),
+  updateSession: (id: string, data: { title?: string; starred?: boolean }) =>
+    request<any>(`/sessions/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   getMessages: (sessionId: string, limit = 100) =>
     request<{ messages: any[]; last_usage?: { input_tokens: number; output_tokens: number; cache_creation_input_tokens: number; cache_read_input_tokens: number; max_context_tokens: number } }>(`/sessions/${sessionId}/messages?limit=${limit}`),
   forkSession: (sourceSessionId: string, atMessageId?: string, title?: string) =>

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -90,16 +90,18 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
 
   const activeIsRunning = agentStatus.state !== 'idle';
 
-  // Split running conversations to pin them at the top
-  const { pinnedRunning, restConversations } = useMemo(() => {
-    const pinned: Session[] = [];
+  // Split running and starred conversations to pin them at the top
+  const { pinnedRunning, pinnedStarred, restConversations } = useMemo(() => {
+    const running: Session[] = [];
+    const starred: Session[] = [];
     const rest: Session[] = [];
     for (const s of conversations) {
-      const running = s.id === activeSession ? activeIsRunning : !!s.is_running;
-      if (running) pinned.push(s);
+      const isRunning = s.id === activeSession ? activeIsRunning : !!s.is_running;
+      if (isRunning) running.push(s);
+      else if (s.starred) starred.push(s);
       else rest.push(s);
     }
-    return { pinnedRunning: pinned, restConversations: rest };
+    return { pinnedRunning: running, pinnedStarred: starred, restConversations: rest };
   }, [conversations, activeSession, activeIsRunning]);
 
   const groupedConversations = useMemo(() => groupByDate(restConversations), [restConversations]);
@@ -213,8 +215,29 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
               </div>
             )}
 
+            {/* Pinned starred sessions */}
+            {pinnedStarred.length > 0 && (
+              <div>
+                <div className="px-3 pt-2 pb-0.5">
+                  <span className="text-[10px] text-yellow-600/70 font-medium">Starred</span>
+                </div>
+                {pinnedStarred.map((s) => (
+                  <SessionItem
+                    key={s.id}
+                    session={s}
+                    isActive={s.id === activeSession}
+                    isRunning={false}
+                    onSelect={onSelect}
+                    onDelete={onDelete}
+                    onRename={renameSession}
+                    onToggleStar={toggleStar}
+                  />
+                ))}
+              </div>
+            )}
+
             {/* Normal date-grouped view */}
-            {groupedConversations.length === 0 && pinnedRunning.length === 0 && (
+            {groupedConversations.length === 0 && pinnedRunning.length === 0 && pinnedStarred.length === 0 && (
               <div className="px-3 py-2 text-[11px] text-[#444]">No conversations yet</div>
             )}
 

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef, useEffect, useCallback, useLayoutEffect } from 'react';
-import { Plus, X, MessageSquare, ChevronRight, ChevronDown, Bot, Loader2, Search, Hammer } from 'lucide-react';
+import { Plus, X, MessageSquare, ChevronRight, ChevronDown, Bot, Loader2, Search, Hammer, MoreHorizontal, Star, Pencil, Trash2 } from 'lucide-react';
 import type { Session, AgentStatus } from '../../types/chat';
 import { groupByDate } from '../../utils/dateGroups';
 import { useChatStore } from '../../stores/chatStore';
@@ -45,7 +45,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { searchResults, searchLoading, searchSessions, clearSearch } = useChatStore();
+  const { searchResults, searchLoading, searchSessions, clearSearch, renameSession, toggleStar } = useChatStore();
 
   const isSearching = localQuery.trim().length > 0;
 
@@ -181,6 +181,8 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
                       isRunning={s.id === activeSession ? activeIsRunning : !!s.is_running}
                       onSelect={onSelect}
                       onDelete={onDelete}
+                      onRename={renameSession}
+                      onToggleStar={toggleStar}
                       showDate
                     />
                   ))
@@ -204,6 +206,8 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
                     isRunning
                     onSelect={onSelect}
                     onDelete={onDelete}
+                    onRename={renameSession}
+                    onToggleStar={toggleStar}
                   />
                 ))}
               </div>
@@ -227,6 +231,8 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
                     isRunning={s.id === activeSession ? activeIsRunning : !!s.is_running}
                     onSelect={onSelect}
                     onDelete={onDelete}
+                    onRename={renameSession}
+                    onToggleStar={toggleStar}
                   />
                 ))}
               </div>
@@ -325,14 +331,66 @@ function StatusIndicator({ session, isActive, isRunning }: {
 }
 
 
-function SessionItem({ session, isActive, isRunning, onSelect, onDelete, showDate }: {
+function SessionItem({ session, isActive, isRunning, onSelect, onDelete, onRename, onToggleStar, showDate }: {
   session: Session;
   isActive: boolean;
   isRunning: boolean;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
+  onRename: (id: string, title: string) => Promise<void>;
+  onToggleStar: (id: string) => Promise<void>;
   showDate?: boolean;
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState('');
+  const menuRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [menuOpen]);
+
+  // Focus input when renaming
+  useEffect(() => {
+    if (renaming) inputRef.current?.focus();
+  }, [renaming]);
+
+  const handleRenameSubmit = () => {
+    const trimmed = renameValue.trim();
+    if (trimmed && trimmed !== cleanTitle(session)) {
+      onRename(session.id, trimmed);
+    }
+    setRenaming(false);
+  };
+
+  if (renaming) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md bg-[#1a1a1a]">
+        <MessageSquare size={13} className="shrink-0 opacity-50" />
+        <input
+          ref={inputRef}
+          value={renameValue}
+          onChange={e => setRenameValue(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleRenameSubmit();
+            if (e.key === 'Escape') setRenaming(false);
+          }}
+          onBlur={handleRenameSubmit}
+          className="flex-1 min-w-0 bg-transparent text-[13px] text-[#e0e0e0] outline-none border-b border-[#444]"
+        />
+      </div>
+    );
+  }
+
   return (
     <div
       onClick={() => onSelect(session.id)}
@@ -344,7 +402,9 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, showDat
     >
       {isImplementSession(session)
         ? <Hammer size={13} className="shrink-0 text-violet-400/60" />
-        : <MessageSquare size={13} className="shrink-0 opacity-50" />
+        : session.starred
+          ? <Star size={13} className="shrink-0 text-yellow-500 fill-yellow-500" />
+          : <MessageSquare size={13} className="shrink-0 opacity-50" />
       }
       <div className="flex-1 min-w-0">
         <div className="truncate text-[13px]">{cleanTitle(session)}</div>
@@ -360,15 +420,55 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, showDat
         </span>
       )}
 
-      {/* Delete button on hover (hidden when running) */}
-      {!isRunning && (
+      {/* Context menu trigger */}
+      <div className="relative shrink-0" ref={menuRef}>
         <button
-          onClick={(e) => { e.stopPropagation(); onDelete(session.id); }}
-          className="shrink-0 p-0.5 text-[#333] opacity-0 group-hover:opacity-100 hover:text-red-400 cursor-pointer transition-opacity"
+          onClick={(e) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
+          className="p-0.5 text-[#333] opacity-0 group-hover:opacity-100 hover:text-[#888] cursor-pointer transition-opacity"
         >
-          <X size={12} />
+          <MoreHorizontal size={14} />
         </button>
-      )}
+
+        {menuOpen && (
+          <div className="absolute right-0 top-full mt-1 z-50 bg-[#1a1a1a] border border-[#333] rounded-lg shadow-xl py-1 min-w-[140px]">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleStar(session.id);
+                setMenuOpen(false);
+              }}
+              className="flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-[#ccc] hover:bg-[#222] cursor-pointer transition-colors"
+            >
+              <Star size={14} className={session.starred ? 'text-yellow-500 fill-yellow-500' : ''} />
+              {session.starred ? 'Unstar' : 'Star'}
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setRenameValue(cleanTitle(session));
+                setRenaming(true);
+                setMenuOpen(false);
+              }}
+              className="flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-[#ccc] hover:bg-[#222] cursor-pointer transition-colors"
+            >
+              <Pencil size={14} />
+              Rename
+            </button>
+            <div className="border-t border-[#2a2a2a] my-1" />
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpen(false);
+                onDelete(session.id);
+              }}
+              className="flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-red-400 hover:bg-[#222] cursor-pointer transition-colors"
+            >
+              <Trash2 size={14} />
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -163,6 +163,8 @@ interface ChatState {
   switchSession: (id: string) => Promise<void>;
   createSession: (title?: string) => Promise<void>;
   deleteSession: (id: string) => Promise<void>;
+  renameSession: (id: string, title: string) => Promise<void>;
+  toggleStar: (id: string) => Promise<void>;
   searchSessions: (query: string) => Promise<void>;
   clearSearch: () => void;
   sendMessage: (content: string) => void;
@@ -440,6 +442,35 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
     } catch (e) {
       console.error('Failed to delete session:', e);
+    }
+  },
+
+  renameSession: async (id: string, title: string) => {
+    try {
+      await api.updateSession(id, { title });
+      set(s => ({
+        sessions: s.sessions.map(sess =>
+          sess.id === id ? { ...sess, title } : sess
+        ),
+      }));
+    } catch (e) {
+      console.error('Failed to rename session:', e);
+    }
+  },
+
+  toggleStar: async (id: string) => {
+    const session = get().sessions.find(s => s.id === id);
+    if (!session) return;
+    const starred = !session.starred;
+    try {
+      await api.updateSession(id, { starred });
+      set(s => ({
+        sessions: s.sessions.map(sess =>
+          sess.id === id ? { ...sess, starred } : sess
+        ),
+      }));
+    } catch (e) {
+      console.error('Failed to toggle star:', e);
     }
   },
 

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -42,6 +42,7 @@ export interface Session {
   total_cost_usd?: number;
   // Real-time running status (set by backend + WS updates)
   is_running?: boolean;
+  starred?: boolean;
 }
 
 export type AgentStatus =


### PR DESCRIPTION
## Summary
- **Message batching**: Replace fragile "already running" retry with per-session locks + message queue — concurrent messages are batched into a single turn instead of failing
- **Session context menu**: Star, rename, delete sessions from web UI sidebar; starred sessions pinned at top
- **Streaming UX**: ⏳ indicator, send+delete for push notifications, improved error delivery
- **Telegram commands**: `/restart` daemon command, `/doctor` diagnostics, unregistered slash commands delivered to LLM
- **Cron**: `context_rotate_at` for time-of-day rotation, persistent config dir across restarts
- **Startup notification**: Silent Telegram ping when Nerve starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)