### PR TITLE
Add bundled skills and platform info to bootstrap

### DIFF
--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -20,7 +20,7 @@ from typing import Any
 import click
 import yaml
 
-from nerve.workspace import initialize_workspace
+from nerve.workspace import initialize_workspace, install_bundled_skills
 
 
 # --- Cron definitions for the wizard ---
@@ -1278,7 +1278,12 @@ class SetupWizard:
         created = initialize_workspace(ws_path, self.choices.mode)
         click.secho(" ✓", fg="green")
 
-        # 2. Patch USER.md with name/timezone if provided (personal mode)
+        # 2. Install bundled skills
+        click.echo("  Installing bundled skills...", nl=False)
+        install_bundled_skills(ws_path)
+        click.secho(" ✓", fg="green")
+
+        # 3. Patch USER.md with name/timezone if provided (personal mode)
         if self.choices.mode == "personal" and self.choices.user_name:
             user_md = ws_path / "USER.md"
             if user_md.exists():
@@ -1287,7 +1292,7 @@ class SetupWizard:
                 content = content.replace("{{TIMEZONE}}", self.choices.timezone)
                 user_md.write_text(content, encoding="utf-8")
 
-        # 3. Patch TOOLS.md with Docker environment layout
+        # 4. Patch TOOLS.md with Docker environment layout
         if self._inside_docker:
             tools_md = ws_path / "TOOLS.md"
             if tools_md.exists():
@@ -1295,7 +1300,7 @@ class SetupWizard:
                 content += _DOCKER_TOOLS_SECTION
                 tools_md.write_text(content, encoding="utf-8")
 
-        # 4. Write TASK.md for worker mode
+        # 5. Write TASK.md for worker mode
         if self.choices.mode == "worker" and self.choices.task_description:
             task_md = ws_path / "TASK.md"
             task_md.write_text(
@@ -1303,29 +1308,29 @@ class SetupWizard:
                 encoding="utf-8",
             )
 
-        # 5. Write config.yaml
+        # 6. Write config.yaml
         click.echo("  Writing config.yaml...", nl=False)
         self._write_config_yaml()
         click.secho(" ✓", fg="green")
 
-        # 6. Write config.local.yaml
+        # 7. Write config.local.yaml
         click.echo("  Writing config.local.yaml...", nl=False)
         self._write_config_local_yaml()
         click.secho(" ✓", fg="green")
 
-        # 7. Create ~/.nerve directory structure
+        # 8. Create ~/.nerve directory structure
         click.echo("  Setting up ~/.nerve/...", nl=False)
         nerve_dir = Path("~/.nerve").expanduser()
         nerve_dir.mkdir(parents=True, exist_ok=True)
         (nerve_dir / "cron").mkdir(parents=True, exist_ok=True)
         click.secho(" ✓", fg="green")
 
-        # 8. Write cron jobs
+        # 9. Write cron jobs
         click.echo("  Configuring cron jobs...", nl=False)
         self._write_cron_jobs()
         click.secho(" ✓", fg="green")
 
-        # 9. Build web UI (server mode only — Docker handles this in entrypoint)
+        # 10. Build web UI (server mode only — Docker handles this in entrypoint)
         if not self._inside_docker:
             self._build_web_ui()
 

--- a/nerve/templates/personal/AGENTS.md
+++ b/nerve/templates/personal/AGENTS.md
@@ -2,6 +2,46 @@
 
 This folder is home. Treat it that way.
 
+## What is Nerve
+
+Nerve is the platform you're running on — a personal AI assistant framework built on Claude. It manages your sessions, memory, tasks, skills, cron jobs, and integrations. Understanding your own platform helps you use it effectively.
+
+### Your Tools
+
+These tools are always available via MCP:
+
+**Memory** — Your persistence layer. You wake up fresh each session; these tools are how you remember.
+- `memorize` — Save a fact to long-term semantic memory (memU)
+- `memory_recall` — Search memU by semantic similarity
+- `conversation_history` — Retrieve past conversations by date range
+- `memory_update` / `memory_delete` — Manage existing memory records
+
+**Tasks** — Track work across sessions.
+- `task_create` / `task_list` / `task_search` — Create, list, find tasks
+- `task_read` / `task_write` — Read and edit task markdown files
+- `task_update` / `task_done` — Update status, mark complete
+
+**Skills** — Reusable procedures and domain knowledge.
+- `skill_list` / `skill_get` — Discover and load skill instructions
+- `skill_create` / `skill_update` — Create or refine skills
+- `skill_read_reference` / `skill_run_script` — Access skill resources
+
+**Plans** — Structured proposal workflow for non-trivial tasks.
+- `plan_propose` — Submit an implementation plan for review
+- `plan_list` / `plan_read` — Browse and inspect plans
+- `plan_approve` / `plan_decline` / `plan_revise` — Manage plan lifecycle
+
+**Notifications** — Async communication with your human.
+- `notify` — Fire-and-forget status update
+- `ask_user` — Question with optional predefined answers; reply auto-injected
+
+**Sync Sources** — Ingest data from external services (Gmail, GitHub, Telegram).
+- `poll_source` / `poll_all_sources` — Fetch new messages
+- `list_sources` / `sync_status` — Check integration health
+- `read_source` — Browse historical messages
+
+Additional tools (Slack, Grafana, Google Workspace, etc.) may be available depending on your configuration. Check `skill_list` for skills that document how to use them.
+
 ## Every Session
 
 Before doing anything else:

--- a/nerve/templates/personal/AGENTS.md
+++ b/nerve/templates/personal/AGENTS.md
@@ -26,9 +26,9 @@ These tools are always available via MCP:
 - `skill_create` / `skill_update` — Create or refine skills
 - `skill_read_reference` / `skill_run_script` — Access skill resources
 
-**Plans** — Structured proposal workflow for non-trivial tasks.
-- `plan_propose` — Submit an implementation plan for review
-- `plan_list` / `plan_read` — Browse and inspect plans
+**Plans** — Async planning for autonomous work (cron jobs, background tasks).
+- `plan_propose` — Submit an implementation plan for async approval
+- `plan_list` / `plan_read` — Browse and inspect pending plans
 - `plan_approve` / `plan_decline` / `plan_revise` — Manage plan lifecycle
 
 **Notifications** — Async communication with your human.

--- a/nerve/templates/skills/nerve-dev/SKILL.md
+++ b/nerve/templates/skills/nerve-dev/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: Nerve Development
+description: >
+  Nerve backend (Python) and frontend (React/TS) development and code contribution.
+  Use when writing Python code for Nerve, fixing bugs, adding features, reviewing Nerve PRs,
+  building the frontend, running tests, or working with the Nerve codebase.
+  Triggers on "nerve code", "nerve PR", "fix nerve", "nerve feature", "nerve test",
+  "build nerve UI", "nerve migration".
+version: 1.0.0
+context: domain
+---
+
+# Nerve Development Skill
+
+## Repository
+
+Nerve lives under the **ClickHouse organization** on GitHub.
+
+- **Upstream:** `git@github.com:ClickHouse/nerve.git`
+- **Issues & PRs:** https://github.com/ClickHouse/nerve
+
+All changes go through PRs — **never push directly to main**.
+
+### Getting Started (Contributors)
+
+```bash
+# 1. Fork on GitHub, then clone your fork
+git clone git@github.com:<your-username>/nerve.git
+cd nerve
+
+# 2. Add upstream remote
+git remote add upstream git@github.com:ClickHouse/nerve.git
+
+# 3. Set up Python environment
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
+# 4. Set up frontend
+cd web && npm install && cd ..
+
+# 5. Verify
+.venv/bin/pytest tests/ -v
+cd web && npm run build
+```
+
+## Project Layout
+
+```
+nerve/
+├── nerve/              # Python backend (FastAPI + Claude Agent SDK)
+│   ├── cli.py          # Click CLI (start/stop/restart/status/logs/doctor)
+│   ├── config.py       # YAML config loader
+│   ├── db/             # SQLite async database package
+│   │   ├── base.py         # Database class (connection, _atomic, FTS, mixin composition)
+│   │   ├── migrations/     # File-based migration system (numbered .py files + runner.py)
+│   │   ├── sessions.py     # SessionStore mixin
+│   │   ├── messages.py     # MessageStore mixin
+│   │   ├── tasks.py        # TaskStore mixin
+│   │   ├── plans.py        # PlanStore mixin
+│   │   ├── notifications.py # NotificationStore mixin
+│   │   ├── sources.py      # SourceStore mixin (inbox, sync/consumer cursors)
+│   │   ├── cron.py         # CronStore mixin
+│   │   ├── skills.py       # SkillStore mixin
+│   │   ├── mcp.py          # McpStore mixin
+│   │   └── audit.py        # AuditStore mixin
+│   ├── bootstrap.py    # Self-configuring onboarding (personal/worker mode)
+│   ├── workspace.py    # Workspace directory management
+│   ├── agent/          # Agent engine, tools, sessions, streaming
+│   ├── gateway/        # FastAPI server, WebSocket, auth
+│   │   ├── server.py       # App factory, lifespan, WebSocket, static serving
+│   │   ├── auth.py         # JWT auth, password verification
+│   │   └── routes/         # Domain-specific REST API route modules
+│   │       ├── __init__.py      # register_all_routes() assembler
+│   │       ├── _deps.py         # RouteDeps container (engine, db, notification_service)
+│   │       ├── sessions.py      # /api/sessions/*, /api/chat
+│   │       ├── tasks.py         # /api/tasks/*
+│   │       ├── plans.py         # /api/plans/*, /api/tasks/{id}/plans
+│   │       ├── skills.py        # /api/skills/*
+│   │       ├── mcp_servers.py   # /api/mcp-servers/*
+│   │       ├── memory.py        # /api/memory/*
+│   │       ├── diagnostics.py   # /api/diagnostics
+│   │       ├── cron.py          # /api/cron/*
+│   │       ├── sources.py       # /api/sources/*
+│   │       ├── notifications.py # /api/notifications/*
+│   │       └── houseofagents.py # /api/houseofagents/*
+│   ├── channels/       # Telegram bot, web UI channel adapters
+│   ├── cron/           # APScheduler job runner
+│   ├── sources/        # Data source adapters (Telegram, Gmail, GitHub)
+│   ├── memory/         # Markdown files + memU semantic indexing
+│   ├── skills/         # Filesystem-based skill loader
+│   ├── tasks/          # Task markdown files + SQLite index
+│   ├── notifications/  # Fire-and-forget + async question delivery
+│   ├── proxy/          # CLIProxyAPI daemon (Docker/worker mode)
+│   ├── houseofagents/  # Optional multi-agent runtime
+│   └── templates/      # Mode templates for nerve init (personal/, worker/)
+├── web/                # React + TypeScript + Vite frontend
+│   ├── src/
+│   │   ├── components/ # React components
+│   │   ├── pages/      # Route pages
+│   │   ├── stores/     # Zustand state stores
+│   │   ├── api/        # API client utilities
+│   │   └── types/      # TypeScript definitions
+│   └── package.json
+├── tests/              # pytest suite
+├── docs/               # Architecture, config, API docs
+├── config.yaml         # Main config (committed)
+├── config.local.yaml   # Secrets (gitignored)
+└── pyproject.toml      # Python project metadata + entry point
+```
+
+## Gateway Routes Architecture
+
+Routes are split into domain-specific modules under `nerve/gateway/routes/`. Each module:
+- Defines its own `router = APIRouter()` with related endpoints
+- Imports `get_deps()` from `_deps.py` to access engine/db/notification_service
+- Keeps Pydantic request models co-located with the handlers
+
+**Adding a new endpoint:** Create or edit the appropriate domain module, add the route handler — it's automatically included via `register_all_routes()` in `__init__.py`.
+
+**Adding a new domain:** Create `routes/new_domain.py` with a `router = APIRouter()`, add endpoints, then import and include it in `routes/__init__.py`.
+
+**Dependency access pattern:**
+```python
+from nerve.gateway.routes._deps import get_deps
+
+@router.get("/api/example")
+async def example(user: dict = Depends(require_auth)):
+    deps = get_deps()
+    # Use deps.engine, deps.db, deps.notification_service
+```
+
+## Development Workflow
+
+**Mandatory order for every change:**
+
+1. **Create a feature branch** — `git checkout -b <username>/<feature-name>` from up-to-date main
+2. **Backend first** — modify Python files under `nerve/`
+3. **Frontend second** — modify TypeScript/React under `web/src/`
+4. **Run tests** — `cd ~/nerve && .venv/bin/pytest tests/ -v`
+5. **Build UI** — `cd ~/nerve/web && npm run build`
+6. **Commit** — focused, scoped commits to the feature branch
+7. **Push to fork** — `git push origin <username>/<feature-name>`
+8. **Create a PR** — open PR targeting `ClickHouse/nerve:main`
+
+### PR Workflow
+
+```bash
+# Keep main up to date
+git fetch upstream
+git checkout main
+git merge upstream/main
+
+# Create feature branch
+git checkout -b <username>/<feature-name>
+
+# ... make changes, test, build ...
+
+# Push to your fork
+git push origin <username>/<feature-name>
+
+# Create PR via gh CLI
+gh pr create --repo ClickHouse/nerve \
+  --title "Short description" \
+  --body "Details of the change"
+```
+
+**PR conventions:**
+- Keep PRs focused — one feature or fix per PR
+- Include test coverage for new functionality
+- Run the full test suite before opening
+
+## Build Commands
+
+### Backend
+
+```bash
+cd ~/nerve
+
+# Run all tests
+.venv/bin/pytest tests/ -v
+
+# Run specific test file or class
+.venv/bin/pytest tests/test_sessions.py -v
+.venv/bin/pytest tests/test_db.py::TestClassName -v
+
+# Install/update dependencies after pyproject.toml changes
+.venv/bin/uv pip install -e .
+
+# Health check
+.venv/bin/nerve doctor
+```
+
+### Frontend
+
+```bash
+cd ~/nerve/web
+
+# Build for production (TypeScript check + Vite bundle → dist/)
+npm run build
+
+# Install dependencies (only if package.json changed)
+npm install
+```
+
+`npm run build` runs `tsc -b && vite build`. Output goes to `web/dist/` which FastAPI serves as static files.
+
+## Critical Rules
+
+1. **NEVER push directly to main.** All changes require a PR to `ClickHouse/nerve`.
+
+2. **ALWAYS run `npm run build` after ANY frontend change.** The server serves pre-built static files from `web/dist/`. Skip the build = changes invisible. This is the #1 gotcha.
+
+3. **ALWAYS run tests before committing.** All tests must pass.
+
+4. **ALWAYS `memory_recall` before modifying Nerve code.** Check for past issues, conventions, and preferences.
+
+5. **Config files:** `config.yaml` (committed) + `config.local.yaml` (gitignored, secrets). Never put API keys in `config.yaml`.
+
+6. **Database migrations:** Each migration is a numbered Python file in `nerve/db/migrations/` (e.g. `v018_your_feature.py`) exporting an `async def up(db)` function. `SCHEMA_VERSION` is derived automatically from the highest migration file number. To add a new migration, create the next numbered file — no other changes needed.
+
+7. **Database domain modules:** Data access methods are organized into mixin classes by domain (sessions, tasks, plans, etc.) under `nerve/db/`. The `Database` class in `base.py` inherits all mixins. Add new methods to the appropriate domain mixin, not to base.py.
+
+8. **Commit style:** Focused, scoped commits. Backend + frontend + docs for one feature = one commit. Don't bundle unrelated changes.
+
+## ⚠️ Security: Pre-Commit Leak Check
+
+**Nerve is open source. This repo is PUBLIC.** Before every commit and push, scan the staged diff for leaked secrets.
+
+**What to scan for:**
+- API keys and tokens (Anthropic, OpenAI, Brave, Telegram, Grafana, any `sk-`, `glsa_`, bearer tokens)
+- Passwords and hashes (bcrypt hashes, JWT secrets, keyring passwords)
+- Personal emails or usernames
+- Service URLs with credentials or internal hostnames
+- Telegram API credentials (`api_id`, `api_hash`, `bot_token`)
+- Anything that looks like it belongs in `config.local.yaml`
+
+**Safe to commit:**
+- Generic field names with empty defaults (`anthropic_api_key: str = ""`)
+- References to `config.local.yaml` in comments/docs
+- Example placeholder values in docs
+
+**If anything leaks:** Do NOT push. Unstage the file, fix it, re-scan. If already pushed, the secret must be rotated immediately.
+
+## Restarting Nerve
+
+```bash
+nerve restart
+
+# If that fails:
+nerve stop && nerve start
+
+# Verify:
+nerve status
+nerve logs
+```
+
+Key paths:
+- PID: `~/.nerve/nerve.pid`
+- Log: `~/.nerve/nerve.log`
+- DB: `~/.nerve/nerve.db`
+
+## Key Tech Stack
+
+| Layer | Tech |
+|-------|------|
+| Backend | Python 3.12+, FastAPI, Uvicorn, aiosqlite |
+| AI | Claude Agent SDK, Anthropic API |
+| Scheduler | APScheduler |
+| Telegram | python-telegram-bot + Telethon |
+| Auth | JWT (pyjwt) + bcrypt |
+| Frontend | React 19, TypeScript 5.9, Vite 7, Tailwind 4 |
+| State | Zustand |
+| Tests | pytest + pytest-asyncio |

--- a/nerve/templates/worker/AGENTS.md
+++ b/nerve/templates/worker/AGENTS.md
@@ -1,5 +1,44 @@
 # AGENTS.md — Worker Guidelines
 
+## What is Nerve
+
+Nerve is the platform you're running on — a task-driven AI worker framework built on Claude. It manages your sessions, memory, tasks, skills, and integrations. Understanding your own platform helps you work effectively.
+
+### Your Tools
+
+These tools are always available via MCP:
+
+**Memory** — Your persistence layer. You wake up fresh each session; these tools are how you remember.
+- `memorize` — Save a fact to long-term semantic memory (memU)
+- `memory_recall` — Search memU by semantic similarity
+- `conversation_history` — Retrieve past conversations by date range
+- `memory_update` / `memory_delete` — Manage existing memory records
+
+**Tasks** — Track work across sessions.
+- `task_create` / `task_list` / `task_search` — Create, list, find tasks
+- `task_read` / `task_write` — Read and edit task markdown files
+- `task_update` / `task_done` — Update status, mark complete
+
+**Skills** — Reusable procedures and domain knowledge.
+- `skill_list` / `skill_get` — Discover and load skill instructions
+- `skill_create` / `skill_update` — Create or refine skills
+- `skill_read_reference` / `skill_run_script` — Access skill resources
+
+**Plans** — Structured proposal workflow for non-trivial tasks.
+- `plan_propose` — Submit an implementation plan for review
+- `plan_list` / `plan_read` — Browse and inspect plans
+- `plan_approve` / `plan_decline` / `plan_revise` — Manage plan lifecycle
+
+**Notifications** — Async communication with your reviewer.
+- `notify` — Fire-and-forget status update
+- `ask_user` — Question with optional predefined answers; reply auto-injected
+
+**Sync Sources** — Ingest data from external services.
+- `poll_source` / `poll_all_sources` — Fetch new messages
+- `list_sources` / `sync_status` — Check integration health
+
+Additional tools may be available depending on configuration. Check `skill_list` for skills that document how to use them.
+
 ## Every Session
 
 Before doing anything:

--- a/nerve/templates/worker/AGENTS.md
+++ b/nerve/templates/worker/AGENTS.md
@@ -24,9 +24,9 @@ These tools are always available via MCP:
 - `skill_create` / `skill_update` — Create or refine skills
 - `skill_read_reference` / `skill_run_script` — Access skill resources
 
-**Plans** — Structured proposal workflow for non-trivial tasks.
-- `plan_propose` — Submit an implementation plan for review
-- `plan_list` / `plan_read` — Browse and inspect plans
+**Plans** — Async planning for autonomous work (cron jobs, background tasks).
+- `plan_propose` — Submit an implementation plan for async approval
+- `plan_list` / `plan_read` — Browse and inspect pending plans
 - `plan_approve` / `plan_decline` / `plan_revise` — Manage plan lifecycle
 
 **Notifications** — Async communication with your reviewer.

--- a/nerve/workspace.py
+++ b/nerve/workspace.py
@@ -61,6 +61,70 @@ def get_expected_files(mode: str) -> list[str]:
     return [filename for filename, _ in read_manifest(mode)]
 
 
+def _get_bundled_skills_dir() -> Path | None:
+    """Resolve the bundled skills directory (nerve/templates/skills/).
+
+    Returns None if no bundled skills directory exists.
+    """
+    # Try importlib.resources first (works for installed packages)
+    try:
+        ref = importlib.resources.files("nerve") / "templates" / "skills"
+        skills_path = Path(str(ref))
+        if skills_path.is_dir():
+            return skills_path
+    except (TypeError, FileNotFoundError):
+        pass
+
+    # Fallback: resolve relative to this file (development mode)
+    skills_path = Path(__file__).parent / "templates" / "skills"
+    if skills_path.is_dir():
+        return skills_path
+
+    return None
+
+
+def install_bundled_skills(workspace_path: Path) -> list[str]:
+    """Copy bundled skills into the workspace skills directory.
+
+    Only copies skills that don't already exist — never overwrites.
+    Each subdirectory of templates/skills/ that contains a SKILL.md
+    is treated as a skill to install.
+
+    Args:
+        workspace_path: Target workspace directory.
+
+    Returns:
+        List of skill IDs that were installed.
+    """
+    bundled_dir = _get_bundled_skills_dir()
+    if bundled_dir is None:
+        logger.debug("No bundled skills directory found — skipping")
+        return []
+
+    skills_dir = workspace_path / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    installed = []
+    for skill_src in sorted(bundled_dir.iterdir()):
+        if not skill_src.is_dir():
+            continue
+        if not (skill_src / "SKILL.md").exists():
+            continue
+
+        skill_id = skill_src.name
+        skill_dst = skills_dir / skill_id
+
+        if skill_dst.exists():
+            logger.debug("Skipping skill %s — already exists", skill_id)
+            continue
+
+        shutil.copytree(skill_src, skill_dst)
+        logger.info("Installed bundled skill: %s", skill_id)
+        installed.append(skill_id)
+
+    return installed
+
+
 def initialize_workspace(workspace_path: Path, mode: str) -> list[str]:
     """Copy mode-appropriate template files into a workspace directory.
 


### PR DESCRIPTION
## Summary
- Ship `nerve-dev` as a pre-installed skill so fresh workspaces have Nerve development knowledge out of the box
- Add "What is Nerve" section with native MCP tools reference to both personal and worker AGENTS.md templates
- Add `install_bundled_skills()` infrastructure to `workspace.py` — non-destructive, copies skill dirs from `templates/skills/` to `workspace/skills/`

## Test plan
- [x] All 55 bootstrap tests pass
- [x] Manual verification: `install_bundled_skills()` installs `nerve-dev` to fresh workspace
- [x] Idempotency: second run skips already-installed skills
- [ ] Run `nerve init` end-to-end in a temp directory

> *Generated by [Nerve](https://github.com/pufit/nerve)*