### PR TITLE
Add AWS Bedrock provider support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,12 +5,23 @@
 workspace: ~/nerve-workspace    # Path to workspace with SOUL.md, MEMORY.md, etc.
 timezone: America/New_York
 
+# Provider — how Nerve connects to Claude (default: anthropic)
+# provider:
+#   type: bedrock              # "anthropic" or "bedrock"
+#   aws_region: us-east-1      # AWS region for Bedrock
+#   # aws_profile: ""          # Optional: AWS SSO profile name
+
 # Agent
 agent:
   model: claude-opus-4-6         # Primary model for conversations
   cron_model: claude-sonnet-4-6  # Cheaper model for cron jobs
+  title_model: claude-haiku-4-5-20251001  # Session title generation
   max_turns: 50                  # Max agentic turns per request
   max_concurrent: 4              # Max concurrent agent sessions
+  # For Bedrock, use model IDs like:
+  #   model: us.anthropic.claude-opus-4-6-v1
+  #   cron_model: us.anthropic.claude-sonnet-4-6
+  #   title_model: us.anthropic.claude-haiku-4-5-20251001-v1:0
 
 # Gateway
 gateway:

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -671,9 +671,19 @@ class AgentEngine:
     def _build_env(self) -> dict[str, str]:
         """Build environment variables for the SDK subprocess."""
         env: dict[str, str] = {}
-        api_key = self.config.effective_api_key
-        if api_key:
-            env["ANTHROPIC_API_KEY"] = api_key
+        if self.config.provider.is_bedrock:
+            env["CLAUDE_CODE_USE_BEDROCK"] = "1"
+            if self.config.provider.aws_region:
+                env["AWS_REGION"] = self.config.provider.aws_region
+            if self.config.provider.aws_profile:
+                env["AWS_PROFILE"] = self.config.provider.aws_profile
+            if self.config.provider.aws_access_key_id:
+                env["AWS_ACCESS_KEY_ID"] = self.config.provider.aws_access_key_id
+                env["AWS_SECRET_ACCESS_KEY"] = self.config.provider.aws_secret_access_key
+        else:
+            api_key = self.config.effective_api_key
+            if api_key:
+                env["ANTHROPIC_API_KEY"] = api_key
         return env
 
     def _build_mcp_servers(self, session_id: str) -> dict[str, Any]:
@@ -1765,50 +1775,37 @@ class AgentEngine:
     async def _generate_session_title(
         self, session_id: str, first_message: str,
     ) -> None:
-        """Generate a meaningful short title for a session using Haiku."""
+        """Generate a meaningful short title for a session using a fast model."""
         try:
-            import httpx
-            api_key = self.config.effective_api_key
-            if not api_key:
+            # Skip if no credentials are configured (neither API key nor Bedrock)
+            if not self.config.provider.is_bedrock and not self.config.effective_api_key:
                 return
 
-            base_url = self.config.anthropic_api_base_url
-            async with httpx.AsyncClient() as http_client:
-                resp = await http_client.post(
-                    f"{base_url}messages",
-                    headers={
-                        "x-api-key": api_key,
-                        "anthropic-version": "2023-06-01",
-                        "content-type": "application/json",
-                    },
-                    json={
-                        "model": "claude-haiku-4-5-20251001",
-                        "max_tokens": 30,
-                        "messages": [{
-                            "role": "user",
-                            "content": (
-                                "Generate a short title (3-5 words, no quotes)"
-                                " for a conversation that starts with:\n\n"
-                                f"{first_message[:200]}"
-                            ),
-                        }],
-                    },
-                    timeout=10,
+            client = self.config.create_anthropic_client(timeout=10.0)
+            response = client.messages.create(
+                model=self.config.agent.title_model,
+                max_tokens=30,
+                messages=[{
+                    "role": "user",
+                    "content": (
+                        "Generate a short title (3-5 words, no quotes)"
+                        " for a conversation that starts with:\n\n"
+                        f"{first_message[:200]}"
+                    ),
+                }],
+            )
+            title = response.content[0].text.strip().strip('"\'').lstrip('#').strip()
+            if title and len(title) < 60:
+                await self.db.update_session_title(session_id, title)
+                await broadcaster.broadcast(session_id, {
+                    "type": "session_updated",
+                    "session_id": session_id,
+                    "title": title,
+                })
+                logger.info(
+                    "Generated title for session %s: %s",
+                    session_id, title,
                 )
-                if resp.status_code == 200:
-                    data = resp.json()
-                    title = data["content"][0]["text"].strip().strip('"\'').lstrip('#').strip()
-                    if title and len(title) < 60:
-                        await self.db.update_session_title(session_id, title)
-                        await broadcaster.broadcast(session_id, {
-                            "type": "session_updated",
-                            "session_id": session_id,
-                            "title": title,
-                        })
-                        logger.info(
-                            "Generated title for session %s: %s",
-                            session_id, title,
-                        )
         except Exception as e:
             logger.warning("Failed to generate session title: %s", e)
 

--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -180,6 +180,10 @@ class SetupChoices:
     anthropic_api_key: str = ""
     openai_api_key: str = ""
     use_proxy: bool = False  # Use CLIProxyAPI instead of direct API key
+    # Provider
+    provider_type: str = "anthropic"  # "anthropic" | "bedrock"
+    aws_region: str = ""
+    aws_profile: str = ""
     workspace_path: Path = field(default_factory=lambda: Path("~/nerve-workspace"))
     timezone: str = "America/New_York"
     user_name: str = ""
@@ -725,11 +729,14 @@ class SetupWizard:
         click.echo()
         click.secho("  1) Anthropic API key  — direct access (requires sk-ant-... key)", dim=True)
         click.secho("  2) Claude Code proxy  — routes through your Claude subscription", dim=True)
+        click.secho("  3) AWS Bedrock        — uses AWS IAM credentials", dim=True)
         click.echo()
 
-        auth_mode = click.prompt("Choose", type=click.Choice(["1", "2"]), default="1")
+        auth_mode = click.prompt("Choose", type=click.Choice(["1", "2", "3"]), default="1")
 
-        if auth_mode == "2":
+        if auth_mode == "3":
+            self._step_bedrock_setup()
+        elif auth_mode == "2":
             self._step_proxy_setup()
         else:
             self._step_api_key_direct()
@@ -751,6 +758,37 @@ class SetupWizard:
                 self.choices.anthropic_api_key = key
                 break
             click.secho("  Invalid key — should start with 'sk-ant-'. Try again.", fg="yellow")
+
+    def _step_bedrock_setup(self) -> None:
+        """Configure AWS Bedrock as the provider."""
+        click.echo()
+        click.secho(
+            "AWS Bedrock routes API calls through your AWS account.\n"
+            "On EC2/ECS/EKS, IAM roles provide credentials automatically.\n"
+            "Outside AWS, configure credentials via AWS CLI or environment variables.",
+            dim=True,
+        )
+        click.echo()
+
+        self.choices.provider_type = "bedrock"
+
+        region = click.prompt("AWS Region", default="us-east-1")
+        self.choices.aws_region = region
+
+        profile = click.prompt(
+            "AWS Profile (Enter to skip — use IAM role or env vars)", default="",
+        )
+        if profile:
+            self.choices.aws_profile = profile
+
+        click.echo()
+        click.secho(
+            "  Make sure you have enabled Claude model access in the\n"
+            "  AWS Bedrock console for your region.",
+            fg="yellow",
+        )
+        click.echo()
+        click.secho("  → Bedrock provider configured.", fg="green")
 
     def _step_proxy_setup(self) -> None:
         """Set up CLIProxyAPI for Claude Code OAuth proxy."""
@@ -1192,7 +1230,9 @@ class SetupWizard:
         click.echo()
 
         ws = str(self.choices.workspace_path)
-        if self.choices.claude_oauth_token:
+        if self.choices.provider_type == "bedrock":
+            api_status = f"Bedrock ✓ ({self.choices.aws_region})"
+        elif self.choices.claude_oauth_token:
             api_status = "OAuth ✓"
         elif self.choices.use_proxy:
             api_status = "Proxy ✓"
@@ -1450,6 +1490,22 @@ class SetupWizard:
                 "github_events": {"enabled": self.choices.github_sync},
             }
 
+        # Provider configuration
+        if self.choices.provider_type == "bedrock":
+            config["provider"] = {
+                "type": "bedrock",
+                "aws_region": self.choices.aws_region,
+            }
+            if self.choices.aws_profile:
+                config["provider"]["aws_profile"] = self.choices.aws_profile
+            # Override model names to Bedrock IDs
+            config["agent"]["model"] = "us.anthropic.claude-opus-4-6-v1"
+            config["agent"]["cron_model"] = "us.anthropic.claude-sonnet-4-6"
+            config["agent"]["title_model"] = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+            config["memory"]["recall_model"] = "us.anthropic.claude-sonnet-4-6"
+            config["memory"]["memorize_model"] = "us.anthropic.claude-sonnet-4-6"
+            config["memory"]["fast_model"] = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
         if self.choices.use_proxy:
             config["proxy"] = {
                 "enabled": True,
@@ -1645,24 +1701,37 @@ def run_non_interactive(config_dir: Path) -> SetupChoices:
     """Non-interactive setup using environment variables. For Docker."""
     choices = SetupChoices()
 
-    # API auth: OAuth token, API key, or proxy mode.
-    # Follows priority waterfall — first match wins.
-    use_proxy = os.environ.get("NERVE_USE_PROXY", "") == "1"
-    choices.use_proxy = use_proxy
-
-    claude_oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
-
-    if claude_oauth_token:
-        choices.claude_oauth_token = claude_oauth_token
-    if api_key:
-        choices.anthropic_api_key = api_key
-
-    if not use_proxy and not api_key and not claude_oauth_token:
-        raise click.ClickException(
-            "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN environment variable is required "
-            "for non-interactive setup (or set NERVE_USE_PROXY=1 to use CLIProxyAPI instead)"
+    # Provider detection — check before API key requirements.
+    provider = os.environ.get("NERVE_PROVIDER", "anthropic")
+    if provider == "bedrock":
+        choices.provider_type = "bedrock"
+        choices.aws_region = os.environ.get(
+            "NERVE_AWS_REGION", os.environ.get("AWS_REGION", "us-east-1"),
         )
+        choices.aws_profile = os.environ.get(
+            "NERVE_AWS_PROFILE", os.environ.get("AWS_PROFILE", ""),
+        )
+        # Bedrock uses IAM — no Anthropic API key needed
+    else:
+        # API auth: OAuth token, API key, or proxy mode.
+        # Follows priority waterfall — first match wins.
+        use_proxy = os.environ.get("NERVE_USE_PROXY", "") == "1"
+        choices.use_proxy = use_proxy
+
+        claude_oauth_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "")
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+
+        if claude_oauth_token:
+            choices.claude_oauth_token = claude_oauth_token
+        if api_key:
+            choices.anthropic_api_key = api_key
+
+        if not use_proxy and not api_key and not claude_oauth_token:
+            raise click.ClickException(
+                "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN environment variable is required "
+                "for non-interactive setup (or set NERVE_USE_PROXY=1 to use CLIProxyAPI, "
+                "or set NERVE_PROVIDER=bedrock for AWS Bedrock)"
+            )
 
     # GitHub token (from host extraction or env var)
     gh_token = os.environ.get("GH_TOKEN", "")

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -67,9 +67,41 @@ class GatewayConfig:
 
 
 @dataclass
+class ProviderConfig:
+    """LLM provider configuration — controls how Nerve connects to Claude.
+
+    Supported types:
+      - "anthropic" (default): Direct Anthropic API or Claude Code proxy.
+      - "bedrock": AWS Bedrock. Uses IAM role on EC2/ECS/EKS automatically;
+        outside AWS, configure credentials via AWS CLI, env vars, or explicit keys.
+    """
+
+    type: str = "anthropic"             # "anthropic" | "bedrock"
+    aws_region: str = ""                # Bedrock region (falls back to us-east-1)
+    aws_profile: str = ""               # AWS SSO profile name (optional)
+    aws_access_key_id: str = ""         # Explicit creds (optional — IAM role preferred)
+    aws_secret_access_key: str = ""     # Explicit creds (optional)
+
+    @property
+    def is_bedrock(self) -> bool:
+        return self.type == "bedrock"
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ProviderConfig:
+        return cls(
+            type=d.get("type", "anthropic"),
+            aws_region=d.get("aws_region", ""),
+            aws_profile=d.get("aws_profile", ""),
+            aws_access_key_id=d.get("aws_access_key_id", ""),
+            aws_secret_access_key=d.get("aws_secret_access_key", ""),
+        )
+
+
+@dataclass
 class AgentConfig:
     model: str = "claude-opus-4-6"
     cron_model: str = "claude-sonnet-4-6"
+    title_model: str = "claude-haiku-4-5-20251001"  # Session title generation
     max_turns: int = 100
     max_concurrent: int = 4
     thinking: str = "max"       # max, high, medium, low, disabled, adaptive, or number (budget_tokens)
@@ -81,6 +113,7 @@ class AgentConfig:
         return cls(
             model=d.get("model", "claude-opus-4-6"),
             cron_model=d.get("cron_model", "claude-sonnet-4-6"),
+            title_model=d.get("title_model", "claude-haiku-4-5-20251001"),
             max_turns=d.get("max_turns", 100),
             max_concurrent=d.get("max_concurrent", 4),
             thinking=str(d.get("thinking", "max")),
@@ -558,6 +591,7 @@ class NerveConfig:
     deployment: str = "server"            # "server" or "docker"
     quiet_start: str = "02:00"            # HH:MM — start of quiet period (local timezone)
     quiet_end: str = "08:00"              # HH:MM — end of quiet period (local timezone)
+    provider: ProviderConfig = field(default_factory=ProviderConfig)
     gateway: GatewayConfig = field(default_factory=GatewayConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
     telegram: TelegramConfig = field(default_factory=TelegramConfig)
@@ -581,6 +615,8 @@ class NerveConfig:
     @property
     def anthropic_api_base_url(self) -> str:
         """Effective Anthropic API base URL — proxy or direct."""
+        if self.provider.is_bedrock:
+            return ""  # Bedrock doesn't use Anthropic base URL
         if self.proxy.enabled:
             return f"http://{self.proxy.host}:{self.proxy.port}/v1/"
         return "https://api.anthropic.com/v1/"
@@ -588,9 +624,70 @@ class NerveConfig:
     @property
     def effective_api_key(self) -> str:
         """Effective API key — proxy's local key or real Anthropic key."""
+        if self.provider.is_bedrock:
+            return ""  # Bedrock uses IAM, not API keys
         if self.proxy.enabled:
             return self.proxy.api_key
         return self.anthropic_api_key
+
+    def create_anthropic_client(self, timeout: float = 60.0) -> Any:
+        """Create an Anthropic client based on the configured provider.
+
+        Returns AnthropicBedrock when provider is "bedrock", otherwise
+        a standard Anthropic client using the effective API key and base URL.
+        """
+        import anthropic
+
+        if self.provider.is_bedrock:
+            from anthropic import AnthropicBedrock
+            kwargs: dict[str, Any] = {"timeout": timeout}
+            if self.provider.aws_region:
+                kwargs["aws_region"] = self.provider.aws_region
+            if self.provider.aws_profile:
+                kwargs["aws_profile"] = self.provider.aws_profile
+            if self.provider.aws_access_key_id:
+                kwargs["aws_access_key"] = self.provider.aws_access_key_id
+                kwargs["aws_secret_key"] = self.provider.aws_secret_access_key
+            return AnthropicBedrock(**kwargs)
+
+        # Default: direct Anthropic API (or proxy)
+        base_url = self.anthropic_api_base_url.rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+        return anthropic.Anthropic(
+            api_key=self.effective_api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+
+    def create_async_anthropic_client(self, timeout: float = 60.0) -> Any:
+        """Create an async Anthropic client based on the configured provider.
+
+        Returns AsyncAnthropicBedrock when provider is "bedrock", otherwise
+        a standard AsyncAnthropic client.
+        """
+        import anthropic
+
+        if self.provider.is_bedrock:
+            from anthropic import AsyncAnthropicBedrock
+            kwargs: dict[str, Any] = {"timeout": timeout}
+            if self.provider.aws_region:
+                kwargs["aws_region"] = self.provider.aws_region
+            if self.provider.aws_profile:
+                kwargs["aws_profile"] = self.provider.aws_profile
+            if self.provider.aws_access_key_id:
+                kwargs["aws_access_key"] = self.provider.aws_access_key_id
+                kwargs["aws_secret_key"] = self.provider.aws_secret_access_key
+            return AsyncAnthropicBedrock(**kwargs)
+
+        base_url = self.anthropic_api_base_url.rstrip("/")
+        if base_url.endswith("/v1"):
+            base_url = base_url[:-3]
+        return anthropic.AsyncAnthropic(
+            api_key=self.effective_api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
 
     @classmethod
     def from_dict(cls, d: dict) -> NerveConfig:
@@ -600,6 +697,7 @@ class NerveConfig:
             deployment=d.get("deployment", "server"),
             quiet_start=d.get("quiet_start", "02:00"),
             quiet_end=d.get("quiet_end", "08:00"),
+            provider=ProviderConfig.from_dict(d.get("provider", {})),
             gateway=GatewayConfig.from_dict(d.get("gateway", {})),
             agent=AgentConfig.from_dict(d.get("agent", {})),
             telegram=TelegramConfig.from_dict(d.get("telegram", {})),

--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -1654,19 +1654,14 @@ class MemUBridge:
             logger.warning("Event date resolution failed: %s", e)
 
     def _get_anthropic_client(self) -> Any:
-        """Get or create the shared sync Anthropic client."""
+        """Get or create the shared sync Anthropic client.
+
+        Uses the config factory method which returns AnthropicBedrock
+        when provider is "bedrock", or standard Anthropic otherwise.
+        """
         if self._anthropic_client is not None:
             return self._anthropic_client
-        import anthropic
-        base_url = self.config.anthropic_api_base_url.rstrip("/")
-        # Strip /v1/ suffix — Anthropic SDK prepends it internally.
-        if base_url.endswith("/v1"):
-            base_url = base_url[:-3]
-        self._anthropic_client = anthropic.Anthropic(
-            api_key=self.config.effective_api_key,
-            base_url=base_url,
-            timeout=60.0,
-        )
+        self._anthropic_client = self.config.create_anthropic_client(timeout=60.0)
         return self._anthropic_client
 
     def _resolve_dates_via_llm(

--- a/nerve/sources/registry.py
+++ b/nerve/sources/registry.py
@@ -33,15 +33,24 @@ def build_source_runners(
     runners: list[SourceRunner] = []
     ttl_days = config.sync.message_ttl_days
 
-    # Build condense config from API credentials
+    # Build condense config from API credentials / provider
     condense_cfg: dict[str, Any] | None = None
-    if config.effective_api_key and config.memory.fast_model:
-        condense_cfg = {
-            "api_key": config.effective_api_key,
-            "model": config.memory.fast_model,
-            "base_url": config.anthropic_api_base_url,
-            "use_proxy": config.proxy.enabled,
-        }
+    if config.memory.fast_model:
+        if config.provider.is_bedrock:
+            condense_cfg = {
+                "provider": "bedrock",
+                "aws_region": config.provider.aws_region,
+                "aws_profile": config.provider.aws_profile,
+                "model": config.memory.fast_model,
+            }
+        elif config.effective_api_key:
+            condense_cfg = {
+                "provider": "anthropic",
+                "api_key": config.effective_api_key,
+                "model": config.memory.fast_model,
+                "base_url": config.anthropic_api_base_url,
+                "use_proxy": config.proxy.enabled,
+            }
 
     # Telegram
     tg = config.sync.telegram

--- a/nerve/sources/runner.py
+++ b/nerve/sources/runner.py
@@ -290,32 +290,47 @@ class SourceRunner:
     # ------------------------------------------------------------------
 
     async def _get_condense_client(self) -> Any | None:
-        """Get or create the shared AsyncAnthropic client for condensation.
+        """Get or create the shared async Anthropic client for condensation.
 
         Returns None when proxy mode is active (uses httpx directly).
+        Supports both direct Anthropic API and AWS Bedrock providers.
         """
         if self.condense_config.get("use_proxy"):
             return None  # Proxy uses OpenAI-compatible httpx calls
         if self._condense_client is not None:
             return self._condense_client
-        api_key = self.condense_config.get("api_key")
-        if not api_key:
-            return None
+
+        provider = self.condense_config.get("provider", "anthropic")
+
         try:
             import anthropic
         except ImportError:
             logger.warning("anthropic package not available for content condensation")
             return None
-        base_url = self.condense_config.get("base_url")
-        kwargs: dict[str, Any] = {"api_key": api_key}
-        if base_url:
-            # Strip /v1/ suffix — Anthropic SDK prepends it internally,
-            # so including it here causes /v1/v1/messages (404).
-            url = base_url.rstrip("/")
-            if url.endswith("/v1"):
-                url = url[:-3]
-            kwargs["base_url"] = url
-        self._condense_client = anthropic.AsyncAnthropic(**kwargs)
+
+        if provider == "bedrock":
+            from anthropic import AsyncAnthropicBedrock
+            kwargs: dict[str, Any] = {}
+            if self.condense_config.get("aws_region"):
+                kwargs["aws_region"] = self.condense_config["aws_region"]
+            if self.condense_config.get("aws_profile"):
+                kwargs["aws_profile"] = self.condense_config["aws_profile"]
+            self._condense_client = AsyncAnthropicBedrock(**kwargs)
+        else:
+            api_key = self.condense_config.get("api_key")
+            if not api_key:
+                return None
+            kwargs = {"api_key": api_key}
+            base_url = self.condense_config.get("base_url")
+            if base_url:
+                # Strip /v1/ suffix — Anthropic SDK prepends it internally,
+                # so including it here causes /v1/v1/messages (404).
+                url = base_url.rstrip("/")
+                if url.endswith("/v1"):
+                    url = url[:-3]
+                kwargs["base_url"] = url
+            self._condense_client = anthropic.AsyncAnthropic(**kwargs)
+
         return self._condense_client
 
     async def _condense_via_proxy(


### PR DESCRIPTION
## Summary

- Adds AWS Bedrock as a first-class LLM provider alongside direct Anthropic API
- All 4 API call paths now support Bedrock: SDK agent sessions, memU memory ops, source condensation, and session title generation
- On AWS (EC2/ECS/EKS), only an IAM role with `bedrock:InvokeModel*` is needed — zero API keys
- Bootstrap wizard updated with Bedrock option (interactive + non-interactive via `NERVE_PROVIDER=bedrock`)

## Changes

**`nerve/config.py`** — New `ProviderConfig` dataclass (`type`, `aws_region`, `aws_profile`, optional explicit creds). `create_anthropic_client()` / `create_async_anthropic_client()` factory methods on `NerveConfig` that return `AnthropicBedrock` or standard `Anthropic` based on config. New `title_model` field on `AgentConfig`.

**`nerve/agent/engine.py`** — `_build_env()` sets `CLAUDE_CODE_USE_BEDROCK=1` + AWS env vars for the CLI subprocess. Title generation rewritten to use SDK client (removes raw httpx, uses configurable `title_model`).

**`nerve/memory/memu_bridge.py`** — `_get_anthropic_client()` delegates to config factory.

**`nerve/sources/runner.py`** + **`registry.py`** — Condense client supports `provider=bedrock` → `AsyncAnthropicBedrock`.

**`nerve/bootstrap.py`** — Option 3 (Bedrock) in wizard, `_step_bedrock_setup()`, Bedrock model IDs in generated config, `NERVE_PROVIDER=bedrock` for non-interactive/Docker setup.

## Usage

```yaml
# config.yaml
provider:
  type: bedrock
  aws_region: us-east-1

agent:
  model: us.anthropic.claude-opus-4-6-v1
  cron_model: us.anthropic.claude-sonnet-4-6
```

## Test plan

- [x] `pytest tests/ -v` — 325 passed (1 pre-existing HoA failure, unrelated)
- [ ] Verify config parsing: `provider:` YAML block → `ProviderConfig` with defaults
- [ ] Verify `_build_env()` sets `CLAUDE_CODE_USE_BEDROCK=1` when provider is bedrock
- [ ] End-to-end on EC2 with IAM role + Bedrock model access

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*