### PR TITLE
feat: add NixOS support with flake.nix and installer detection

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774273680,
+        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Nerve — self-hosted AI agent runtime";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            # Core tools
+            uv
+            nodejs_22
+            git
+
+            # Native libs for Python wheel builds (bcrypt, cryptography, aiosqlite, etc.)
+            openssl
+            sqlite
+            libffi
+            pkg-config
+          ];
+
+          env = {
+            # Let uv manage Python — don't pull it from Nix
+            UV_PYTHON_PREFERENCE = "only-managed";
+          };
+
+          shellHook = ''
+            # Help native builds find nix-provided libs
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [ pkgs.openssl pkgs.sqlite pkgs.libffi ]}:$LD_LIBRARY_PATH"
+          '';
+        };
+      });
+}

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,8 @@ detect_os() {
                         DISTRO="arch"; PKG_MGR="pacman" ;;
                     opensuse*)
                         DISTRO="suse"; PKG_MGR="zypper" ;;
+                    nixos)
+                        DISTRO="nixos"; PKG_MGR="nix" ;;
                     *)
                         DISTRO="${ID:-unknown}" ;;
                 esac
@@ -115,6 +117,17 @@ detect_os() {
     esac
 }
 
+# --- NixOS helper ---
+
+nixos_require() {
+    local tool="$1"
+    if command_exists "$tool"; then return 0; fi
+    error "$tool is required but not found."
+    error "On NixOS, enter the dev shell first:  nix develop"
+    error "Or install $tool in your system/user profile."
+    exit 1
+}
+
 # --- Dependency: git ---
 
 ensure_git() {
@@ -122,6 +135,8 @@ ensure_git() {
         success "git $(git --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
         return
     fi
+
+    if [ "$DISTRO" = "nixos" ]; then nixos_require git; return; fi
 
     info "git is not installed"
     if [ "$HAS_SUDO" = "0" ] && [ "$OS" = "linux" ]; then
@@ -161,6 +176,8 @@ ensure_uv() {
         success "uv $(uv --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
         return
     fi
+
+    if [ "$DISTRO" = "nixos" ]; then nixos_require uv; return; fi
 
     info "Installing uv (Python package manager)..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -213,6 +230,11 @@ ensure_python() {
 
     # Last resort: system packages
     warn "uv python install failed. Trying system packages..."
+
+    if [ "$DISTRO" = "nixos" ]; then
+        error "uv python install failed. On NixOS, ensure you're in the dev shell: nix develop"
+        exit 1
+    fi
 
     if [ "$HAS_SUDO" = "0" ] && [ "$OS" = "linux" ]; then
         error "Cannot install Python: no sudo and uv python install failed."
@@ -275,6 +297,8 @@ ensure_node() {
         fi
         warn "Node.js $(node --version) is too old (need v${MIN_NODE_MAJOR}+)"
     fi
+
+    if [ "$DISTRO" = "nixos" ]; then nixos_require node; return; fi
 
     info "Node.js ${MIN_NODE_MAJOR}+ is not installed"
 


### PR DESCRIPTION
## Summary
- Add `flake.nix` with dev shell providing uv, Node.js 22, git, and native libs (openssl, sqlite, libffi) for Python wheel compilation
- Add `.envrc` for direnv integration (`use flake`)
- Detect NixOS in `install.sh` and skip system package installs — guide users to `nix develop` instead
- Python is managed by uv, not Nix (`UV_PYTHON_PREFERENCE=only-managed`)

## Test plan
- [ ] `nix develop` enters shell with uv, node, git available
- [ ] `uv venv && uv pip install -e .` succeeds (native deps compile against nix-provided libs)
- [ ] `cd web && npm ci && npm run build` succeeds
- [ ] `install.sh` on NixOS: detects distro, skips system installs, prints `nix develop` guidance if tools are missing