### PR TITLE
Fix restart, surrogates, condense config, systemd-aware restart

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -51,6 +51,19 @@ except ImportError:
     ThinkingBlock = None
 
 
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def _sanitize_surrogates(s: str) -> str:
+    """Remove orphaned UTF-16 surrogates that break JSON serialization.
+
+    The CLI may truncate large tool output mid-emoji, splitting a surrogate
+    pair and leaving an unpaired high/low surrogate.  These are invalid in
+    JSON and cause 400 errors from the Anthropic API.
+    """
+    return _SURROGATE_RE.sub("\ufffd", s) if _SURROGATE_RE.search(s) else s
+
+
 def _normalize_ts(ts: str) -> str:
     """Normalize timestamp to SQLite-compatible ``YYYY-MM-DD HH:MM:SS`` format.
 
@@ -945,6 +958,8 @@ class AgentEngine:
             if isinstance(block.content, str)
             else json.dumps(block.content, default=str)
         )
+        # Sanitize orphaned surrogates — CLI may truncate output mid-emoji
+        result_content = _sanitize_surrogates(result_content)
         tool_use_id = getattr(block, "tool_use_id", None)
         is_error = getattr(block, "is_error", False)
 

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -366,9 +366,10 @@ def restart(ctx: click.Context) -> None:
         return
 
     # Build the command that `start` would use to launch the daemon.
+    # Always use ``-m nerve`` so the restart works regardless of how *this*
+    # process was invoked (console-script, ``python -m nerve``, etc.).
     verbose = ctx.obj["verbose"]
-    nerve_bin = sys.argv[0]
-    start_cmd_parts = [sys.executable, nerve_bin, "-c", str(config_dir)]
+    start_cmd_parts = [sys.executable, "-m", "nerve", "-c", str(config_dir)]
     if verbose:
         start_cmd_parts.append("-v")
     start_cmd_parts.extend(["start", "--foreground"])

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -100,6 +100,13 @@ def _get_daemon_status() -> tuple[bool, int | None]:
     return False, None
 
 
+# --- Systemd helpers ---
+
+def _is_systemd_managed() -> bool:
+    """Check if the Nerve daemon is running under systemd."""
+    return os.environ.get("INVOCATION_ID") is not None
+
+
 # --- Docker Compose helpers ---
 
 def _is_docker_mode(config) -> bool:
@@ -363,6 +370,17 @@ def restart(ctx: click.Context) -> None:
         if rc == 0:
             click.echo("Nerve restarted (Docker)")
         ctx.exit(rc)
+        return
+
+    # Systemd mode (Restart=always): just kill the process — systemd
+    # will bring it back automatically.
+    if _is_systemd_managed():
+        running, old_pid = _get_daemon_status()
+        if running:
+            click.echo(f"Restarting Nerve (PID {old_pid})... systemd will respawn.")
+            os.kill(old_pid, signal.SIGTERM)
+        else:
+            click.echo("Nerve is not running — systemd will start it shortly.")
         return
 
     # Build the command that `start` would use to launch the daemon.

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -148,6 +148,7 @@ class GmailSyncConfig:
     prompt_hint: str = ""
     model: str = ""
     condense: bool = False
+    condense_prompt: str = ""  # Custom prompt for LLM condensation (overrides default)
 
     @classmethod
     def from_dict(cls, d: dict) -> GmailSyncConfig:
@@ -161,6 +162,7 @@ class GmailSyncConfig:
             prompt_hint=d.get("prompt_hint", ""),
             model=d.get("model", ""),
             condense=d.get("condense", False),
+            condense_prompt=d.get("condense_prompt", ""),
         )
 
 

--- a/nerve/sources/registry.py
+++ b/nerve/sources/registry.py
@@ -73,12 +73,15 @@ def build_source_runners(
             source = GmailSource(account=account, config={
                 "keyring_password": gmail.keyring_password,
             })
+            gmail_condense_cfg = condense_cfg
+            if condense_cfg and gmail.condense_prompt:
+                gmail_condense_cfg = {**condense_cfg, "prompt": gmail.condense_prompt}
             runners.append(SourceRunner(
                 source=source,
                 db=db,
                 batch_size=gmail.batch_size,
                 condense=gmail.condense,
-                condense_config=condense_cfg,
+                condense_config=gmail_condense_cfg,
                 ttl_days=ttl_days,
             ))
             logger.info("Registered source: %s (batch=%d)", source.source_name, gmail.batch_size)

--- a/nerve/sources/runner.py
+++ b/nerve/sources/runner.py
@@ -389,8 +389,9 @@ class SourceRunner:
             async with sem:
                 original_len = len(record.content)
                 try:
+                    condense_prompt = self.condense_config.get("prompt") or _CONDENSE_PROMPT
                     prompt_content = (
-                        f"{_CONDENSE_PROMPT}\n\n"
+                        f"{condense_prompt}\n\n"
                         f"---\n\n"
                         f"{record.content}"
                     )


### PR DESCRIPTION
## Summary
- Fix orphaned UTF-16 surrogates crashing API requests (`_sanitize_surrogates()`)
- Support custom `condense_prompt` per source in config
- Fix restart failing when triggered via Telegram or `python -m nerve`
- Make restart systemd-aware: let systemd respawn instead of helper script

🤖 Generated with [Claude Code](https://claude.com/claude-code)