### PR TITLE
Add lock option for cron jobs

### DIFF
--- a/nerve/cron/jobs.py
+++ b/nerve/cron/jobs.py
@@ -29,6 +29,7 @@ class CronJob:
     reminder_mode: bool = False  # Persistent only: send short reminder instead of full prompt on subsequent runs
     catchup: bool = True  # Fire once on startup if missed while server was down
     enabled: bool = True
+    lock: bool = False  # When True, prevent concurrent runs of this job (next run waits for previous)
     skip_when_idle: list[str] = field(default_factory=list)  # Source names to check; skip run if no new messages
     idle_consumer: str = "inbox"  # Consumer cursor name for the idle check
     show_session_label: bool = True  # Show "Session: ..." in notification messages
@@ -48,6 +49,7 @@ class CronJob:
             reminder_mode=bool(d.get("reminder_mode", False)),
             catchup=d.get("catchup", True),
             enabled=d.get("enabled", True),
+            lock=bool(d.get("lock", False)),
             skip_when_idle=d.get("skip_when_idle", []),
             idle_consumer=d.get("idle_consumer", "inbox"),
             show_session_label=d.get("show_session_label", True),
@@ -100,6 +102,7 @@ def save_jobs(jobs: list[CronJob], jobs_file: Path) -> None:
             "reminder_mode": job.reminder_mode,
             "catchup": job.catchup,
             "enabled": job.enabled,
+            "lock": job.lock,
             "skip_when_idle": job.skip_when_idle,
             "idle_consumer": job.idle_consumer,
             "show_session_label": job.show_session_label,

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -60,6 +60,7 @@ class CronService:
         self.scheduler = AsyncIOScheduler()
         self._jobs: list[CronJob] = []
         self._source_runners: list[SourceRunner] = []
+        self._job_locks: dict[str, asyncio.Lock] = {}
 
     async def start(self) -> None:
         """Load jobs and start the scheduler."""
@@ -346,7 +347,16 @@ class CronService:
         return False
 
     async def _run_job_wrapper(self, job: CronJob) -> None:
-        """Wrapper to run a cron job with logging."""
+        """Wrapper to run a cron job with logging and optional lock."""
+        if job.lock:
+            lock = self._job_locks.setdefault(job.id, asyncio.Lock())
+            async with lock:
+                await self._run_job_inner(job)
+        else:
+            await self._run_job_inner(job)
+
+    async def _run_job_inner(self, job: CronJob) -> None:
+        """Inner implementation of job execution."""
         # Pre-check: skip if no new messages in monitored sources
         if job.skip_when_idle:
             has_pending = await self._has_pending_messages(
@@ -548,6 +558,7 @@ class CronService:
                 "description": job.description,
                 "enabled": job.enabled,
                 "session_mode": job.session_mode,
+                "lock": job.lock,
                 "next_run": next_run.isoformat() if next_run else None,
             })
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -348,3 +348,96 @@ class TestCronJobCatchup:
             "id": "x", "schedule": "1h", "prompt": "p", "catchup": False,
         })
         assert job.catchup is False
+
+
+# ---------------------------------------------------------------------------
+# CronJob.lock field
+# ---------------------------------------------------------------------------
+
+class TestCronJobLock:
+    def test_default_false(self):
+        job = _make_job()
+        assert job.lock is False
+
+    def test_from_dict_default(self):
+        job = CronJob.from_dict({"id": "x", "schedule": "1h", "prompt": "p"})
+        assert job.lock is False
+
+    def test_from_dict_explicit_true(self):
+        job = CronJob.from_dict({
+            "id": "x", "schedule": "1h", "prompt": "p", "lock": True,
+        })
+        assert job.lock is True
+
+
+# ---------------------------------------------------------------------------
+# Job lock (concurrent run serialization)
+# ---------------------------------------------------------------------------
+
+class TestJobLock:
+    @pytest.mark.asyncio
+    async def test_lock_serializes_concurrent_runs(self, cron_service):
+        """When lock=True, overlapping runs execute sequentially."""
+        call_order = []
+
+        async def slow_cron(*args, **kwargs):
+            call_order.append("start")
+            await asyncio.sleep(0.1)
+            call_order.append("end")
+            return "ok"
+
+        cron_service.engine.run_cron = slow_cron
+        job = _make_job(id="locked-job", lock=True)
+
+        await asyncio.gather(
+            cron_service._run_job_wrapper(job),
+            cron_service._run_job_wrapper(job),
+        )
+
+        # With lock: runs are sequential — start/end/start/end
+        assert call_order == ["start", "end", "start", "end"]
+
+    @pytest.mark.asyncio
+    async def test_no_lock_allows_concurrent_runs(self, cron_service):
+        """When lock=False (default), runs can overlap."""
+        call_order = []
+
+        async def slow_cron(*args, **kwargs):
+            call_order.append("start")
+            await asyncio.sleep(0.1)
+            call_order.append("end")
+            return "ok"
+
+        cron_service.engine.run_cron = slow_cron
+        job = _make_job(id="unlocked-job", lock=False)
+
+        await asyncio.gather(
+            cron_service._run_job_wrapper(job),
+            cron_service._run_job_wrapper(job),
+        )
+
+        # Without lock: runs overlap — start/start/end/end
+        assert call_order == ["start", "start", "end", "end"]
+
+    @pytest.mark.asyncio
+    async def test_lock_uses_per_job_locks(self, cron_service):
+        """Different locked jobs get independent locks (don't block each other)."""
+        call_order = []
+
+        async def slow_cron(*args, **kwargs):
+            call_order.append(f"start")
+            await asyncio.sleep(0.1)
+            call_order.append(f"end")
+            return "ok"
+
+        cron_service.engine.run_cron = slow_cron
+        job_a = _make_job(id="job-a", lock=True)
+        job_b = _make_job(id="job-b", lock=True)
+
+        await asyncio.gather(
+            cron_service._run_job_wrapper(job_a),
+            cron_service._run_job_wrapper(job_b),
+        )
+
+        # Different jobs run concurrently even with lock=True
+        assert call_order == ["start", "start", "end", "end"]


### PR DESCRIPTION
## Summary
- Add `lock: bool` field to cron job config (default: `false`)
- When `lock: true`, a per-job `asyncio.Lock` serializes overlapping runs — if the scheduler fires while the previous run is still executing, the new run waits instead of running concurrently
- Exposed in `/api/cron/jobs` list endpoint

## Test plan
- [x] 6 new tests covering lock serialization, concurrent overlap without lock, per-job lock independence, and field parsing
- [x] Full test suite passes (326 tests)

> *Generated by [Nerve](https://github.com/pufit/nerve)*