### PR TITLE
refactor(web): deduplicate tool block components

### DIFF
--- a/web/src/components/Chat/tools/BashToolBlock.tsx
+++ b/web/src/components/Chat/tools/BashToolBlock.tsx
@@ -1,53 +1,44 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, Terminal, Loader2 } from 'lucide-react';
+import { Terminal, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 export function BashToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
   const command = String(block.input.command || '');
   const truncatedCmd = command.length > 80 ? command.slice(0, 80) + '...' : command;
 
   return (
-    <div className="my-1.5 border border-[#2a2a2a] rounded-lg bg-[#0a0a0a] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#111] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
-          : <Terminal size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-emerald-400'}`} />
-        }
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Terminal}
+      iconClassName="text-emerald-400"
+      label=""
+      theme="default"
+      headerExtra={<>
         <span className="text-emerald-500 text-[13px] font-mono select-none">$</span>
         <span className="text-[13px] font-mono text-[#ccc] truncate">{truncatedCmd}</span>
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-[#1a1a1a]">
-          {/* Full command */}
-          {command.length > 80 && (
-            <div className="px-3 py-2 border-b border-[#1a1a1a]">
-              <pre className="text-[12px] font-mono text-[#ccc] whitespace-pre-wrap">{command}</pre>
-            </div>
-          )}
-
-          {/* Output */}
-          {block.result !== undefined && (
-            <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#888]'}`}>
-              {block.result}
-            </pre>
-          )}
-
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" /> Running...
-            </div>
-          )}
+      </>}
+    >
+      {/* Full command */}
+      {command.length > 80 && (
+        <div className="px-3 py-2 border-b border-[#1a1a1a]">
+          <pre className="text-[12px] font-mono text-[#ccc] whitespace-pre-wrap">{command}</pre>
         </div>
       )}
-    </div>
+
+      {/* Output */}
+      {block.result !== undefined && (
+        <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#888]'}`}>
+          {block.result}
+        </pre>
+      )}
+
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" /> Running...
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/CollapsibleToolBlock.tsx
+++ b/web/src/components/Chat/tools/CollapsibleToolBlock.tsx
@@ -1,0 +1,98 @@
+import { useState, type ReactNode } from 'react';
+import { ChevronRight, ChevronDown, Loader2 } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+interface CollapsibleToolBlockProps {
+  /** Whether the tool is currently running. */
+  isRunning: boolean;
+  /** Whether the tool resulted in an error. */
+  isError?: boolean;
+  /** Primary icon shown in collapsed state. */
+  icon: LucideIcon;
+  /** CSS class for the icon (color). Falls back to text-[#888]. */
+  iconClassName?: string;
+  /** Short label next to the icon (e.g. "List Tasks"). */
+  label: string;
+  /** CSS class for the label text. Falls back to text-[#ccc]. */
+  labelClassName?: string;
+  /** Extra elements rendered between label and chevron. */
+  headerExtra?: ReactNode;
+  /** Border + background theme. Defaults to neutral gray. */
+  theme?: 'default' | 'amber' | 'purple' | 'cyan';
+  /** Start expanded? Defaults to false. */
+  defaultExpanded?: boolean;
+  /** Content shown when expanded. */
+  children: ReactNode;
+}
+
+const THEMES = {
+  default: {
+    border: 'border-[#2a2a2a]',
+    bg: 'bg-[#141414]',
+    hover: 'hover:bg-[#1a1a1a]',
+    divider: 'border-[#2a2a2a]',
+    spinner: 'text-[#6366f1]',
+  },
+  amber: {
+    border: 'border-amber-500/20',
+    bg: 'bg-[#141411]',
+    hover: 'hover:bg-[#1a1a18]',
+    divider: 'border-amber-500/10',
+    spinner: 'text-amber-400',
+  },
+  purple: {
+    border: 'border-purple-500/20',
+    bg: 'bg-[#141418]',
+    hover: 'hover:bg-[#1a1a20]',
+    divider: 'border-purple-500/10',
+    spinner: 'text-purple-400',
+  },
+  cyan: {
+    border: 'border-cyan-500/20',
+    bg: 'bg-[#141416]',
+    hover: 'hover:bg-[#1a1a1e]',
+    divider: 'border-cyan-500/10',
+    spinner: 'text-cyan-400',
+  },
+} as const;
+
+export function CollapsibleToolBlock({
+  isRunning,
+  isError,
+  icon: Icon,
+  iconClassName = 'text-[#888]',
+  label,
+  labelClassName = 'text-[#ccc]',
+  headerExtra,
+  theme = 'default',
+  defaultExpanded = false,
+  children,
+}: CollapsibleToolBlockProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const t = THEMES[theme];
+
+  return (
+    <div className={`my-1.5 border ${t.border} rounded-lg ${t.bg} overflow-hidden`}>
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className={`flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer ${t.hover} transition-colors`}
+      >
+        {isRunning
+          ? <Loader2 size={14} className={`${t.spinner} animate-spin shrink-0`} />
+          : <Icon size={14} className={`shrink-0 ${isError ? 'text-red-400' : iconClassName}`} />
+        }
+        <span className={`text-[13px] font-medium ${labelClassName}`}>{label}</span>
+        {headerExtra}
+        <div className="ml-auto shrink-0">
+          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className={`border-t ${t.divider}`}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Chat/tools/EditToolBlock.tsx
+++ b/web/src/components/Chat/tools/EditToolBlock.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, FileEdit, Loader2 } from 'lucide-react';
+import { FileEdit, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
   const filePath = String(block.input.file_path || '');
   const oldString = String(block.input.old_string || '');
@@ -13,52 +12,43 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
   const newLines = newString.split('\n');
 
   return (
-    <div className="my-1.5 border border-[#2a2a2a] rounded-lg bg-[#141414] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a1a] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
-          : <FileEdit size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-amber-400'}`} />
-        }
-        <span className="text-[13px] font-mono font-medium text-[#ccc]">Edit</span>
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={FileEdit}
+      iconClassName="text-amber-400"
+      label="Edit"
+      labelClassName="text-[#ccc] font-mono"
+      headerExtra={
         <span className="text-[12px] text-[#666] truncate font-mono">{filePath}</span>
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-[#2a2a2a]">
-          {/* Diff view */}
-          <div className="font-mono text-[12px] overflow-x-auto max-h-80 overflow-y-auto">
-            {oldLines.map((line, i) => (
-              <div key={`old-${i}`} className="px-3 py-0.5 bg-red-900/15 text-red-300/80">
-                <span className="select-none text-red-500/50 mr-2">-</span>{line}
-              </div>
-            ))}
-            {newLines.map((line, i) => (
-              <div key={`new-${i}`} className="px-3 py-0.5 bg-green-900/15 text-green-300/80">
-                <span className="select-none text-green-500/50 mr-2">+</span>{line}
-              </div>
-            ))}
+      }
+    >
+      {/* Diff view */}
+      <div className="font-mono text-[12px] overflow-x-auto max-h-80 overflow-y-auto">
+        {oldLines.map((line, i) => (
+          <div key={`old-${i}`} className="px-3 py-0.5 bg-red-900/15 text-red-300/80">
+            <span className="select-none text-red-500/50 mr-2">-</span>{line}
           </div>
+        ))}
+        {newLines.map((line, i) => (
+          <div key={`new-${i}`} className="px-3 py-0.5 bg-green-900/15 text-green-300/80">
+            <span className="select-none text-green-500/50 mr-2">+</span>{line}
+          </div>
+        ))}
+      </div>
 
-          {/* Error */}
-          {block.isError && block.result && (
-            <div className="px-3 py-2 border-t border-[#222]">
-              <pre className="text-[12px] font-mono text-red-400 whitespace-pre-wrap">{block.result}</pre>
-            </div>
-          )}
-
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2 border-t border-[#222]">
-              <Loader2 size={12} className="animate-spin" /> Applying edit...
-            </div>
-          )}
+      {/* Error */}
+      {block.isError && block.result && (
+        <div className="px-3 py-2 border-t border-[#222]">
+          <pre className="text-[12px] font-mono text-red-400 whitespace-pre-wrap">{block.result}</pre>
         </div>
       )}
-    </div>
+
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2 border-t border-[#222]">
+          <Loader2 size={12} className="animate-spin" /> Applying edit...
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/FileToolBlock.tsx
+++ b/web/src/components/Chat/tools/FileToolBlock.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, FileText, FilePlus, Loader2 } from 'lucide-react';
+import { FileText, FilePlus, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 export function FileToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
   const filePath = String(block.input.file_path || block.input.path || '');
   const isWrite = block.tool === 'Write';
@@ -13,40 +12,31 @@ export function FileToolBlock({ block }: { block: ToolCallBlockData }) {
   const lineCount = block.result ? block.result.split('\n').length : null;
 
   return (
-    <div className="my-1.5 border border-[#2a2a2a] rounded-lg bg-[#141414] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a1a] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-blue-400'}`} />
-        }
-        <span className="text-[13px] font-mono font-medium text-[#ccc]">{block.tool}</span>
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName="text-blue-400"
+      label={block.tool}
+      labelClassName="text-[#ccc] font-mono"
+      headerExtra={<>
         <span className="text-[12px] text-[#666] truncate font-mono">{filePath}</span>
         {lineCount && !isWrite && (
           <span className="text-[10px] text-[#444] shrink-0">{lineCount} lines</span>
         )}
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
+      </>}
+    >
+      {block.result !== undefined && (
+        <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto bg-[#0f0f0f] ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
+          {block.result}
+        </pre>
+      )}
 
-      {expanded && (
-        <div className="border-t border-[#2a2a2a]">
-          {block.result !== undefined && (
-            <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto bg-[#0f0f0f] ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
-              {block.result}
-            </pre>
-          )}
-
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" /> {isWrite ? 'Writing...' : 'Reading...'}
-            </div>
-          )}
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" /> {isWrite ? 'Writing...' : 'Reading...'}
         </div>
       )}
-    </div>
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/MemoryToolBlock.tsx
+++ b/web/src/components/Chat/tools/MemoryToolBlock.tsx
@@ -1,22 +1,7 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, Brain, BookOpen, Search, Loader2 } from 'lucide-react';
+import { Brain, BookOpen, Search, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
-
-/** Extract readable text from MCP content blocks or plain text. */
-function extractText(result: string): string {
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: any) => b.type === 'text')
-        .map((b: any) => b.text)
-        .join('\n');
-    }
-  } catch {
-    // Not JSON — return as-is
-  }
-  return result;
-}
+import { extractText } from '../../../utils/extractResultText';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 interface MemoryItem {
   type: string;  // event, profile, knowledge, behavior
@@ -45,7 +30,6 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 export function MemoryToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
 
   const isRecall = block.tool.includes('recall');
@@ -75,80 +59,72 @@ export function MemoryToolBlock({ block }: { block: ToolCallBlockData }) {
   const count = countMatch ? countMatch[1] : memoryItems.length > 0 ? String(memoryItems.length) : null;
 
   return (
-    <div className="my-1.5 border border-purple-500/20 rounded-lg bg-[#141418] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a20] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-purple-400 animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-purple-400'}`} />
-        }
-        <span className="text-[13px] font-medium text-purple-300">{label}</span>
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName="text-purple-400"
+      label={label}
+      labelClassName="text-purple-300"
+      theme="purple"
+      headerExtra={<>
         {truncatedQuery && <span className="text-[12px] text-[#666] truncate">{truncatedQuery}</span>}
         {count && !isRunning && (
           <span className="text-[10px] text-purple-400/60 shrink-0">{count} items</span>
         )}
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-purple-500/10">
-          {/* Memorize: show what was memorized */}
-          {isMemorize && query && (
-            <div className="px-3 py-2 text-[12px] text-[#bbb]">
-              <div className="flex items-center gap-1.5 mb-1">
-                <Brain size={11} className="text-purple-400" />
-                <span className="text-[10px] uppercase tracking-wider text-purple-400/60">Memorized</span>
-              </div>
-              <p className="leading-relaxed">{String(query)}</p>
-              {block.input.memory_type ? (
-                <span className={`inline-block mt-1.5 text-[10px] px-1.5 py-0.5 rounded ${TYPE_COLORS[String(block.input.memory_type)] || 'text-[#888] bg-[#222]'}`}>
-                  {String(block.input.memory_type)}
-                </span>
-              ) : null}
-            </div>
-          )}
-
-          {/* Recall / History: show parsed memory items */}
-          {(isRecall || isHistory) && memoryItems.length > 0 ? (
-            <div className="px-3 py-2 space-y-1.5 max-h-80 overflow-y-auto">
-              {memoryItems.map((item, i) => (
-                <div key={i} className="flex gap-2 text-[12px] leading-relaxed">
-                  <span className={`shrink-0 text-[10px] px-1 py-0.5 rounded mt-0.5 ${TYPE_COLORS[item.type] || 'text-[#888] bg-[#222]'}`}>
-                    {item.type}
-                  </span>
-                  <span className="text-[#bbb]">{item.text}</span>
-                </div>
-              ))}
-            </div>
-          ) : resultText && !isMemorize ? (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
-              {resultText}
-            </pre>
+      </>}
+    >
+      {/* Memorize: show what was memorized */}
+      {isMemorize && query && (
+        <div className="px-3 py-2 text-[12px] text-[#bbb]">
+          <div className="flex items-center gap-1.5 mb-1">
+            <Brain size={11} className="text-purple-400" />
+            <span className="text-[10px] uppercase tracking-wider text-purple-400/60">Memorized</span>
+          </div>
+          <p className="leading-relaxed">{String(query)}</p>
+          {block.input.memory_type ? (
+            <span className={`inline-block mt-1.5 text-[10px] px-1.5 py-0.5 rounded ${TYPE_COLORS[String(block.input.memory_type)] || 'text-[#888] bg-[#222]'}`}>
+              {String(block.input.memory_type)}
+            </span>
           ) : null}
-
-          {/* Success/error feedback for memorize */}
-          {isMemorize && resultText && !block.isError && (
-            <div className="px-3 py-1.5 text-[11px] text-green-400/70 border-t border-purple-500/10">
-              Saved to memory
-            </div>
-          )}
-          {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-purple-500/10">
-              {resultText}
-            </pre>
-          )}
-
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" /> {isRecall || isHistory ? 'Searching...' : 'Saving...'}
-            </div>
-          )}
         </div>
       )}
-    </div>
+
+      {/* Recall / History: show parsed memory items */}
+      {(isRecall || isHistory) && memoryItems.length > 0 ? (
+        <div className="px-3 py-2 space-y-1.5 max-h-80 overflow-y-auto">
+          {memoryItems.map((item, i) => (
+            <div key={i} className="flex gap-2 text-[12px] leading-relaxed">
+              <span className={`shrink-0 text-[10px] px-1 py-0.5 rounded mt-0.5 ${TYPE_COLORS[item.type] || 'text-[#888] bg-[#222]'}`}>
+                {item.type}
+              </span>
+              <span className="text-[#bbb]">{item.text}</span>
+            </div>
+          ))}
+        </div>
+      ) : resultText && !isMemorize ? (
+        <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
+          {resultText}
+        </pre>
+      ) : null}
+
+      {/* Success/error feedback for memorize */}
+      {isMemorize && resultText && !block.isError && (
+        <div className="px-3 py-1.5 text-[11px] text-green-400/70 border-t border-purple-500/10">
+          Saved to memory
+        </div>
+      )}
+      {block.isError && resultText && (
+        <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-purple-500/10">
+          {resultText}
+        </pre>
+      )}
+
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" /> {isRecall || isHistory ? 'Searching...' : 'Saving...'}
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/NotificationToolBlock.tsx
+++ b/web/src/components/Chat/tools/NotificationToolBlock.tsx
@@ -1,23 +1,9 @@
-import { useState } from 'react';
-import { Bell, HelpCircle, Loader2, ChevronRight, ChevronDown } from 'lucide-react';
+import { Bell, HelpCircle, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
-
-/** Extract readable text from MCP content blocks. */
-function extractText(result: string): string {
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: any) => b.type === 'text')
-        .map((b: any) => b.text)
-        .join('\n');
-    }
-  } catch { /* not JSON */ }
-  return result;
-}
+import { extractText } from '../../../utils/extractResultText';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
   const isNotify = block.tool === 'notify';
   const isAsk = block.tool === 'ask_user';
@@ -30,23 +16,20 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
   const body = String(block.input.body || '');
 
   const Icon = isAsk ? HelpCircle : Bell;
-  const iconColor = block.isError ? 'text-red-400' : isAsk ? 'text-blue-400' : 'text-amber-400';
+  const iconColor = isAsk ? 'text-blue-400' : 'text-amber-400';
   const label = isNotify ? 'Notify' : 'Ask User';
 
   const resultText = block.result ? extractText(block.result) : '';
   const isSent = resultText.includes('sent') || resultText.includes('Sent');
 
   return (
-    <div className="my-1.5 border border-[#2a2a2a] rounded-lg bg-[#141414] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a1a] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${iconColor}`} />
-        }
-        <span className="text-[13px] font-medium text-[#ccc]">{label}</span>
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName={iconColor}
+      label={label}
+      headerExtra={<>
         {title && <span className="text-[12px] text-[#777] truncate">{title}</span>}
         {priority !== 'normal' && (
           <span className={`text-[10px] px-1.5 py-0.5 rounded shrink-0 ${
@@ -63,45 +46,38 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
         {isSent && !isRunning && (
           <span className="text-[10px] text-emerald-400/70 shrink-0">sent</span>
         )}
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
+      </>}
+    >
+      <div className="px-3 py-2">
+        {title && <p className="text-[13px] text-[#e0e0e0] font-medium">{title}</p>}
+        {body && <p className="text-[12px] text-[#888] mt-0.5">{body}</p>}
 
-      {expanded && (
-        <div className="border-t border-[#2a2a2a]">
-          <div className="px-3 py-2">
-            {title && <p className="text-[13px] text-[#e0e0e0] font-medium">{title}</p>}
-            {body && <p className="text-[12px] text-[#888] mt-0.5">{body}</p>}
-
-            {/* Options for questions */}
-            {isAsk && options.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                {options.map(opt => (
-                  <span key={opt} className="px-2 py-0.5 text-[11px] bg-[#1a1a2e] text-blue-300/80 rounded border border-blue-500/20">
-                    {opt}
-                  </span>
-                ))}
-              </div>
-            )}
+        {/* Options for questions */}
+        {isAsk && options.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {options.map(opt => (
+              <span key={opt} className="px-2 py-0.5 text-[11px] bg-[#1a1a2e] text-blue-300/80 rounded border border-blue-500/20">
+                {opt}
+              </span>
+            ))}
           </div>
+        )}
+      </div>
 
-          {/* Result */}
-          {resultText && (
-            <div className="px-3 py-2 border-t border-[#222]">
-              <pre className={`text-[12px] font-mono whitespace-pre-wrap ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
-                {resultText}
-              </pre>
-            </div>
-          )}
-
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2 border-t border-[#222]">
-              <Loader2 size={12} className="animate-spin" /> Sending...
-            </div>
-          )}
+      {/* Result */}
+      {resultText && (
+        <div className="px-3 py-2 border-t border-[#222]">
+          <pre className={`text-[12px] font-mono whitespace-pre-wrap ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
+            {resultText}
+          </pre>
         </div>
       )}
-    </div>
+
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2 border-t border-[#222]">
+          <Loader2 size={12} className="animate-spin" /> Sending...
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/PlanToolBlock.tsx
+++ b/web/src/components/Chat/tools/PlanToolBlock.tsx
@@ -1,22 +1,10 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, Lightbulb, ListTodo, FileText, Check, X, MessageSquare, Loader2, ExternalLink } from 'lucide-react';
+import { Lightbulb, ListTodo, FileText, Check, X, MessageSquare, Loader2, ExternalLink } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { MarkdownContent } from '../MarkdownContent';
 import type { ToolCallBlockData } from '../../../types/chat';
-
-/** Extract readable text from MCP content blocks. */
-function extractText(result: string): string {
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: any) => b.type === 'text')
-        .map((b: any) => b.text)
-        .join('\n');
-    }
-  } catch { /* not JSON */ }
-  return result;
-}
+import { extractText } from '../../../utils/extractResultText';
+import { PLAN_STATUS_COLORS as STATUS_COLORS } from '../../../constants/statusStyles';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 interface ParsedPlan {
   status: string;
@@ -44,14 +32,6 @@ function parsePlanList(text: string): ParsedPlan[] {
   return items;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-500/15 text-yellow-400',
-  approved: 'bg-green-500/15 text-green-400',
-  implementing: 'bg-blue-500/15 text-blue-400',
-  declined: 'bg-red-500/15 text-red-400',
-  superseded: 'bg-[#333] text-[#888]',
-};
-
 type PlanTool = 'plan_propose' | 'plan_list' | 'plan_read' | 'plan_approve' | 'plan_decline' | 'plan_revise';
 
 const TOOL_CONFIG: Record<PlanTool, { label: string; icon: typeof Lightbulb; runningLabel: string }> = {
@@ -64,7 +44,6 @@ const TOOL_CONFIG: Record<PlanTool, { label: string; icon: typeof Lightbulb; run
 };
 
 export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const navigate = useNavigate();
   const isRunning = block.status === 'running';
 
@@ -103,176 +82,166 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
   else if (planId) summary = planId;
 
   // Icon color
-  const iconColor = block.isError ? 'text-red-400'
-    : toolName === 'plan_approve' ? 'text-emerald-400'
+  const iconColor = toolName === 'plan_approve' ? 'text-emerald-400'
     : toolName === 'plan_decline' ? 'text-red-400'
     : 'text-amber-400';
 
   return (
-    <div className="my-1.5 border border-amber-500/20 rounded-lg bg-[#141411] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a18] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-amber-400 animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${iconColor}`} />
-        }
-        <span className="text-[13px] font-medium text-amber-300">{config.label}</span>
-        {summary && <span className="text-[12px] text-[#666] truncate">{summary}</span>}
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-amber-500/10">
-
-          {/* ── plan_propose ── */}
-          {toolName === 'plan_propose' && (
-            <div className="px-3 py-2">
-              {block.input.content ? (
-                <div className="text-[12px] text-[#999] max-h-40 overflow-y-auto whitespace-pre-wrap">
-                  {String(block.input.content).slice(0, 500)}
-                  {String(block.input.content).length > 500 ? '...' : null}
-                </div>
-              ) : null}
-              {proposedPlanId && !block.isError && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); navigate(`/plans/${proposedPlanId}`); }}
-                  className="mt-2 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
-                >
-                  <ExternalLink size={10} /> Review plan
-                </button>
-              )}
-              {proposedPlanId && !block.isError && (
-                <div className="mt-1 text-[11px] text-green-400/70">
-                  Plan proposed — awaiting review
-                </div>
-              )}
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName={iconColor}
+      label={config.label}
+      labelClassName="text-amber-300"
+      theme="amber"
+      headerExtra={
+        summary ? <span className="text-[12px] text-[#666] truncate">{summary}</span> : undefined
+      }
+    >
+      {/* ── plan_propose ── */}
+      {toolName === 'plan_propose' && (
+        <div className="px-3 py-2">
+          {block.input.content ? (
+            <div className="text-[12px] text-[#999] max-h-40 overflow-y-auto whitespace-pre-wrap">
+              {String(block.input.content).slice(0, 500)}
+              {String(block.input.content).length > 500 ? '...' : null}
             </div>
+          ) : null}
+          {proposedPlanId && !block.isError && (
+            <button
+              onClick={(e) => { e.stopPropagation(); navigate(`/plans/${proposedPlanId}`); }}
+              className="mt-2 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
+            >
+              <ExternalLink size={10} /> Review plan
+            </button>
           )}
-
-          {/* ── plan_list ── */}
-          {toolName === 'plan_list' && (planList.length > 0 ? (
-            <div className="px-3 py-2 space-y-1 max-h-60 overflow-y-auto">
-              {planList.map((p, i) => (
-                <div
-                  key={i}
-                  className="flex items-center gap-2 text-[12px] cursor-pointer hover:bg-[#1f1f1c] rounded px-1 py-0.5"
-                  onClick={() => navigate(`/plans/${p.planId}`)}
-                >
-                  <span className={`px-1.5 py-0.5 rounded text-[10px] shrink-0 ${STATUS_COLORS[p.status] || 'bg-[#333] text-[#888]'}`}>
-                    {p.status}
-                  </span>
-                  <span className="text-[#bbb] truncate">{p.taskTitle}</span>
-                  <span className="text-[10px] text-[#555] shrink-0">v{p.version}</span>
-                </div>
-              ))}
-            </div>
-          ) : resultText ? (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
-              {resultText}
-            </pre>
-          ) : null)}
-
-          {/* ── plan_read ── */}
-          {toolName === 'plan_read' && resultText && !block.isError && (
-            <div className="px-3 py-2">
-              {/* Header metadata */}
-              {readHeader && (
-                <pre className="text-[12px] text-[#888] whitespace-pre-wrap mb-2">{readHeader}</pre>
-              )}
-              {/* Plan content */}
-              {readContent && (
-                <div className="max-h-96 overflow-y-auto bg-[#0f0f0d] rounded-lg p-4 border border-amber-500/10">
-                  <MarkdownContent content={readContent} />
-                </div>
-              )}
-              {planId && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); navigate(`/plans/${planId}`); }}
-                  className="mt-2 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
-                >
-                  <ExternalLink size={10} /> Open plan
-                </button>
-              )}
-            </div>
-          )}
-
-          {/* ── plan_approve ── */}
-          {toolName === 'plan_approve' && resultText && !block.isError && (
-            <div className="px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px] text-emerald-400">
-                <Check size={12} />
-                <span>Plan approved</span>
-              </div>
-              {implSessionId && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); navigate(`/chat/${implSessionId}`); }}
-                  className="mt-2 flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 cursor-pointer"
-                >
-                  <MessageSquare size={10} /> Watch implementation
-                </button>
-              )}
-              {planId && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); navigate(`/plans/${planId}`); }}
-                  className="mt-1 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
-                >
-                  <ExternalLink size={10} /> View plan
-                </button>
-              )}
-            </div>
-          )}
-
-          {/* ── plan_decline ── */}
-          {toolName === 'plan_decline' && resultText && !block.isError && (
-            <div className="px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px] text-red-400">
-                <X size={12} />
-                <span>Plan declined</span>
-              </div>
-              {feedback && (
-                <div className="mt-2 flex gap-0">
-                  <div className="w-0.5 bg-red-400/30 rounded-full shrink-0" />
-                  <p className="pl-2 text-[12px] text-[#888] whitespace-pre-wrap">{feedback}</p>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* ── plan_revise ── */}
-          {toolName === 'plan_revise' && resultText && !block.isError && (
-            <div className="px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px] text-amber-400">
-                <MessageSquare size={12} />
-                <span>Revision requested</span>
-              </div>
-              {feedback && (
-                <div className="mt-2 flex gap-0">
-                  <div className="w-0.5 bg-amber-400/30 rounded-full shrink-0" />
-                  <p className="pl-2 text-[12px] text-[#999] whitespace-pre-wrap">{feedback}</p>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* ── Error fallback ── */}
-          {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-amber-500/10">
-              {resultText}
-            </pre>
-          )}
-
-          {/* ── Running spinner ── */}
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" /> {config.runningLabel}
+          {proposedPlanId && !block.isError && (
+            <div className="mt-1 text-[11px] text-green-400/70">
+              Plan proposed — awaiting review
             </div>
           )}
         </div>
       )}
-    </div>
+
+      {/* ── plan_list ── */}
+      {toolName === 'plan_list' && (planList.length > 0 ? (
+        <div className="px-3 py-2 space-y-1 max-h-60 overflow-y-auto">
+          {planList.map((p, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 text-[12px] cursor-pointer hover:bg-[#1f1f1c] rounded px-1 py-0.5"
+              onClick={() => navigate(`/plans/${p.planId}`)}
+            >
+              <span className={`px-1.5 py-0.5 rounded text-[10px] shrink-0 ${STATUS_COLORS[p.status] || 'bg-[#333] text-[#888]'}`}>
+                {p.status}
+              </span>
+              <span className="text-[#bbb] truncate">{p.taskTitle}</span>
+              <span className="text-[10px] text-[#555] shrink-0">v{p.version}</span>
+            </div>
+          ))}
+        </div>
+      ) : resultText ? (
+        <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
+          {resultText}
+        </pre>
+      ) : null)}
+
+      {/* ── plan_read ── */}
+      {toolName === 'plan_read' && resultText && !block.isError && (
+        <div className="px-3 py-2">
+          {/* Header metadata */}
+          {readHeader && (
+            <pre className="text-[12px] text-[#888] whitespace-pre-wrap mb-2">{readHeader}</pre>
+          )}
+          {/* Plan content */}
+          {readContent && (
+            <div className="max-h-96 overflow-y-auto bg-[#0f0f0d] rounded-lg p-4 border border-amber-500/10">
+              <MarkdownContent content={readContent} />
+            </div>
+          )}
+          {planId && (
+            <button
+              onClick={(e) => { e.stopPropagation(); navigate(`/plans/${planId}`); }}
+              className="mt-2 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
+            >
+              <ExternalLink size={10} /> Open plan
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── plan_approve ── */}
+      {toolName === 'plan_approve' && resultText && !block.isError && (
+        <div className="px-3 py-2">
+          <div className="flex items-center gap-2 text-[12px] text-emerald-400">
+            <Check size={12} />
+            <span>Plan approved</span>
+          </div>
+          {implSessionId && (
+            <button
+              onClick={(e) => { e.stopPropagation(); navigate(`/chat/${implSessionId}`); }}
+              className="mt-2 flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 cursor-pointer"
+            >
+              <MessageSquare size={10} /> Watch implementation
+            </button>
+          )}
+          {planId && (
+            <button
+              onClick={(e) => { e.stopPropagation(); navigate(`/plans/${planId}`); }}
+              className="mt-1 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
+            >
+              <ExternalLink size={10} /> View plan
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── plan_decline ── */}
+      {toolName === 'plan_decline' && resultText && !block.isError && (
+        <div className="px-3 py-2">
+          <div className="flex items-center gap-2 text-[12px] text-red-400">
+            <X size={12} />
+            <span>Plan declined</span>
+          </div>
+          {feedback && (
+            <div className="mt-2 flex gap-0">
+              <div className="w-0.5 bg-red-400/30 rounded-full shrink-0" />
+              <p className="pl-2 text-[12px] text-[#888] whitespace-pre-wrap">{feedback}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── plan_revise ── */}
+      {toolName === 'plan_revise' && resultText && !block.isError && (
+        <div className="px-3 py-2">
+          <div className="flex items-center gap-2 text-[12px] text-amber-400">
+            <MessageSquare size={12} />
+            <span>Revision requested</span>
+          </div>
+          {feedback && (
+            <div className="mt-2 flex gap-0">
+              <div className="w-0.5 bg-amber-400/30 rounded-full shrink-0" />
+              <p className="pl-2 text-[12px] text-[#999] whitespace-pre-wrap">{feedback}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Error fallback ── */}
+      {block.isError && resultText && (
+        <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-amber-500/10">
+          {resultText}
+        </pre>
+      )}
+
+      {/* ── Running spinner ── */}
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" /> {config.runningLabel}
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/SkillToolBlock.tsx
+++ b/web/src/components/Chat/tools/SkillToolBlock.tsx
@@ -1,20 +1,7 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, Sparkles, BookOpen, Play, List, Plus, Pencil, Loader2 } from 'lucide-react';
+import { Sparkles, BookOpen, Play, List, Plus, Pencil, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
-
-/** Extract readable text from MCP content blocks. */
-function extractText(result: string): string {
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: any) => b.type === 'text')
-        .map((b: any) => b.text)
-        .join('\n');
-    }
-  } catch { /* not JSON */ }
-  return result;
-}
+import { extractText } from '../../../utils/extractResultText';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 /** Parse skill list from result text. */
 function parseSkillList(text: string): Array<{ name: string; id: string; description: string }> {
@@ -29,7 +16,6 @@ function parseSkillList(text: string): Array<{ name: string; id: string; descrip
 }
 
 export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
 
   const toolName = block.tool.split('__').pop() || block.tool;
@@ -68,167 +54,152 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
   const contentLines = resultText ? resultText.split('\n').length : 0;
 
   return (
-    <div className="my-1.5 border border-[#2a2a2a] rounded-lg bg-[#141414] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a1a] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-purple-400'}`} />
-        }
-        <span className="text-[13px] font-medium text-[#ccc]">{label}</span>
-
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName="text-purple-400"
+      label={label}
+      headerExtra={<>
         {/* Skill name badge */}
         {skillName && (
           <span className="text-[11px] font-mono bg-purple-500/10 text-purple-300 px-1.5 py-0.5 rounded truncate max-w-[200px]">
             {skillName}
           </span>
         )}
-
         {/* Reference path */}
         {isRef && refPath && (
           <span className="text-[11px] text-[#666] font-mono truncate">{refPath}</span>
         )}
-
         {/* List count */}
         {isList && skillList.length > 0 && (
           <span className="text-[10px] text-[#555] shrink-0">{skillList.length} skills</span>
         )}
-
         {/* Loaded content hint */}
         {isGet && !isRunning && resultText && !block.isError && (
           <span className="text-[10px] text-[#555] shrink-0">{contentLines} lines</span>
         )}
-
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
+      </>}
+    >
+      {/* Skill list */}
+      {skillList.length > 0 && (
+        <div className="px-3 py-2 space-y-1.5 max-h-60 overflow-y-auto">
+          {skillList.map((s) => (
+            <div key={s.id} className="flex items-start gap-2 text-[12px]">
+              <Sparkles size={11} className="text-purple-400 mt-0.5 shrink-0" />
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[#ccc] font-medium">{s.name}</span>
+                  <span className="text-[10px] text-[#555] font-mono">{s.id}</span>
+                </div>
+                <p className="text-[11px] text-[#777] truncate">{s.description}</p>
+              </div>
+            </div>
+          ))}
         </div>
-      </button>
+      )}
 
-      {expanded && (
-        <div className="border-t border-[#2a2a2a]">
-          {/* Skill list */}
-          {skillList.length > 0 && (
-            <div className="px-3 py-2 space-y-1.5 max-h-60 overflow-y-auto">
-              {skillList.map((s) => (
-                <div key={s.id} className="flex items-start gap-2 text-[12px]">
-                  <Sparkles size={11} className="text-purple-400 mt-0.5 shrink-0" />
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1.5">
-                      <span className="text-[#ccc] font-medium">{s.name}</span>
-                      <span className="text-[10px] text-[#555] font-mono">{s.id}</span>
-                    </div>
-                    <p className="text-[11px] text-[#777] truncate">{s.description}</p>
-                  </div>
-                </div>
-              ))}
+      {/* Loaded skill content */}
+      {isGet && resultText && !block.isError && !skillList.length && (
+        <div className="max-h-80 overflow-y-auto">
+          {loadedSkillTitle && (
+            <div className="px-3 py-1.5 border-b border-[#222] flex items-center gap-2">
+              <Sparkles size={11} className="text-purple-400" />
+              <span className="text-[12px] text-[#ccc] font-medium">{loadedSkillTitle}</span>
             </div>
           )}
+          <pre className="px-3 py-2 text-[11px] font-mono whitespace-pre-wrap text-[#888] leading-relaxed">
+            {resultText}
+          </pre>
+        </div>
+      )}
 
-          {/* Loaded skill content */}
-          {isGet && resultText && !block.isError && !skillList.length && (
-            <div className="max-h-80 overflow-y-auto">
-              {loadedSkillTitle && (
-                <div className="px-3 py-1.5 border-b border-[#222] flex items-center gap-2">
-                  <Sparkles size={11} className="text-purple-400" />
-                  <span className="text-[12px] text-[#ccc] font-medium">{loadedSkillTitle}</span>
-                </div>
-              )}
-              <pre className="px-3 py-2 text-[11px] font-mono whitespace-pre-wrap text-[#888] leading-relaxed">
-                {resultText}
-              </pre>
+      {/* Script output */}
+      {isRun && resultText && !block.isError && (
+        <div className="px-3 py-2">
+          <div className="text-[10px] uppercase tracking-wider text-[#555] mb-1">Output</div>
+          <pre className="text-[12px] font-mono whitespace-pre-wrap max-h-60 overflow-y-auto bg-[#0a0a0a] rounded p-2 border border-[#222] text-[#999]">
+            {resultText}
+          </pre>
+        </div>
+      )}
+
+      {/* Reference content */}
+      {isRef && resultText && !block.isError && (
+        <div className="max-h-80 overflow-y-auto">
+          {refPath && (
+            <div className="px-3 py-1.5 border-b border-[#222]">
+              <span className="text-[11px] text-[#666] font-mono">{skillName}/{refPath}</span>
             </div>
           )}
+          <pre className="px-3 py-2 text-[11px] font-mono whitespace-pre-wrap text-[#888] leading-relaxed">
+            {resultText}
+          </pre>
+        </div>
+      )}
 
-          {/* Script output */}
-          {isRun && resultText && !block.isError && (
-            <div className="px-3 py-2">
-              <div className="text-[10px] uppercase tracking-wider text-[#555] mb-1">Output</div>
-              <pre className="text-[12px] font-mono whitespace-pre-wrap max-h-60 overflow-y-auto bg-[#0a0a0a] rounded p-2 border border-[#222] text-[#999]">
-                {resultText}
-              </pre>
+      {/* Create skill */}
+      {isCreate && (
+        <div className="px-3 py-2">
+          {skillName && (
+            <div className="flex items-center gap-2 mb-1.5">
+              <Plus size={11} className="text-purple-400" />
+              <span className="text-[12px] text-[#ccc] font-medium">{skillName}</span>
             </div>
           )}
-
-          {/* Reference content */}
-          {isRef && resultText && !block.isError && (
-            <div className="max-h-80 overflow-y-auto">
-              {refPath && (
-                <div className="px-3 py-1.5 border-b border-[#222]">
-                  <span className="text-[11px] text-[#666] font-mono">{skillName}/{refPath}</span>
-                </div>
-              )}
-              <pre className="px-3 py-2 text-[11px] font-mono whitespace-pre-wrap text-[#888] leading-relaxed">
-                {resultText}
-              </pre>
-            </div>
+          {skillDescription && (
+            <p className="text-[11px] text-[#888] mb-1.5 pl-5">{skillDescription.slice(0, 300)}</p>
           )}
-
-          {/* Create skill */}
-          {isCreate && (
-            <div className="px-3 py-2">
-              {skillName && (
-                <div className="flex items-center gap-2 mb-1.5">
-                  <Plus size={11} className="text-purple-400" />
-                  <span className="text-[12px] text-[#ccc] font-medium">{skillName}</span>
-                </div>
-              )}
-              {skillDescription && (
-                <p className="text-[11px] text-[#888] mb-1.5 pl-5">{skillDescription.slice(0, 300)}</p>
-              )}
-              {String(block.input.content || '') && (
-                <pre className="text-[11px] font-mono text-[#666] whitespace-pre-wrap max-h-40 overflow-y-auto bg-[#0a0a0a] rounded p-2 border border-[#222] mt-1">
-                  {String(block.input.content).slice(0, 500)}{String(block.input.content).length > 500 ? '...' : ''}
-                </pre>
-              )}
-              {resultText && !block.isError && (
-                <div className="mt-2 text-[11px] text-emerald-400/70 flex items-center gap-1">
-                  <Sparkles size={10} /> {resultText}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Update skill */}
-          {isUpdate && (
-            <div className="px-3 py-2">
-              {String(block.input.content || '') && (
-                <pre className="text-[11px] font-mono text-[#777] whitespace-pre-wrap max-h-60 overflow-y-auto bg-[#0a0a0a] rounded p-2 border border-[#222]">
-                  {String(block.input.content).slice(0, 800)}{String(block.input.content).length > 800 ? '\n...' : ''}
-                </pre>
-              )}
-              {resultText && !block.isError && (
-                <div className="mt-2 text-[11px] text-emerald-400/70 flex items-center gap-1">
-                  <Sparkles size={10} /> {resultText}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Fallback for unknown skill tools */}
-          {!isList && !isGet && !isRun && !isRef && !isCreate && !isUpdate && resultText && !block.isError && (
-            <pre className="px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto text-[#999]">
-              {resultText}
+          {String(block.input.content || '') && (
+            <pre className="text-[11px] font-mono text-[#666] whitespace-pre-wrap max-h-40 overflow-y-auto bg-[#0a0a0a] rounded p-2 border border-[#222] mt-1">
+              {String(block.input.content).slice(0, 500)}{String(block.input.content).length > 500 ? '...' : ''}
             </pre>
           )}
-
-          {/* Error */}
-          {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-[#222]">
-              {resultText}
-            </pre>
-          )}
-
-          {/* Running */}
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" />
-              {isGet ? 'Loading skill...' : isRun ? 'Running script...' : 'Working...'}
+          {resultText && !block.isError && (
+            <div className="mt-2 text-[11px] text-emerald-400/70 flex items-center gap-1">
+              <Sparkles size={10} /> {resultText}
             </div>
           )}
         </div>
       )}
-    </div>
+
+      {/* Update skill */}
+      {isUpdate && (
+        <div className="px-3 py-2">
+          {String(block.input.content || '') && (
+            <pre className="text-[11px] font-mono text-[#777] whitespace-pre-wrap max-h-60 overflow-y-auto bg-[#0a0a0a] rounded p-2 border border-[#222]">
+              {String(block.input.content).slice(0, 800)}{String(block.input.content).length > 800 ? '\n...' : ''}
+            </pre>
+          )}
+          {resultText && !block.isError && (
+            <div className="mt-2 text-[11px] text-emerald-400/70 flex items-center gap-1">
+              <Sparkles size={10} /> {resultText}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Fallback for unknown skill tools */}
+      {!isList && !isGet && !isRun && !isRef && !isCreate && !isUpdate && resultText && !block.isError && (
+        <pre className="px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto text-[#999]">
+          {resultText}
+        </pre>
+      )}
+
+      {/* Error */}
+      {block.isError && resultText && (
+        <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-[#222]">
+          {resultText}
+        </pre>
+      )}
+
+      {/* Running */}
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" />
+          {isGet ? 'Loading skill...' : isRun ? 'Running script...' : 'Working...'}
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/SourceToolBlock.tsx
+++ b/web/src/components/Chat/tools/SourceToolBlock.tsx
@@ -1,22 +1,7 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, Inbox, Radio, BookOpen, Loader2, Mail, Github, MessageCircle } from 'lucide-react';
+import { Inbox, Radio, BookOpen, Loader2, Mail, Github, MessageCircle } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
-
-/** Extract readable text from MCP content blocks or plain text. */
-function extractText(result: string): string {
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: any) => b.type === 'text')
-        .map((b: any) => b.text)
-        .join('\n');
-    }
-  } catch {
-    // Not JSON — return as-is
-  }
-  return result;
-}
+import { extractText } from '../../../utils/extractResultText';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 function sourceIcon(source: string) {
   const type = source.split(':')[0];
@@ -106,7 +91,6 @@ function parseSourceMessages(text: string): { messages: SourceMessage[]; message
 }
 
 export function SourceToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
 
   const isList = block.tool.includes('list_sources');
@@ -148,107 +132,99 @@ export function SourceToolBlock({ block }: { block: ToolCallBlockData }) {
   }
 
   return (
-    <div className="my-1.5 border border-cyan-500/20 rounded-lg bg-[#141416] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a1e] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-cyan-400 animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-cyan-400'}`} />
-        }
-        <span className="text-[13px] font-medium text-cyan-300">{label}</span>
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName="text-cyan-400"
+      label={label}
+      labelClassName="text-cyan-300"
+      theme="cyan"
+      headerExtra={<>
         {summary && <span className="text-[12px] text-[#666] truncate">{summary}</span>}
         {(isPoll || isRead) && messageCount > 0 && !isRunning && (
           <span className="text-[10px] text-cyan-400/60 shrink-0">{messageCount} msg</span>
         )}
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-cyan-500/10">
-          {/* list_sources: structured source list */}
-          {isList && sourceEntries.length > 0 && (
-            <div className="px-3 py-2 space-y-1">
-              {sourceEntries.map((entry, i) => (
-                <div key={i} className="flex items-center gap-2 text-[12px]">
-                  {sourceIcon(entry.name)}
-                  <span className="text-[#ccc] font-mono">{entry.name}</span>
-                  {entry.messageCount && <span className="text-[#666]">{entry.messageCount} msgs</span>}
-                  {entry.unread && parseInt(entry.unread) > 0 && (
-                    <span className="text-amber-400 font-medium">{entry.unread} unread</span>
-                  )}
-                  {entry.unread === '0' && (
-                    <span className="text-[#444]">0 unread</span>
-                  )}
-                </div>
-              ))}
+      </>}
+    >
+      {/* list_sources: structured source list */}
+      {isList && sourceEntries.length > 0 && (
+        <div className="px-3 py-2 space-y-1">
+          {sourceEntries.map((entry, i) => (
+            <div key={i} className="flex items-center gap-2 text-[12px]">
+              {sourceIcon(entry.name)}
+              <span className="text-[#ccc] font-mono">{entry.name}</span>
+              {entry.messageCount && <span className="text-[#666]">{entry.messageCount} msgs</span>}
+              {entry.unread && parseInt(entry.unread) > 0 && (
+                <span className="text-amber-400 font-medium">{entry.unread} unread</span>
+              )}
+              {entry.unread === '0' && (
+                <span className="text-[#444]">0 unread</span>
+              )}
             </div>
-          )}
-
-          {/* poll/read: message list */}
-          {(isPoll || isRead) && parsedMessages.length > 0 && (
-            <div className="max-h-96 overflow-y-auto">
-              {parsedMessages.map((msg, i) => (
-                <div key={i} className="px-3 py-2 border-t border-[#1a1a1a] first:border-t-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    {sourceIcon(msg.source)}
-                    <span className="text-[12px] text-[#ccc] font-medium truncate flex-1">{msg.summary}</span>
-                    <span className="text-[10px] text-[#666] shrink-0">{msg.relativeTime}</span>
-                  </div>
-                  <div className="text-[11px] text-[#555] flex items-center gap-2 mb-1">
-                    <span>{msg.type}</span>
-                    <span>seq:{msg.seq}</span>
-                    {msg.time && <span>{msg.time}</span>}
-                  </div>
-                  {msg.content && (
-                    <pre className="text-[11px] text-[#999] whitespace-pre-wrap leading-relaxed max-h-32 overflow-y-auto">
-                      {msg.content.length > 500 ? msg.content.slice(0, 500) + '...' : msg.content}
-                    </pre>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* No messages state */}
-          {isNoMessages && !isList && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Inbox size={12} className="text-[#444]" /> No new messages
-            </div>
-          )}
-
-          {/* Fallback: raw text for unparsed results */}
-          {!isList && parsedMessages.length === 0 && !isNoMessages && resultText && (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
-              {resultText}
-            </pre>
-          )}
-
-          {/* list_sources fallback */}
-          {isList && sourceEntries.length === 0 && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-[#999] whitespace-pre-wrap max-h-60 overflow-y-auto">
-              {resultText}
-            </pre>
-          )}
-
-          {/* Error */}
-          {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-cyan-500/10">
-              {resultText}
-            </pre>
-          )}
-
-          {/* Running state */}
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" /> {isPoll ? 'Polling...' : isList ? 'Loading sources...' : 'Browsing...'}
-            </div>
-          )}
+          ))}
         </div>
       )}
-    </div>
+
+      {/* poll/read: message list */}
+      {(isPoll || isRead) && parsedMessages.length > 0 && (
+        <div className="max-h-96 overflow-y-auto">
+          {parsedMessages.map((msg, i) => (
+            <div key={i} className="px-3 py-2 border-t border-[#1a1a1a] first:border-t-0">
+              <div className="flex items-center gap-2 mb-1">
+                {sourceIcon(msg.source)}
+                <span className="text-[12px] text-[#ccc] font-medium truncate flex-1">{msg.summary}</span>
+                <span className="text-[10px] text-[#666] shrink-0">{msg.relativeTime}</span>
+              </div>
+              <div className="text-[11px] text-[#555] flex items-center gap-2 mb-1">
+                <span>{msg.type}</span>
+                <span>seq:{msg.seq}</span>
+                {msg.time && <span>{msg.time}</span>}
+              </div>
+              {msg.content && (
+                <pre className="text-[11px] text-[#999] whitespace-pre-wrap leading-relaxed max-h-32 overflow-y-auto">
+                  {msg.content.length > 500 ? msg.content.slice(0, 500) + '...' : msg.content}
+                </pre>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* No messages state */}
+      {isNoMessages && !isList && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Inbox size={12} className="text-[#444]" /> No new messages
+        </div>
+      )}
+
+      {/* Fallback: raw text for unparsed results */}
+      {!isList && parsedMessages.length === 0 && !isNoMessages && resultText && (
+        <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
+          {resultText}
+        </pre>
+      )}
+
+      {/* list_sources fallback */}
+      {isList && sourceEntries.length === 0 && resultText && (
+        <pre className="px-3 py-2 text-[12px] text-[#999] whitespace-pre-wrap max-h-60 overflow-y-auto">
+          {resultText}
+        </pre>
+      )}
+
+      {/* Error */}
+      {block.isError && resultText && (
+        <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-cyan-500/10">
+          {resultText}
+        </pre>
+      )}
+
+      {/* Running state */}
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" /> {isPoll ? 'Polling...' : isList ? 'Loading sources...' : 'Browsing...'}
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Chat/tools/TaskToolBlock.tsx
+++ b/web/src/components/Chat/tools/TaskToolBlock.tsx
@@ -1,29 +1,8 @@
-import { useState } from 'react';
-import { ChevronRight, ChevronDown, CheckSquare, ListTodo, Plus, CheckCircle, Pencil, FileText, Loader2 } from 'lucide-react';
+import { CheckSquare, ListTodo, Plus, CheckCircle, Pencil, FileText, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
-
-const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-500/15 text-yellow-400',
-  'in-progress': 'bg-blue-500/15 text-blue-400',
-  'in_progress': 'bg-blue-500/15 text-blue-400',
-  done: 'bg-green-500/15 text-green-400',
-  completed: 'bg-green-500/15 text-green-400',
-  deferred: 'bg-[#333] text-[#888]',
-};
-
-/** Extract readable text from MCP content blocks. */
-function extractText(result: string): string {
-  try {
-    const parsed = JSON.parse(result);
-    if (Array.isArray(parsed)) {
-      return parsed
-        .filter((b: any) => b.type === 'text')
-        .map((b: any) => b.text)
-        .join('\n');
-    }
-  } catch { /* not JSON */ }
-  return result;
-}
+import { extractText } from '../../../utils/extractResultText';
+import { TASK_STATUS_COLORS as STATUS_COLORS } from '../../../constants/statusStyles';
+import { CollapsibleToolBlock } from './CollapsibleToolBlock';
 
 interface ParsedTask {
   title: string;
@@ -60,7 +39,6 @@ function parseTaskList(text: string): ParsedTask[] {
 }
 
 export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
-  const [expanded, setExpanded] = useState(false);
   const isRunning = block.status === 'running';
 
   const toolName = block.tool.split('__').pop() || block.tool;
@@ -86,16 +64,13 @@ export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
   const taskList = isList ? parseTaskList(resultText) : [];
 
   return (
-    <div className="my-1.5 border border-[#2a2a2a] rounded-lg bg-[#141414] overflow-hidden">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-[#1a1a1a] transition-colors"
-      >
-        {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : isDone ? 'text-green-400' : isCreate ? 'text-blue-400' : 'text-[#888]'}`} />
-        }
-        <span className="text-[13px] font-medium text-[#ccc] shrink-0 whitespace-nowrap">{label}</span>
+    <CollapsibleToolBlock
+      isRunning={isRunning}
+      isError={block.isError}
+      icon={Icon}
+      iconClassName={isDone ? 'text-green-400' : isCreate ? 'text-blue-400' : 'text-[#888]'}
+      label={label}
+      headerExtra={<>
         {title && <span className="text-[12px] text-[#777] truncate">{title}</span>}
         {status && (
           <span className={`text-[10px] px-1.5 py-0.5 rounded ${STATUS_COLORS[status] || 'bg-[#333] text-[#888]'}`}>
@@ -105,76 +80,69 @@ export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
         {isList && taskList.length > 0 && (
           <span className="text-[10px] text-[#555] shrink-0">{taskList.length} tasks</span>
         )}
-        <div className="ml-auto shrink-0">
-          {expanded ? <ChevronDown size={14} className="text-[#555]" /> : <ChevronRight size={14} className="text-[#555]" />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-[#2a2a2a]">
-          {/* Create: show what was created */}
-          {isCreate && title && (
-            <div className="px-3 py-2">
-              <div className="text-[12px] text-[#bbb] flex items-center gap-2">
-                <Plus size={11} className="text-blue-400" />
-                <span className="font-medium">{title}</span>
-              </div>
-              {block.input.content ? (
-                <p className="text-[12px] text-[#888] mt-1 pl-5">{String(block.input.content).slice(0, 200)}</p>
-              ) : null}
-              {block.input.deadline ? (
-                <p className="text-[10px] text-[#666] mt-1 pl-5">Deadline: {String(block.input.deadline)}</p>
-              ) : null}
-            </div>
-          )}
-
-          {/* Done/Update: show status change */}
-          {(isDone || isUpdate) && (
-            <div className="px-3 py-2 text-[12px]">
-              <span className="text-[#888]">{block.input.task_id ? String(block.input.task_id) : title}</span>
-              {block.input.note ? <p className="text-[#777] mt-1">{String(block.input.note)}</p> : null}
-            </div>
-          )}
-
-          {/* Task list */}
-          {taskList.length > 0 ? (
-            <div className="px-3 py-2 space-y-1 max-h-60 overflow-y-auto">
-              {taskList.map((t, i) => (
-                <div key={i} className="flex items-center gap-2 text-[12px]">
-                  <span className={`px-1.5 py-0.5 rounded text-[10px] shrink-0 ${STATUS_COLORS[t.status] || 'bg-[#333] text-[#888]'}`}>
-                    {t.status}
-                  </span>
-                  <span className="text-[#bbb] truncate">{t.title}</span>
-                  {t.deadline && <span className="text-[10px] text-[#555] shrink-0">{t.deadline}</span>}
-                </div>
-              ))}
-            </div>
-          ) : resultText && !isCreate && !isDone && !isUpdate ? (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
-              {resultText}
-            </pre>
+      </>}
+    >
+      {/* Create: show what was created */}
+      {isCreate && title && (
+        <div className="px-3 py-2">
+          <div className="text-[12px] text-[#bbb] flex items-center gap-2">
+            <Plus size={11} className="text-blue-400" />
+            <span className="font-medium">{title}</span>
+          </div>
+          {block.input.content ? (
+            <p className="text-[12px] text-[#888] mt-1 pl-5">{String(block.input.content).slice(0, 200)}</p>
           ) : null}
-
-          {/* Success message */}
-          {(isCreate || isDone) && resultText && !block.isError && !taskList.length && (
-            <div className="px-3 py-1.5 text-[11px] text-green-400/70 border-t border-[#222]">
-              {isDone ? 'Task completed' : 'Task created'}
-            </div>
-          )}
-
-          {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-[#222]">
-              {resultText}
-            </pre>
-          )}
-
-          {isRunning && block.result === undefined && (
-            <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
-              <Loader2 size={12} className="animate-spin" /> Working...
-            </div>
-          )}
+          {block.input.deadline ? (
+            <p className="text-[10px] text-[#666] mt-1 pl-5">Deadline: {String(block.input.deadline)}</p>
+          ) : null}
         </div>
       )}
-    </div>
+
+      {/* Done/Update: show status change */}
+      {(isDone || isUpdate) && (
+        <div className="px-3 py-2 text-[12px]">
+          <span className="text-[#888]">{block.input.task_id ? String(block.input.task_id) : title}</span>
+          {block.input.note ? <p className="text-[#777] mt-1">{String(block.input.note)}</p> : null}
+        </div>
+      )}
+
+      {/* Task list */}
+      {taskList.length > 0 ? (
+        <div className="px-3 py-2 space-y-1 max-h-60 overflow-y-auto">
+          {taskList.map((t, i) => (
+            <div key={i} className="flex items-center gap-2 text-[12px]">
+              <span className={`px-1.5 py-0.5 rounded text-[10px] shrink-0 ${STATUS_COLORS[t.status] || 'bg-[#333] text-[#888]'}`}>
+                {t.status}
+              </span>
+              <span className="text-[#bbb] truncate">{t.title}</span>
+              {t.deadline && <span className="text-[10px] text-[#555] shrink-0">{t.deadline}</span>}
+            </div>
+          ))}
+        </div>
+      ) : resultText && !isCreate && !isDone && !isUpdate ? (
+        <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-[#999]'}`}>
+          {resultText}
+        </pre>
+      ) : null}
+
+      {/* Success message */}
+      {(isCreate || isDone) && resultText && !block.isError && !taskList.length && (
+        <div className="px-3 py-1.5 text-[11px] text-green-400/70 border-t border-[#222]">
+          {isDone ? 'Task completed' : 'Task created'}
+        </div>
+      )}
+
+      {block.isError && resultText && (
+        <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-[#222]">
+          {resultText}
+        </pre>
+      )}
+
+      {isRunning && block.result === undefined && (
+        <div className="px-3 py-3 text-[12px] text-[#666] flex items-center gap-2">
+          <Loader2 size={12} className="animate-spin" /> Working...
+        </div>
+      )}
+    </CollapsibleToolBlock>
   );
 }

--- a/web/src/components/Tasks/TaskCard.tsx
+++ b/web/src/components/Tasks/TaskCard.tsx
@@ -1,13 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Calendar, ExternalLink } from 'lucide-react';
 import type { Task } from '../../stores/taskStore';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  in_progress: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  done: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  deferred: 'bg-[#333]/50 text-[#888] border-[#333]',
-};
+import { TASK_STATUS_STYLES as STATUS_STYLES } from '../../constants/statusStyles';
 
 export function TaskCard({ task, onStatusChange }: {
   task: Task;

--- a/web/src/components/Tasks/TaskList.tsx
+++ b/web/src/components/Tasks/TaskList.tsx
@@ -10,12 +10,7 @@ interface Task {
   created_at: string;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  pending: 'text-yellow-400',
-  in_progress: 'text-blue-400',
-  done: 'text-green-400',
-  deferred: 'text-[#888]',
-};
+import { TASK_STATUS_TEXT_COLORS as STATUS_COLORS } from '../../constants/statusStyles';
 
 export function TaskList() {
   const [tasks, setTasks] = useState<Task[]>([]);

--- a/web/src/constants/statusStyles.ts
+++ b/web/src/constants/statusStyles.ts
@@ -1,0 +1,58 @@
+/** Compact badge style — no border, used inside tool blocks. */
+export const TASK_STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-yellow-500/15 text-yellow-400',
+  'in-progress': 'bg-blue-500/15 text-blue-400',
+  'in_progress': 'bg-blue-500/15 text-blue-400',
+  done: 'bg-green-500/15 text-green-400',
+  completed: 'bg-green-500/15 text-green-400',
+  deferred: 'bg-[#333] text-[#888]',
+};
+
+/** Bordered pill style — used on pages and cards. */
+export const TASK_STATUS_STYLES: Record<string, string> = {
+  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
+  in_progress: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
+  done: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
+  deferred: 'bg-[#333]/50 text-[#888] border-[#333]',
+};
+
+/** Compact badge style for plan statuses in tool blocks. */
+export const PLAN_STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-yellow-500/15 text-yellow-400',
+  approved: 'bg-green-500/15 text-green-400',
+  implementing: 'bg-blue-500/15 text-blue-400',
+  declined: 'bg-red-500/15 text-red-400',
+  superseded: 'bg-[#333] text-[#888]',
+};
+
+/** Bordered pill style for plan statuses on pages. */
+export const PLAN_STATUS_STYLES: Record<string, string> = {
+  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
+  approved: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
+  implementing: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
+  declined: 'bg-red-400/10 text-red-400 border-red-400/20',
+  superseded: 'bg-[#333]/50 text-[#888] border-[#333]',
+  failed: 'bg-red-400/10 text-red-400 border-red-400/20',
+};
+
+/** Plan type styles (skill-create, skill-update). */
+export const PLAN_TYPE_STYLES: Record<string, { label: string; className: string }> = {
+  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-purple-400 border-purple-400/20' },
+  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-purple-300 border-purple-400/20' },
+};
+
+/** Bordered pill style for notification statuses. */
+export const NOTIFICATION_STATUS_STYLES: Record<string, string> = {
+  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
+  answered: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
+  expired: 'bg-[#333]/50 text-[#888] border-[#333]',
+  dismissed: 'bg-[#333]/50 text-[#666] border-[#333]',
+};
+
+/** Text-only status colors for inline use (e.g. task lists). */
+export const TASK_STATUS_TEXT_COLORS: Record<string, string> = {
+  pending: 'text-yellow-400',
+  in_progress: 'text-blue-400',
+  done: 'text-green-400',
+  deferred: 'text-[#888]',
+};

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -2,13 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bell, X, CheckCheck, EyeOff } from 'lucide-react';
 import { useNotificationStore, type Notification } from '../stores/notificationStore';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  answered: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  expired: 'bg-[#333]/50 text-[#888] border-[#333]',
-  dismissed: 'bg-[#333]/50 text-[#666] border-[#333]',
-};
+import { NOTIFICATION_STATUS_STYLES as STATUS_STYLES } from '../constants/statusStyles';
 
 const PRIORITY_DOTS: Record<string, string> = {
   urgent: 'bg-red-500',

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -4,20 +4,7 @@ import { ArrowLeft, Check, X, MessageSquare, ExternalLink, Users, ChevronDown } 
 import { usePlanStore } from '../stores/planStore';
 import { MarkdownContent } from '../components/Chat/MarkdownContent';
 import { api } from '../api/client';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  approved: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  implementing: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  declined: 'bg-red-400/10 text-red-400 border-red-400/20',
-  superseded: 'bg-[#333]/50 text-[#888] border-[#333]',
-  failed: 'bg-red-400/10 text-red-400 border-red-400/20',
-};
-
-const TYPE_STYLES: Record<string, { label: string; className: string }> = {
-  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-purple-400 border-purple-400/20' },
-  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-purple-300 border-purple-400/20' },
-};
+import { PLAN_STATUS_STYLES as STATUS_STYLES, PLAN_TYPE_STYLES as TYPE_STYLES } from '../constants/statusStyles';
 
 interface HoaStatus {
   enabled: boolean;

--- a/web/src/pages/PlansPage.tsx
+++ b/web/src/pages/PlansPage.tsx
@@ -2,20 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Lightbulb } from 'lucide-react';
 import { usePlanStore, type Plan } from '../stores/planStore';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  approved: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  implementing: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  declined: 'bg-red-400/10 text-red-400 border-red-400/20',
-  superseded: 'bg-[#333]/50 text-[#888] border-[#333]',
-  failed: 'bg-red-400/10 text-red-400 border-red-400/20',
-};
-
-const TYPE_STYLES: Record<string, { label: string; className: string }> = {
-  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-purple-400 border-purple-400/20' },
-  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-purple-300 border-purple-400/20' },
-};
+import { PLAN_STATUS_STYLES as STATUS_STYLES, PLAN_TYPE_STYLES as TYPE_STYLES } from '../constants/statusStyles';
 
 const FILTERS = [
   { label: 'All', value: '' },

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -3,13 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit3, Eye, Save, Calendar, ExternalLink } from 'lucide-react';
 import { useTaskStore } from '../stores/taskStore';
 import { MarkdownContent } from '../components/Chat/MarkdownContent';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  in_progress: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  done: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  deferred: 'bg-[#333]/50 text-[#888] border-[#333]',
-};
+import { TASK_STATUS_STYLES as STATUS_STYLES } from '../constants/statusStyles';
 
 export function TaskDetailPage() {
   const { taskId } = useParams<{ taskId: string }>();

--- a/web/src/utils/extractResultText.ts
+++ b/web/src/utils/extractResultText.ts
@@ -1,4 +1,18 @@
-/** Extract readable text from MCP content blocks (used by SubagentToolBlock and chatStore). */
+/** Extract readable text from MCP content blocks. */
+export function extractText(result: string): string {
+  try {
+    const parsed = JSON.parse(result);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((b: any) => b.type === 'text')
+        .map((b: any) => b.text)
+        .join('\n');
+    }
+  } catch { /* not JSON */ }
+  return result;
+}
+
+/** Extract readable text from MCP content blocks, filtering agent metadata (used by SubagentToolBlock and chatStore). */
 export function extractResultText(result: string): string {
   try {
     const parsed = JSON.parse(result);


### PR DESCRIPTION
## Summary
- Extract shared `extractText()` into `utils/extractResultText.ts` (was copy-pasted across 6 tool blocks)
- Create `CollapsibleToolBlock` wrapper component, replacing the repeated expand/collapse shell in 9 tool blocks
- Centralize status color constants into `constants/statusStyles.ts` (was duplicated across 9+ files)

Net result: -72 lines, single source of truth for shared patterns.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vite build` succeeds
- [x] Verify tool blocks render correctly in the web UI