### PR TITLE
fix: replace remaining pufit references with clickhouse in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The installer handles everything — installs dependencies (Python, Node.js, uv)
 **Prerequisites:** [Git](https://git-scm.com/), [Python 3.13+](https://www.python.org/), [uv](https://docs.astral.sh/uv/), [Node.js 18+](https://nodejs.org/)
 
 ```bash
-git clone https://github.com/pufit/nerve.git && cd nerve
+git clone https://github.com/ClickHouse/nerve.git && cd nerve
 uv venv --python 3.13 && source .venv/bin/activate
 uv pip install -e .
 cd web && npm ci && npm run build && cd ..

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,7 @@
 The fastest way to get Nerve running:
 
 ```bash
-git clone https://github.com/pufit/nerve.git nerve
+git clone https://github.com/ClickHouse/nerve.git nerve
 cd nerve
 pip install -e .       # or: uv pip install -e .
 cd web && npm install && npm run build && cd ..
@@ -31,7 +31,7 @@ The `nerve init` wizard walks you through deployment, mode selection, API keys, 
 ### Option A: Server (bare metal)
 
 ```bash
-git clone https://github.com/pufit/nerve.git nerve
+git clone https://github.com/ClickHouse/nerve.git nerve
 cd nerve
 
 # Create virtual environment
@@ -51,7 +51,7 @@ nerve init
 ### Option B: Docker
 
 ```bash
-git clone https://github.com/pufit/nerve.git nerve
+git clone https://github.com/ClickHouse/nerve.git nerve
 cd nerve
 pip install -e .   # Needed to run the wizard on the host
 nerve init         # Choose "docker" at the deployment step

--- a/docs/worker-guide.md
+++ b/docs/worker-guide.md
@@ -6,7 +6,7 @@ Worker mode deploys Nerve as a task-focused autonomous agent. Give it a job desc
 
 ```bash
 # Clone and install
-git clone https://github.com/pufit/nerve.git nerve
+git clone https://github.com/ClickHouse/nerve.git nerve
 cd nerve
 uv venv && source .venv/bin/activate
 uv pip install -e .

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
 # Nerve Installer
-# https://github.com/pufit/nerve
+# https://github.com/ClickHouse/nerve
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/pufit/nerve/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/ClickHouse/nerve/main/install.sh | bash
 #
 # Environment variables:
 #   NERVE_INSTALL_DIR  — Where to clone the repo (default: ~/nerve)
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 # --- Configuration ---
-NERVE_REPO="https://github.com/pufit/nerve.git"
+NERVE_REPO="https://github.com/ClickHouse/nerve.git"
 NERVE_BRANCH="${NERVE_BRANCH:-main}"
 INSTALL_DIR="${NERVE_INSTALL_DIR:-$HOME/nerve}"
 MIN_PYTHON_MINOR=12
@@ -502,10 +502,10 @@ print_summary() {
 
 usage() {
     cat <<EOF
-Nerve Installer — https://github.com/pufit/nerve
+Nerve Installer — https://github.com/ClickHouse/nerve
 
 Usage:
-  curl -fsSL https://raw.githubusercontent.com/pufit/nerve/main/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/ClickHouse/nerve/main/install.sh | bash
   curl -fsSL .../install.sh | bash -s -- --yes
 
 Options:


### PR DESCRIPTION
## Summary
- Replaces all remaining `pufit` GitHub username references with `ClickHouse` in documentation URLs
- Affects `README.md`, `docs/setup.md`, `docs/worker-guide.md`, and `install.sh`
- Continuation of #8 / commit 2c538d9 which started this rename

## Test plan
- [x] Verify all URLs in docs point to `ClickHouse/nerve`