### PR TITLE
Improve light theme: add accent/semantic tokens, fix hardcoded colors

### DIFF
--- a/web/src/components/Auth/LoginPage.tsx
+++ b/web/src/components/Auth/LoginPage.tsx
@@ -23,13 +23,13 @@ export function LoginPage() {
           onChange={(e) => setPassword(e.target.value)}
           placeholder="Password"
           autoFocus
-          className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded text-text outline-none focus:border-[#6366f1] mb-4"
+          className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded text-text outline-none focus:border-accent mb-4"
         />
         {error && <p className="text-red-400 text-sm mb-3">{error}</p>}
         <button
           type="submit"
           disabled={loading}
-          className="w-full py-2 bg-[#6366f1] hover:bg-[#818cf8] text-white rounded font-medium disabled:opacity-50 cursor-pointer"
+          className="w-full py-2 bg-accent hover:bg-accent-hover text-white rounded font-medium disabled:opacity-50 cursor-pointer"
         >
           {loading ? '...' : 'Login'}
         </button>

--- a/web/src/components/Chat/AssistantMessage.tsx
+++ b/web/src/components/Chat/AssistantMessage.tsx
@@ -3,10 +3,10 @@ import { BlockRenderer } from './BlockRenderer';
 
 export function AssistantMessage({ message }: { message: ChatMessage }) {
   return (
-    <div className="py-4 px-5 bg-bg-sunken" data-role="assistant">
+    <div className="py-4 px-5 msg-assistant" data-role="assistant">
       <div className="max-w-3xl mx-auto">
         <div className="flex gap-3">
-          <div className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium shrink-0 mt-0.5 bg-[#6366f1]/20 text-[#6366f1]">
+          <div className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium shrink-0 mt-0.5 bg-accent/20 text-accent">
             N
           </div>
           <div className="min-w-0 flex-1">

--- a/web/src/components/Chat/BlockRenderer.tsx
+++ b/web/src/components/Chat/BlockRenderer.tsx
@@ -10,7 +10,7 @@ interface BlockRendererProps {
   blocks: MessageBlock[];
   /** Show streaming cursor on last block + streaming prop on last ThinkingBlock. */
   streaming?: boolean;
-  /** Tailwind bg class for text cursor (default: 'bg-[#6366f1]'). */
+  /** Tailwind bg class for text cursor (default: 'bg-accent'). */
   cursorColor?: string;
   /** Optional wrapper class for text blocks (e.g. 'text-[13px] my-1'). */
   textClassName?: string;
@@ -19,7 +19,7 @@ interface BlockRendererProps {
 export function BlockRenderer({
   blocks,
   streaming = false,
-  cursorColor = 'bg-[#6366f1]',
+  cursorColor = 'bg-accent',
   textClassName,
 }: BlockRendererProps) {
   const renderItems = useMemo(() => groupToolCalls(blocks), [blocks]);

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -4,7 +4,7 @@ import { useChatStore } from '../../stores/chatStore';
 import type { QuoteAction, QuoteEntry } from '../../stores/chatStore';
 
 const ACTION_CONFIG: Record<QuoteAction, { icon: typeof Plus; label: string; color: string; placeholder: string }> = {
-  add:      { icon: Plus,       label: 'Add',     color: '#6366f1', placeholder: 'Instructions...' },
+  add:      { icon: Plus,       label: 'Add',     color: 'var(--theme-accent)', placeholder: 'Instructions...' },
   remove:   { icon: Trash2,     label: 'Remove',  color: '#ef4444', placeholder: 'Instructions...' },
   improve:  { icon: Sparkles,   label: 'Improve', color: '#a855f7', placeholder: 'Instructions...' },
   question: { icon: HelpCircle, label: 'Ask',     color: '#f59e0b', placeholder: 'What do you want to know?' },
@@ -120,7 +120,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
             placeholder={quotes.length > 0 ? 'Add context (optional)...' : 'Send a message...'}
             rows={1}
             disabled={disabled}
-            className="flex-1 px-4 py-3 bg-surface-raised border border-border rounded-xl text-[15px] text-text outline-none focus:border-[#6366f1]/50 resize-none disabled:opacity-50 placeholder:text-text-faint"
+            className="flex-1 px-4 py-3 bg-surface-raised border border-border rounded-xl text-[15px] text-text outline-none focus:border-accent/50 resize-none disabled:opacity-50 placeholder:text-text-faint"
           />
           {isStreaming ? (
             <button
@@ -134,7 +134,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
             <button
               onClick={handleSend}
               disabled={!canSend}
-              className="w-10 h-10 bg-[#6366f1] hover:bg-[#818cf8] text-white rounded-xl flex items-center justify-center disabled:opacity-30 cursor-pointer transition-colors shrink-0"
+              className="w-10 h-10 bg-accent hover:bg-accent-hover text-white rounded-xl flex items-center justify-center disabled:opacity-30 cursor-pointer transition-colors shrink-0"
             >
               <Send size={18} />
             </button>

--- a/web/src/components/Chat/DiffView.tsx
+++ b/web/src/components/Chat/DiffView.tsx
@@ -7,8 +7,8 @@ import type { FileDiff, DiffHunk, DiffLine as DiffLineType } from '../../types/c
 
 function HunkHeader({ hunk }: { hunk: DiffHunk }) {
   return (
-    <div className="bg-[#6366f1]/10 text-[11px] px-3 py-1 border-y border-[#6366f1]/20 select-none flex items-center gap-2 sticky top-0 z-[1]">
-      <span className="text-indigo-400 font-mono">
+    <div className="bg-accent/10 text-[11px] px-3 py-1 border-y border-accent/20 select-none flex items-center gap-2 sticky top-0 z-[1]">
+      <span className="text-accent font-mono">
         @@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@
       </span>
       {hunk.header && (

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -293,7 +293,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
                     onClick={() => onSelect(s.id)}
                     className={`group flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md cursor-pointer text-[12px] transition-colors
                       ${s.id === activeSession
-                        ? 'bg-[#6366f1]/10 text-text-muted'
+                        ? 'bg-accent/10 text-text-muted'
                         : 'text-text-faint hover:bg-surface-raised hover:text-text-muted'
                       }`}
                   >
@@ -326,7 +326,7 @@ function StatusIndicator({ session, isActive, isRunning }: {
 }) {
   // Active + running: spinner
   if (isActive && isRunning) {
-    return <Loader2 size={12} className="shrink-0 text-[#6366f1] animate-spin" />;
+    return <Loader2 size={12} className="shrink-0 text-accent animate-spin" />;
   }
 
   // Non-active but running: pulsing green dot
@@ -419,7 +419,7 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, onRenam
       onClick={() => onSelect(session.id)}
       className={`group flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md cursor-pointer text-sm transition-colors
         ${isActive
-          ? 'bg-[#6366f1]/10 text-text'
+          ? 'bg-accent/10 text-text'
           : 'text-text-muted hover:bg-surface-raised hover:text-text-secondary'
         }`}
     >

--- a/web/src/components/Chat/SidePanel.tsx
+++ b/web/src/components/Chat/SidePanel.tsx
@@ -17,7 +17,7 @@ const TAB_ICONS: Record<string, typeof Bot> = {
 const TAB_COLORS: Record<string, string> = {
   Plan: 'text-amber-400',
   Explore: 'text-cyan-400',
-  'general-purpose': 'text-indigo-400',
+  'general-purpose': 'text-accent',
   files: 'text-teal-400',
 };
 
@@ -130,7 +130,7 @@ function TabHeader({ tab, onClose }: { tab: PanelTab; onClose: () => void }) {
 // ------------------------------------------------------------------ //
 
 function TabContent({ tab, containerRef }: { tab: PanelTab; containerRef: React.RefObject<HTMLDivElement | null> }) {
-  const cursorColor = tab.type === 'plan' ? 'bg-amber-400' : 'bg-indigo-400';
+  const cursorColor = tab.type === 'plan' ? 'bg-amber-400' : 'bg-accent';
   const hasBlocks = tab.blocks.length > 0;
   const endRef = useRef<HTMLDivElement>(null);
   const isNearBottom = useRef(true);
@@ -313,7 +313,7 @@ export function SidePanel() {
       {/* Resize handle */}
       <div
         onMouseDown={handleResizeStart}
-        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-indigo-500/30 z-10"
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-accent/30 z-10"
       />
 
       {/* Tab bar (when multiple tabs) */}

--- a/web/src/components/Chat/StreamingMessage.tsx
+++ b/web/src/components/Chat/StreamingMessage.tsx
@@ -4,14 +4,14 @@ import { BlockRenderer } from './BlockRenderer';
 export function StreamingMessage({ blocks }: { blocks: MessageBlock[] }) {
   if (blocks.length === 0) {
     return (
-      <div className="py-4 px-5 bg-bg-sunken">
+      <div className="py-4 px-5 msg-assistant">
         <div className="max-w-3xl mx-auto">
           <div className="flex gap-3">
-            <div className="w-7 h-7 rounded-full bg-[#6366f1]/20 flex items-center justify-center text-xs font-medium text-[#6366f1] shrink-0">
+            <div className="w-7 h-7 rounded-full bg-accent/20 flex items-center justify-center text-xs font-medium text-accent shrink-0">
               N
             </div>
             <div className="pt-1.5">
-              <span className="streaming-cursor inline-block w-2 h-4 bg-[#6366f1]" />
+              <span className="streaming-cursor inline-block w-2 h-4 bg-accent" />
             </div>
           </div>
         </div>
@@ -23,7 +23,7 @@ export function StreamingMessage({ blocks }: { blocks: MessageBlock[] }) {
     <div className="py-4 px-5 bg-bg-sunken">
       <div className="max-w-3xl mx-auto">
         <div className="flex gap-3">
-          <div className="w-7 h-7 rounded-full bg-[#6366f1]/20 flex items-center justify-center text-xs font-medium text-[#6366f1] shrink-0 mt-0.5">
+          <div className="w-7 h-7 rounded-full bg-accent/20 flex items-center justify-center text-xs font-medium text-accent shrink-0 mt-0.5">
             N
           </div>
           <div className="min-w-0 flex-1">

--- a/web/src/components/Chat/ThinkingBlock.tsx
+++ b/web/src/components/Chat/ThinkingBlock.tsx
@@ -11,17 +11,17 @@ export function ThinkingBlock({ content, streaming }: { content: string; streami
         onClick={() => setExpanded(!expanded)}
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-hover rounded-r-md transition-colors"
       >
-        <Brain size={14} className="text-[#6366f1] shrink-0" />
+        <Brain size={14} className="text-accent shrink-0" />
         {expanded ? <ChevronDown size={14} className="text-text-faint" /> : <ChevronRight size={14} className="text-text-faint" />}
         <span className="text-[13px] text-text-muted italic truncate">
           {expanded ? 'Thinking' : preview || 'Thinking...'}
         </span>
-        {streaming && <span className="streaming-cursor inline-block w-1.5 h-3.5 bg-[#6366f1] ml-1 shrink-0" />}
+        {streaming && <span className="streaming-cursor inline-block w-1.5 h-3.5 bg-accent ml-1 shrink-0" />}
       </button>
       {expanded && (
         <div className="px-4 pb-3 text-[13px] text-text-muted italic whitespace-pre-wrap leading-relaxed">
           {content}
-          {streaming && <span className="streaming-cursor inline-block w-1.5 h-3.5 bg-[#6366f1] ml-0.5 align-text-bottom" />}
+          {streaming && <span className="streaming-cursor inline-block w-1.5 h-3.5 bg-accent ml-0.5 align-text-bottom" />}
         </div>
       )}
     </div>

--- a/web/src/components/Chat/TodoPanel.tsx
+++ b/web/src/components/Chat/TodoPanel.tsx
@@ -65,7 +65,7 @@ function TodoRow({ todo }: { todo: TodoItem }) {
       {isCompleted ? (
         <CheckCircle2 size={14} className="text-green-500 shrink-0 todo-icon-enter" />
       ) : isActive ? (
-        <Loader2 size={14} className="text-[#6366f1] shrink-0 animate-spin" />
+        <Loader2 size={14} className="text-accent shrink-0 animate-spin" />
       ) : (
         <Circle size={14} className="text-text-faint shrink-0" />
       )}

--- a/web/src/components/Chat/ToolCallBlock.tsx
+++ b/web/src/components/Chat/ToolCallBlock.tsx
@@ -90,7 +90,7 @@ function GenericToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-text-muted'}`} />
         }
         <span className="text-[13px] font-mono font-medium text-text-secondary">{block.tool}</span>

--- a/web/src/components/Chat/ToolCallGroupBlock.tsx
+++ b/web/src/components/Chat/ToolCallGroupBlock.tsx
@@ -43,7 +43,7 @@ export function ToolCallGroupBlock({ group }: { group: ToolCallGroup }) {
                      rounded-md transition-colors"
         >
           {hasRunning
-            ? <Loader2 size={12} className="text-[#6366f1] animate-spin shrink-0" />
+            ? <Loader2 size={12} className="text-accent animate-spin shrink-0" />
             : <Icon size={12} className={`shrink-0 ${hasError ? 'text-red-400' : 'text-text-faint'}`} />
           }
           <span className="font-mono font-medium">

--- a/web/src/components/Chat/tools/BashToolBlock.tsx
+++ b/web/src/components/Chat/tools/BashToolBlock.tsx
@@ -15,7 +15,7 @@ export function BashToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-hover transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Terminal size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-emerald-400'}`} />
         }
         <span className="text-emerald-500 text-[13px] font-mono select-none">$</span>

--- a/web/src/components/Chat/tools/EditToolBlock.tsx
+++ b/web/src/components/Chat/tools/EditToolBlock.tsx
@@ -19,7 +19,7 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <FileEdit size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-amber-400'}`} />
         }
         <span className="text-[13px] font-mono font-medium text-text-secondary">Edit</span>

--- a/web/src/components/Chat/tools/FileToolBlock.tsx
+++ b/web/src/components/Chat/tools/FileToolBlock.tsx
@@ -19,7 +19,7 @@ export function FileToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-blue-400'}`} />
         }
         <span className="text-[13px] font-mono font-medium text-text-secondary">{block.tool}</span>

--- a/web/src/components/Chat/tools/NotificationToolBlock.tsx
+++ b/web/src/components/Chat/tools/NotificationToolBlock.tsx
@@ -43,7 +43,7 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${iconColor}`} />
         }
         <span className="text-[13px] font-medium text-text-secondary">{label}</span>
@@ -78,7 +78,7 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
             {isAsk && options.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-2">
                 {options.map(opt => (
-                  <span key={opt} className="px-2 py-0.5 text-[11px] bg-[#1a1a2e] text-blue-300/80 rounded border border-blue-500/20">
+                  <span key={opt} className="px-2 py-0.5 text-[11px] bg-surface-raised text-info/80 rounded border border-info/20">
                     {opt}
                   </span>
                 ))}

--- a/web/src/components/Chat/tools/PlanApprovalBlock.tsx
+++ b/web/src/components/Chat/tools/PlanApprovalBlock.tsx
@@ -51,12 +51,12 @@ export function PlanApprovalBlock({ block }: { block: ToolCallBlockData }) {
 
   return (
     <div className="my-2">
-      <div className="border border-indigo-500/20 rounded-lg bg-[#111118] overflow-hidden">
+      <div className="border border-accent/20 rounded-lg bg-bg-sunken overflow-hidden">
         <div className="px-4 py-3">
           <div className="flex items-center gap-2 mb-2">
             {isExitPlan
-              ? <FileCheck size={15} className="text-indigo-400" />
-              : <Play size={15} className="text-indigo-400" />
+              ? <FileCheck size={15} className="text-accent" />
+              : <Play size={15} className="text-accent" />
             }
             <span className="text-[13px] font-medium text-text">
               {isExitPlan
@@ -78,7 +78,7 @@ export function PlanApprovalBlock({ block }: { block: ToolCallBlockData }) {
           <div className="flex gap-2">
             <button
               onClick={() => { setResponded(true); setApproved(true); answerInteraction(null); }}
-              className="flex-1 py-2 rounded-md text-[13px] font-medium bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer transition-colors flex items-center justify-center gap-2"
+              className="flex-1 py-2 rounded-md text-[13px] font-medium bg-accent hover:bg-accent-hover text-white cursor-pointer transition-colors flex items-center justify-center gap-2"
             >
               <Check size={13} />
               {isExitPlan ? 'Approve' : 'Allow'}

--- a/web/src/components/Chat/tools/QuestionBlock.tsx
+++ b/web/src/components/Chat/tools/QuestionBlock.tsx
@@ -94,21 +94,21 @@ export function QuestionBlock({ block }: { block: ToolCallBlockData }) {
 
   return (
     <div className="question-block my-2">
-      <div className="border border-indigo-500/20 rounded-lg bg-[#111118] overflow-hidden">
+      <div className="border border-accent/20 rounded-lg bg-bg-sunken overflow-hidden">
         {questions.map((q, qIdx) => (
-          <div key={qIdx} className={qIdx > 0 ? 'border-t border-[#1a1a2a]' : ''}>
+          <div key={qIdx} className={qIdx > 0 ? 'border-t border-border-subtle' : ''}>
             {/* Question header */}
             <div className="px-4 pt-3.5 pb-2">
               <div className="flex items-center gap-2 mb-2">
-                <MessageCircleQuestion size={15} className="text-indigo-400 shrink-0" />
-                <span className="text-[10px] font-semibold uppercase tracking-wider text-indigo-400/70 bg-indigo-500/10 px-2 py-0.5 rounded">
+                <MessageCircleQuestion size={15} className="text-accent shrink-0" />
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-accent/70 bg-accent/10 px-2 py-0.5 rounded">
                   {q.header}
                 </span>
                 {q.multiSelect && (
                   <span className="text-[10px] text-text-faint ml-auto">Select multiple</span>
                 )}
               </div>
-              <p className="text-[14px] text-[#ddd] leading-relaxed">{q.question}</p>
+              <p className="text-[14px] text-text-secondary leading-relaxed">{q.question}</p>
             </div>
 
             {/* Options */}
@@ -127,21 +127,21 @@ export function QuestionBlock({ block }: { block: ToolCallBlockData }) {
                       className={`question-option w-full text-left px-3.5 py-2.5 rounded-md border transition-all duration-150 ${
                         submitted
                           ? isSelected
-                            ? 'border-indigo-500/40 bg-indigo-500/10 cursor-default'
+                            ? 'border-accent/40 bg-accent/10 cursor-default'
                             : 'border-surface-raised bg-bg-sunken opacity-40 cursor-default'
                           : isSelected
-                            ? 'border-indigo-500/50 bg-indigo-500/10 cursor-pointer'
+                            ? 'border-accent/50 bg-accent/10 cursor-pointer'
                             : 'border-border-subtle bg-bg-sunken hover:border-border hover:bg-surface cursor-pointer'
                       }`}
                     >
                       <div className="flex items-start gap-3">
                         <div className={`mt-0.5 shrink-0 w-4 h-4 ${q.multiSelect ? 'rounded-sm' : 'rounded-full'} border flex items-center justify-center transition-colors duration-150 ${
-                          isSelected ? 'border-indigo-500 bg-indigo-500' : 'border-text-faint bg-transparent'
+                          isSelected ? 'border-accent bg-accent' : 'border-text-faint bg-transparent'
                         }`}>
                           {isSelected && <Check size={10} className="text-white" strokeWidth={3} />}
                         </div>
                         <div className="flex-1 min-w-0">
-                          <div className={`text-[13px] font-medium ${isSelected ? 'text-indigo-300' : 'text-text-secondary'}`}>
+                          <div className={`text-[13px] font-medium ${isSelected ? 'text-accent-text' : 'text-text-secondary'}`}>
                             {opt.label}
                           </div>
                           {opt.description && (
@@ -152,7 +152,7 @@ export function QuestionBlock({ block }: { block: ToolCallBlockData }) {
                     </button>
 
                     {opt.markdown && (isHovered || (isSelected && !submitted)) && (
-                      <div className="mx-2 mt-1 mb-0.5 px-3 py-2 bg-[#0a0a0e] border border-[#1e1e28] rounded text-[12px] max-h-48 overflow-y-auto">
+                      <div className="mx-2 mt-1 mb-0.5 px-3 py-2 bg-bg border border-border-subtle rounded text-[12px] max-h-48 overflow-y-auto">
                         <MarkdownContent content={opt.markdown} />
                       </div>
                     )}
@@ -171,8 +171,8 @@ export function QuestionBlock({ block }: { block: ToolCallBlockData }) {
               disabled={!allAnswered}
               className={`w-full py-2 rounded-md text-[13px] font-medium transition-all duration-150 flex items-center justify-center gap-2 ${
                 allAnswered
-                  ? 'bg-indigo-600 hover:bg-indigo-500 text-white cursor-pointer'
-                  : 'bg-[#1a1a22] text-text-faint cursor-not-allowed'
+                  ? 'bg-accent hover:bg-accent-hover text-white cursor-pointer'
+                  : 'bg-surface text-text-faint cursor-not-allowed'
               }`}
             >
               <Send size={13} />
@@ -183,7 +183,7 @@ export function QuestionBlock({ block }: { block: ToolCallBlockData }) {
 
         {/* Answered confirmation */}
         {submitted && (
-          <div className="px-4 py-2 border-t border-indigo-500/10 flex items-center gap-2">
+          <div className="px-4 py-2 border-t border-accent/10 flex items-center gap-2">
             <Check size={12} className="text-green-400" />
             <span className="text-[11px] text-green-400/70">Answered</span>
           </div>

--- a/web/src/components/Chat/tools/SkillToolBlock.tsx
+++ b/web/src/components/Chat/tools/SkillToolBlock.tsx
@@ -74,7 +74,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-purple-400'}`} />
         }
         <span className="text-[13px] font-medium text-text-secondary">{label}</span>

--- a/web/src/components/Chat/tools/SubagentToolBlock.tsx
+++ b/web/src/components/Chat/tools/SubagentToolBlock.tsx
@@ -14,7 +14,7 @@ const AGENT_ICONS: Record<string, typeof Bot> = {
 const AGENT_COLORS: Record<string, string> = {
   Explore: 'text-cyan-400',
   Plan: 'text-amber-400',
-  'general-purpose': 'text-indigo-400',
+  'general-purpose': 'text-accent',
 };
 
 export function SubagentToolBlock({ block }: { block: ToolCallBlockData }) {
@@ -73,7 +73,7 @@ export function SubagentToolBlock({ block }: { block: ToolCallBlockData }) {
       {/* Compact card header */}
       <div className="flex items-center gap-2 px-3 py-2">
         {isRunning
-          ? <Loader2 size={14} className="text-indigo-400 animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : color}`} />
         }
         <span className={`text-[13px] font-medium ${color}`}>{subagentType}</span>

--- a/web/src/components/Chat/tools/TaskToolBlock.tsx
+++ b/web/src/components/Chat/tools/TaskToolBlock.tsx
@@ -92,7 +92,7 @@ export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-[#6366f1] animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : isDone ? 'text-green-400' : isCreate ? 'text-blue-400' : 'text-text-muted'}`} />
         }
         <span className="text-[13px] font-medium text-text-secondary shrink-0 whitespace-nowrap">{label}</span>

--- a/web/src/components/Files/EditorTabBar.tsx
+++ b/web/src/components/Files/EditorTabBar.tsx
@@ -21,13 +21,13 @@ export function EditorTabBar({ files, activePath, onSelect, onClose }: {
           key={f.path}
           className={`flex items-center gap-1.5 px-3 py-2 text-[13px] cursor-pointer border-r border-border-subtle shrink-0
             ${f.path === activePath
-              ? 'bg-bg text-text border-b-2 border-b-[#6366f1]'
+              ? 'bg-bg text-text border-b-2 border-b-accent'
               : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'
             }`}
           onClick={() => onSelect(f.path)}
         >
           <span>{f.name}</span>
-          {f.modified && <span className="w-1.5 h-1.5 rounded-full bg-[#6366f1]" />}
+          {f.modified && <span className="w-1.5 h-1.5 rounded-full bg-accent" />}
           <button
             onClick={(e) => { e.stopPropagation(); onClose(f.path); }}
             className="p-0.5 hover:bg-border-subtle rounded cursor-pointer"

--- a/web/src/components/Files/FileEditor.tsx
+++ b/web/src/components/Files/FileEditor.tsx
@@ -47,7 +47,7 @@ export function FileEditor({ path, content, modified, saving, onContentChange, o
             <button
               onClick={onSave}
               disabled={saving}
-              className="flex items-center gap-1.5 px-3 py-1 text-[12px] bg-[#6366f1] hover:bg-[#818cf8] text-white rounded-md cursor-pointer disabled:opacity-50"
+              className="flex items-center gap-1.5 px-3 py-1 text-[12px] bg-accent hover:bg-accent-hover text-white rounded-md cursor-pointer disabled:opacity-50"
             >
               <Save size={12} />
               {saving ? 'Saving...' : 'Save'}

--- a/web/src/components/Files/FileTree.tsx
+++ b/web/src/components/Files/FileTree.tsx
@@ -23,8 +23,8 @@ function FileTreeNode({ node, depth, selectedPath, onSelect }: {
             : <ChevronRight size={12} className="shrink-0 text-text-faint" />
           }
           {expanded
-            ? <FolderOpen size={14} className="shrink-0 text-[#6366f1]" />
-            : <Folder size={14} className="shrink-0 text-[#6366f1]" />
+            ? <FolderOpen size={14} className="shrink-0 text-accent" />
+            : <Folder size={14} className="shrink-0 text-accent" />
           }
           <span className="truncate">{node.name}</span>
         </button>
@@ -46,7 +46,7 @@ function FileTreeNode({ node, depth, selectedPath, onSelect }: {
     <button
       onClick={() => onSelect(node.path)}
       className={`flex items-center gap-1.5 w-full text-left px-2 py-1 text-[13px] cursor-pointer rounded
-        ${isSelected ? 'bg-[#6366f1]/10 text-text' : 'text-text-muted hover:bg-surface-raised hover:text-text-secondary'}`}
+        ${isSelected ? 'bg-accent/10 text-text' : 'text-text-muted hover:bg-surface-raised hover:text-text-secondary'}`}
       style={{ paddingLeft: depth * 16 + 20 }}
     >
       <File size={13} className="shrink-0 text-text-dim" />

--- a/web/src/components/Layout/NavRail.tsx
+++ b/web/src/components/Layout/NavRail.tsx
@@ -43,7 +43,7 @@ export function NavRail() {
 
   return (
     <div className="w-14 bg-surface border-r border-border flex flex-col items-center py-3 shrink-0">
-      <div className="text-[#6366f1] font-bold text-xs mb-4 tracking-wider">N</div>
+      <div className="text-accent font-bold text-xs mb-4 tracking-wider">N</div>
 
       <div className="flex-1 flex flex-col gap-1">
         {visibleItems.map(({ path, icon: Icon, label }) => {
@@ -55,7 +55,7 @@ export function NavRail() {
               onClick={() => navigate(path)}
               className={`relative w-10 h-10 rounded-lg flex flex-col items-center justify-center gap-0.5 cursor-pointer transition-colors
                 ${active
-                  ? 'bg-[#6366f1]/15 text-[#6366f1]'
+                  ? 'bg-accent/15 text-accent'
                   : 'text-text-dim hover:text-text-muted hover:bg-surface-hover'
                 }`}
               title={label}

--- a/web/src/components/Memory/MemoryBrowser.tsx
+++ b/web/src/components/Memory/MemoryBrowser.tsx
@@ -60,7 +60,7 @@ export function MemoryBrowser() {
             key={f.path}
             onClick={() => openFile(f.path)}
             className={`px-3 py-1.5 text-sm cursor-pointer hover:bg-surface-raised truncate ${
-              f.path === selected ? 'bg-surface-raised border-l-2 border-[#6366f1]' : ''
+              f.path === selected ? 'bg-surface-raised border-l-2 border-accent' : ''
             }`}
           >
             <div className="truncate">{f.name}</div>
@@ -81,7 +81,7 @@ export function MemoryBrowser() {
                     <button
                       onClick={saveFile}
                       disabled={saving}
-                      className="text-xs px-2 py-1 bg-[#6366f1] rounded text-white cursor-pointer"
+                      className="text-xs px-2 py-1 bg-accent rounded text-white cursor-pointer"
                     >
                       {saving ? 'Saving...' : 'Save'}
                     </button>

--- a/web/src/components/Notifications/NotificationToast.tsx
+++ b/web/src/components/Notifications/NotificationToast.tsx
@@ -38,12 +38,12 @@ export function NotificationToast() {
               {isQuestion ? (
                 <HelpCircle size={16} className="text-blue-400 shrink-0 mt-0.5" />
               ) : (
-                <Bell size={16} className="text-[#6366f1] shrink-0 mt-0.5" />
+                <Bell size={16} className="text-accent shrink-0 mt-0.5" />
               )}
               <div className="flex-1 min-w-0">
                 <div className="flex items-start justify-between gap-2">
                   <p
-                    className="text-sm font-medium text-text cursor-pointer hover:text-[#6366f1]"
+                    className="text-sm font-medium text-text cursor-pointer hover:text-accent"
                     onClick={() => {
                       navigate('/notifications');
                       dismissToast(notif.id);
@@ -71,7 +71,7 @@ export function NotificationToast() {
                           answerNotification(notif.id, opt);
                           dismissToast(notif.id);
                         }}
-                        className="px-2 py-0.5 bg-[#6366f1]/15 text-[#6366f1] rounded text-xs border border-[#6366f1]/30 hover:bg-[#6366f1]/25 cursor-pointer"
+                        className="px-2 py-0.5 bg-accent/15 text-accent rounded text-xs border border-accent/30 hover:bg-accent/25 cursor-pointer"
                       >
                         {opt}
                       </button>

--- a/web/src/components/Sources/renderers/EmailRenderer.tsx
+++ b/web/src/components/Sources/renderers/EmailRenderer.tsx
@@ -56,7 +56,7 @@ body {
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
-a { color: #6366f1; }
+a { color: #4f46e5; }
 img { max-width: 100%; height: auto; }
 table { border-collapse: collapse; max-width: 100%; }
 td, th { padding: 4px 8px; }
@@ -71,14 +71,14 @@ pre { white-space: pre-wrap; }
         <button
           onClick={() => setShowHtml(true)}
           className={`text-[12px] px-2 py-1 rounded transition-colors cursor-pointer
-            ${showHtml ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-dim hover:text-text-muted'}`}
+            ${showHtml ? 'bg-accent/15 text-accent' : 'text-text-dim hover:text-text-muted'}`}
         >
           HTML
         </button>
         <button
           onClick={() => setShowHtml(false)}
           className={`text-[12px] px-2 py-1 rounded transition-colors cursor-pointer
-            ${!showHtml ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-dim hover:text-text-muted'}`}
+            ${!showHtml ? 'bg-accent/15 text-accent' : 'text-text-dim hover:text-text-muted'}`}
         >
           Text
         </button>

--- a/web/src/components/Sources/renderers/GitHubRenderer.tsx
+++ b/web/src/components/Sources/renderers/GitHubRenderer.tsx
@@ -35,7 +35,7 @@ export function GitHubRenderer({ content, metadata, summary: _summary }: Props) 
           </div>
           {subjectUrl && (
             <a href={subjectUrl} target="_blank" rel="noopener noreferrer"
-              className="flex items-center gap-1 text-[12px] text-[#6366f1] hover:text-[#818cf8] transition-colors">
+              className="flex items-center gap-1 text-[12px] text-accent hover:text-link transition-colors">
               <ExternalLink size={11} /> View on GitHub
             </a>
           )}

--- a/web/src/components/Sources/renderers/MarkdownRenderer.tsx
+++ b/web/src/components/Sources/renderers/MarkdownRenderer.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function MarkdownRenderer({ content, muted = false }: Props) {
   return (
     <div className={`prose prose-invert prose-sm max-w-none
-      prose-headings:text-[#eee] prose-a:text-[#6366f1] prose-code:text-[#e5e5e5]
+      prose-headings:text-text prose-a:text-accent prose-code:text-text-secondary
       prose-pre:bg-surface prose-pre:border prose-pre:border-border-subtle
       ${muted ? 'text-text-muted' : 'text-text-secondary'}`}>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>

--- a/web/src/components/Tasks/TaskCreateDialog.tsx
+++ b/web/src/components/Tasks/TaskCreateDialog.tsx
@@ -31,7 +31,7 @@ export function TaskCreateDialog({ onClose, onCreate }: {
               value={title}
               onChange={e => setTitle(e.target.value)}
               autoFocus
-              className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[14px] text-text outline-none focus:border-[#6366f1]/50"
+              className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[14px] text-text outline-none focus:border-accent/50"
             />
           </div>
           <div>
@@ -40,7 +40,7 @@ export function TaskCreateDialog({ onClose, onCreate }: {
               value={content}
               onChange={e => setContent(e.target.value)}
               rows={4}
-              className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[14px] text-text outline-none focus:border-[#6366f1]/50 resize-none"
+              className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[14px] text-text outline-none focus:border-accent/50 resize-none"
             />
           </div>
           <div>
@@ -49,7 +49,7 @@ export function TaskCreateDialog({ onClose, onCreate }: {
               type="date"
               value={deadline}
               onChange={e => setDeadline(e.target.value)}
-              className="px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[14px] text-text outline-none focus:border-[#6366f1]/50"
+              className="px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[14px] text-text outline-none focus:border-accent/50"
             />
           </div>
           <div className="flex justify-end gap-2 pt-2">
@@ -58,7 +58,7 @@ export function TaskCreateDialog({ onClose, onCreate }: {
               Cancel
             </button>
             <button type="submit"
-              className="px-4 py-2 text-[13px] bg-[#6366f1] hover:bg-[#818cf8] text-white rounded-lg cursor-pointer disabled:opacity-50"
+              className="px-4 py-2 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer disabled:opacity-50"
               disabled={!title.trim()}>
               Create
             </button>

--- a/web/src/components/Tasks/TaskFilters.tsx
+++ b/web/src/components/Tasks/TaskFilters.tsx
@@ -18,7 +18,7 @@ export function TaskFilters({ active, onChange }: {
           onClick={() => onChange(f.value)}
           className={`px-3 py-1.5 text-[13px] rounded-md cursor-pointer transition-colors
             ${active === f.value
-              ? 'bg-[#6366f1]/15 text-[#6366f1] font-medium'
+              ? 'bg-accent/15 text-accent font-medium'
               : 'text-text-dim hover:text-text-muted hover:bg-surface-raised'
             }`}
         >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,20 +3,35 @@
 
 /* ── Theme tokens ── */
 @theme inline {
+  /* Surfaces */
   --color-bg: var(--theme-bg);
   --color-bg-sunken: var(--theme-bg-sunken);
   --color-surface: var(--theme-surface);
   --color-surface-raised: var(--theme-surface-raised);
   --color-surface-hover: var(--theme-surface-hover);
   --color-code-bg: var(--theme-code-bg);
+  /* Text */
   --color-text: var(--theme-text);
   --color-text-secondary: var(--theme-text-secondary);
   --color-text-muted: var(--theme-text-muted);
   --color-text-dim: var(--theme-text-dim);
   --color-text-faint: var(--theme-text-faint);
+  --color-placeholder: var(--theme-placeholder);
+  /* Borders */
   --color-border: var(--theme-border);
   --color-border-subtle: var(--theme-border-subtle);
+  /* Accent */
+  --color-accent: var(--theme-accent);
+  --color-accent-hover: var(--theme-accent-hover);
+  --color-accent-muted: var(--theme-accent-muted);
+  --color-accent-text: var(--theme-accent-text);
+  /* Links */
   --color-link: var(--theme-link);
+  /* Semantic */
+  --color-success: var(--theme-success);
+  --color-error: var(--theme-error);
+  --color-warning: var(--theme-warning);
+  --color-info: var(--theme-info);
 }
 
 /* ── Dark palette (default) ── */
@@ -33,9 +48,18 @@
   --theme-text-muted: #888888;
   --theme-text-dim: #666666;
   --theme-text-faint: #444444;
+  --theme-placeholder: #555555;
   --theme-border: #2a2a2a;
   --theme-border-subtle: #222222;
+  --theme-accent: #6366f1;
+  --theme-accent-hover: #818cf8;
+  --theme-accent-muted: rgba(99, 102, 241, 0.15);
+  --theme-accent-text: #c7d2fe;
   --theme-link: #818cf8;
+  --theme-success: #4ade80;
+  --theme-error: #f87171;
+  --theme-warning: #fbbf24;
+  --theme-info: #60a5fa;
 }
 
 /* ── Light palette (explicit) ── */
@@ -44,17 +68,26 @@
   --theme-bg: #f5f5f5;
   --theme-bg-sunken: #ebebeb;
   --theme-surface: #ffffff;
-  --theme-surface-raised: #ffffff;
+  --theme-surface-raised: #f8f8f8;
   --theme-surface-hover: #e8e8e8;
-  --theme-code-bg: #f0f0f0;
+  --theme-code-bg: #f3f4f6;
   --theme-text: #1a1a1a;
   --theme-text-secondary: #333333;
   --theme-text-muted: #666666;
   --theme-text-dim: #999999;
   --theme-text-faint: #bbbbbb;
+  --theme-placeholder: #9ca3af;
   --theme-border: #d4d4d4;
-  --theme-border-subtle: #e0e0e0;
+  --theme-border-subtle: #e5e7eb;
+  --theme-accent: #4f46e5;
+  --theme-accent-hover: #4338ca;
+  --theme-accent-muted: rgba(79, 70, 229, 0.10);
+  --theme-accent-text: #3730a3;
   --theme-link: #4f46e5;
+  --theme-success: #16a34a;
+  --theme-error: #dc2626;
+  --theme-warning: #d97706;
+  --theme-info: #2563eb;
 }
 
 /* ── System preference (when no explicit data-theme) ── */
@@ -64,17 +97,26 @@
     --theme-bg: #f5f5f5;
     --theme-bg-sunken: #ebebeb;
     --theme-surface: #ffffff;
-    --theme-surface-raised: #ffffff;
+    --theme-surface-raised: #f8f8f8;
     --theme-surface-hover: #e8e8e8;
-    --theme-code-bg: #f0f0f0;
+    --theme-code-bg: #f3f4f6;
     --theme-text: #1a1a1a;
     --theme-text-secondary: #333333;
     --theme-text-muted: #666666;
     --theme-text-dim: #999999;
     --theme-text-faint: #bbbbbb;
+    --theme-placeholder: #9ca3af;
     --theme-border: #d4d4d4;
-    --theme-border-subtle: #e0e0e0;
+    --theme-border-subtle: #e5e7eb;
+    --theme-accent: #4f46e5;
+    --theme-accent-hover: #4338ca;
+    --theme-accent-muted: rgba(79, 70, 229, 0.10);
+    --theme-accent-text: #3730a3;
     --theme-link: #4f46e5;
+    --theme-success: #16a34a;
+    --theme-error: #dc2626;
+    --theme-warning: #d97706;
+    --theme-info: #2563eb;
   }
 }
 
@@ -92,6 +134,15 @@ body {
 ::-webkit-scrollbar-thumb { background: var(--theme-border-subtle); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--theme-border); }
 
+/* ── Chat message backgrounds ── */
+/* Dark: assistant messages are slightly darker than the chat bg */
+.msg-assistant { background: var(--theme-bg-sunken); }
+/* Light: invert — assistant messages are lighter (white) to stand out */
+[data-theme="light"] .msg-assistant { background: var(--theme-surface); }
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) .msg-assistant { background: var(--theme-surface); }
+}
+
 /* Markdown rendering styles */
 .markdown-content h1 { font-size: 1.5em; font-weight: 600; margin: 0.8em 0 0.4em; }
 .markdown-content h2 { font-size: 1.25em; font-weight: 600; margin: 0.7em 0 0.3em; }
@@ -105,7 +156,7 @@ body {
 .markdown-content table { border-collapse: collapse; margin: 0.5em 0; width: 100%; }
 .markdown-content th, .markdown-content td { border: 1px solid var(--theme-border-subtle); padding: 0.4em 0.8em; text-align: left; }
 .markdown-content th { background: var(--theme-surface-raised); font-weight: 600; }
-.markdown-content tr:nth-child(even) { background: var(--theme-surface); }
+.markdown-content tr:nth-child(even) { background: color-mix(in srgb, var(--theme-text) 4%, transparent); }
 .markdown-content hr { border: none; border-top: 1px solid var(--theme-border-subtle); margin: 1em 0; }
 .markdown-content img { max-width: 100%; border-radius: 4px; }
 
@@ -142,54 +193,41 @@ body {
 }
 
 /* ── Highlight.js light mode overrides ── */
-[data-theme="light"] .hljs {
+/* Both explicit [data-theme="light"] and system-preference light share the same syntax palette.
+   We use :is() to merge selectors and avoid duplication. */
+:is([data-theme="light"], :root:not([data-theme="dark"]):where(@media (prefers-color-scheme: light) *)) .hljs {
   color: #24292e;
   background: var(--theme-code-bg);
 }
+[data-theme="light"] .hljs { color: #24292e; background: var(--theme-code-bg); }
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) .hljs { color: #24292e; background: var(--theme-code-bg); }
+}
+
+/* Shared light syntax colors — helper class applied via both selectors */
+[data-theme="light"] .hljs-comment, [data-theme="light"] .hljs-quote { color: #6a737d; }
+[data-theme="light"] .hljs-keyword, [data-theme="light"] .hljs-selector-tag { color: #d73a49; }
+[data-theme="light"] .hljs-string { color: #032f62; }
+[data-theme="light"] .hljs-number, [data-theme="light"] .hljs-literal { color: #005cc5; }
+[data-theme="light"] .hljs-built_in, [data-theme="light"] .hljs-type { color: #e36209; }
+[data-theme="light"] .hljs-title, [data-theme="light"] .hljs-section, [data-theme="light"] .hljs-name { color: #6f42c1; }
+[data-theme="light"] .hljs-attr, [data-theme="light"] .hljs-attribute { color: #005cc5; }
+[data-theme="light"] .hljs-variable { color: #e36209; }
+[data-theme="light"] .hljs-deletion { color: #b31d28; background: #ffeef0; }
+[data-theme="light"] .hljs-addition { color: #22863a; background: #f0fff4; }
 
 @media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) .hljs {
-    color: #24292e;
-    background: var(--theme-code-bg);
-  }
-  :root:not([data-theme="dark"]) .hljs-comment,
-  :root:not([data-theme="dark"]) .hljs-quote { color: #6a737d; }
-  :root:not([data-theme="dark"]) .hljs-keyword,
-  :root:not([data-theme="dark"]) .hljs-selector-tag { color: #d73a49; }
-  :root:not([data-theme="dark"]) .hljs-string,
-  :root:not([data-theme="dark"]) .hljs-addition { color: #032f62; }
-  :root:not([data-theme="dark"]) .hljs-number,
-  :root:not([data-theme="dark"]) .hljs-literal { color: #005cc5; }
-  :root:not([data-theme="dark"]) .hljs-built_in,
-  :root:not([data-theme="dark"]) .hljs-type { color: #e36209; }
-  :root:not([data-theme="dark"]) .hljs-title,
-  :root:not([data-theme="dark"]) .hljs-section,
-  :root:not([data-theme="dark"]) .hljs-name { color: #6f42c1; }
-  :root:not([data-theme="dark"]) .hljs-attr,
-  :root:not([data-theme="dark"]) .hljs-attribute { color: #005cc5; }
+  :root:not([data-theme="dark"]) .hljs-comment, :root:not([data-theme="dark"]) .hljs-quote { color: #6a737d; }
+  :root:not([data-theme="dark"]) .hljs-keyword, :root:not([data-theme="dark"]) .hljs-selector-tag { color: #d73a49; }
+  :root:not([data-theme="dark"]) .hljs-string { color: #032f62; }
+  :root:not([data-theme="dark"]) .hljs-number, :root:not([data-theme="dark"]) .hljs-literal { color: #005cc5; }
+  :root:not([data-theme="dark"]) .hljs-built_in, :root:not([data-theme="dark"]) .hljs-type { color: #e36209; }
+  :root:not([data-theme="dark"]) .hljs-title, :root:not([data-theme="dark"]) .hljs-section, :root:not([data-theme="dark"]) .hljs-name { color: #6f42c1; }
+  :root:not([data-theme="dark"]) .hljs-attr, :root:not([data-theme="dark"]) .hljs-attribute { color: #005cc5; }
   :root:not([data-theme="dark"]) .hljs-variable { color: #e36209; }
   :root:not([data-theme="dark"]) .hljs-deletion { color: #b31d28; background: #ffeef0; }
   :root:not([data-theme="dark"]) .hljs-addition { color: #22863a; background: #f0fff4; }
 }
-
-[data-theme="light"] .hljs-comment,
-[data-theme="light"] .hljs-quote { color: #6a737d; }
-[data-theme="light"] .hljs-keyword,
-[data-theme="light"] .hljs-selector-tag { color: #d73a49; }
-[data-theme="light"] .hljs-string,
-[data-theme="light"] .hljs-addition { color: #032f62; }
-[data-theme="light"] .hljs-number,
-[data-theme="light"] .hljs-literal { color: #005cc5; }
-[data-theme="light"] .hljs-built_in,
-[data-theme="light"] .hljs-type { color: #e36209; }
-[data-theme="light"] .hljs-title,
-[data-theme="light"] .hljs-section,
-[data-theme="light"] .hljs-name { color: #6f42c1; }
-[data-theme="light"] .hljs-attr,
-[data-theme="light"] .hljs-attribute { color: #005cc5; }
-[data-theme="light"] .hljs-variable { color: #e36209; }
-[data-theme="light"] .hljs-deletion { color: #b31d28; background: #ffeef0; }
-[data-theme="light"] .hljs-addition { color: #22863a; background: #f0fff4; }
 
 /* Pulse animation for streaming cursor */
 @keyframes blink {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -114,7 +114,7 @@ export function ChatPage() {
               })()}
               {statusLabel && (
                 <div className="flex items-center gap-1.5 text-[12px] text-text-muted">
-                  <Loader2 size={12} className="animate-spin text-[#6366f1]" />
+                  <Loader2 size={12} className="animate-spin text-accent" />
                   <span>{statusLabel}</span>
                 </div>
               )}

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -151,7 +151,7 @@ function CronSidebar() {
       <div className="p-2 space-y-1">
         <button onClick={() => selectJob(null)}
           className={`w-full flex items-center justify-between px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer
-            ${selectedJobId === null ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
+            ${selectedJobId === null ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
           <span className="flex items-center gap-2"><Timer size={14} /> All Jobs</span>
           <span className="text-[11px] opacity-70">{jobs.length}</span>
         </button>
@@ -160,7 +160,7 @@ function CronSidebar() {
           <div key={job.id} className={`group ${!job.enabled ? 'opacity-50' : ''}`}>
             <button onClick={() => selectJob(job.id)}
               className={`w-full flex items-center justify-between px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer
-                ${selectedJobId === job.id ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
+                ${selectedJobId === job.id ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
               <span className="flex items-center gap-2 min-w-0 truncate">
                 {jobTypeIcon(job.type)}
                 <span className="truncate">{jobLabel(job)}</span>

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -20,7 +20,7 @@ export function FilesPage() {
       {/* File tree sidebar */}
       <div className="w-64 bg-bg border-r border-border-subtle flex flex-col shrink-0">
         <div className="flex items-center gap-2 p-3 border-b border-border-subtle">
-          <FolderOpen size={16} className="text-[#6366f1]" />
+          <FolderOpen size={16} className="text-accent" />
           <span className="text-sm font-medium text-text-muted">Workspace</span>
         </div>
         <div className="flex-1 overflow-y-auto">

--- a/web/src/pages/HouseOfAgentsPage.tsx
+++ b/web/src/pages/HouseOfAgentsPage.tsx
@@ -101,7 +101,7 @@ export function HouseOfAgentsPage() {
                 value={newPipelineId}
                 onChange={e => setNewPipelineId(e.target.value)}
                 placeholder="pipeline-name"
-                className="w-full px-2 py-1 text-[12px] bg-surface-raised border border-border-subtle rounded text-text-secondary placeholder-[#555] focus:outline-none focus:border-amber-400/50"
+                className="w-full px-2 py-1 text-[12px] bg-surface-raised border border-border-subtle rounded text-text-secondary placeholder:text-placeholder focus:outline-none focus:border-amber-400/50"
                 onKeyDown={e => e.key === 'Enter' && handleCreate()}
                 autoFocus
               />

--- a/web/src/pages/McpServerDetailPage.tsx
+++ b/web/src/pages/McpServerDetailPage.tsx
@@ -5,7 +5,7 @@ import { useMcpStore } from '../stores/mcpStore';
 import { formatMcpName } from '../utils/formatMcpName';
 
 const TYPE_COLORS: Record<string, string> = {
-  sdk: 'text-[#6366f1] bg-[#6366f1]/10',
+  sdk: 'text-accent bg-accent/10',
   stdio: 'text-emerald-400 bg-emerald-400/10',
   sse: 'text-amber-400 bg-amber-400/10',
   http: 'text-sky-400 bg-sky-400/10',

--- a/web/src/pages/McpServersPage.tsx
+++ b/web/src/pages/McpServersPage.tsx
@@ -5,7 +5,7 @@ import { useMcpStore, type McpServer } from '../stores/mcpStore';
 import { formatMcpName } from '../utils/formatMcpName';
 
 const TYPE_COLORS: Record<string, string> = {
-  sdk: 'text-[#6366f1] bg-[#6366f1]/10',
+  sdk: 'text-accent bg-accent/10',
   stdio: 'text-emerald-400 bg-emerald-400/10',
   sse: 'text-amber-400 bg-amber-400/10',
   http: 'text-sky-400 bg-sky-400/10',
@@ -21,7 +21,7 @@ function ServerCard({ server }: { server: McpServer }) {
 
   return (
     <div
-      className="bg-surface-raised border border-border rounded-lg p-4 hover:border-[#3a3a3a] cursor-pointer transition-colors"
+      className="bg-surface-raised border border-border rounded-lg p-4 hover:border-border cursor-pointer transition-colors"
       onClick={() => navigate(`/mcp/${encodeURIComponent(server.name)}`)}
     >
       <div className="flex items-start justify-between mb-2">
@@ -106,9 +106,9 @@ export function McpServersPage() {
             <p className="text-sm text-text-dim mb-1">No MCP servers registered</p>
             <p className="text-xs text-text-faint">
               Add external MCP servers in{' '}
-              <code className="text-[#6366f1]">config.yaml</code>
+              <code className="text-accent">config.yaml</code>
               {' '}under the{' '}
-              <code className="text-[#6366f1]">mcp_servers</code> key.
+              <code className="text-accent">mcp_servers</code> key.
             </p>
           </div>
         ) : (

--- a/web/src/pages/MemuPage.tsx
+++ b/web/src/pages/MemuPage.tsx
@@ -6,7 +6,7 @@ import {
 import { useMemoryStore, type Category, type MemoryItem, type Resource, type TabView } from '../stores/memoryStore';
 
 const TYPE_COLORS: Record<string, string> = {
-  profile: '#6366f1',
+  profile: 'var(--theme-accent)',
   event: '#f59e0b',
   knowledge: '#22c55e',
   behavior: '#ef4444',
@@ -74,18 +74,18 @@ function EditForm({ item, onSave, onCancel }: {
   };
 
   return (
-    <div className="border border-[#6366f1]/30 rounded-lg p-3 bg-[#6366f1]/5 space-y-2">
+    <div className="border border-accent/30 rounded-lg p-3 bg-accent/5 space-y-2">
       <textarea
         value={content}
         onChange={e => setContent(e.target.value)}
         rows={3}
-        className="w-full bg-surface-raised border border-border-subtle rounded px-3 py-2 text-[13px] text-[#ddd] outline-none focus:border-[#6366f1]/50 resize-none"
+        className="w-full bg-surface-raised border border-border-subtle rounded px-3 py-2 text-[13px] text-text-secondary outline-none focus:border-accent/50 resize-none"
       />
       <div className="flex items-center gap-2">
         <select
           value={memType}
           onChange={e => setMemType(e.target.value)}
-          className="bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-[#ddd] outline-none focus:border-[#6366f1]/50"
+          className="bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-text-secondary outline-none focus:border-accent/50"
         >
           {Object.keys(TYPE_COLORS).map(t => (
             <option key={t} value={t}>{t}</option>
@@ -93,7 +93,7 @@ function EditForm({ item, onSave, onCancel }: {
         </select>
         <div className="flex-1" />
         <button onClick={onCancel} className="px-3 py-1 text-xs text-text-muted hover:text-text-secondary cursor-pointer transition-colors">Cancel</button>
-        <button onClick={handleSave} disabled={saving || !content.trim()} className="px-3 py-1 bg-[#6366f1] text-white text-xs rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#5558e6] transition-colors">
+        <button onClick={handleSave} disabled={saving || !content.trim()} className="px-3 py-1 bg-accent text-white text-xs rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent-hover transition-colors">
           {saving ? 'Saving...' : 'Save'}
         </button>
       </div>
@@ -103,7 +103,7 @@ function EditForm({ item, onSave, onCancel }: {
           {categories.map(cat => {
             const selected = selectedCatIds.has(cat.id);
             return (
-              <button key={cat.id} onClick={() => toggleCat(cat.id)} className={`text-[10px] px-1.5 py-0.5 rounded cursor-pointer transition-colors ${selected ? 'bg-[#6366f1]/25 text-[#6366f1] border border-[#6366f1]/40' : 'bg-surface-raised text-text-dim border border-border-subtle hover:text-text-muted hover:border-border'}`}>
+              <button key={cat.id} onClick={() => toggleCat(cat.id)} className={`text-[10px] px-1.5 py-0.5 rounded cursor-pointer transition-colors ${selected ? 'bg-accent/25 text-accent border border-accent/40' : 'bg-surface-raised text-text-dim border border-border-subtle hover:text-text-muted hover:border-border'}`}>
                 {cat.name.replace(/_/g, ' ')}
               </button>
             );
@@ -187,10 +187,10 @@ function CategorySummaryEditor({ category }: { category: Category }) {
 
   return (
     <div className="px-3 py-2 bg-bg-sunken border-b border-border-subtle">
-      <textarea value={value} onChange={e => setValue(e.target.value)} rows={3} autoFocus className="w-full bg-surface-raised border border-border-subtle rounded px-2 py-1.5 text-[11px] text-[#ddd] outline-none focus:border-[#6366f1]/50 resize-none" />
+      <textarea value={value} onChange={e => setValue(e.target.value)} rows={3} autoFocus className="w-full bg-surface-raised border border-border-subtle rounded px-2 py-1.5 text-[11px] text-text-secondary outline-none focus:border-accent/50 resize-none" />
       <div className="flex justify-end gap-2 mt-1">
         <button onClick={() => setEditingCategoryId(null)} className="px-2 py-0.5 text-[10px] text-text-muted hover:text-text-secondary cursor-pointer">Cancel</button>
-        <button onClick={handleSave} disabled={saving} className="px-2 py-0.5 bg-[#6366f1] text-white text-[10px] rounded cursor-pointer disabled:opacity-40 hover:bg-[#5558e6] transition-colors">
+        <button onClick={handleSave} disabled={saving} className="px-2 py-0.5 bg-accent text-white text-[10px] rounded cursor-pointer disabled:opacity-40 hover:bg-accent-hover transition-colors">
           {saving ? 'Saving...' : 'Save'}
         </button>
       </div>
@@ -214,14 +214,14 @@ function CreateCategoryForm({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <div className="border border-[#6366f1]/30 rounded-lg p-3 bg-[#6366f1]/5 mx-3 mb-3">
+    <div className="border border-accent/30 rounded-lg p-3 bg-accent/5 mx-3 mb-3">
       <div className="flex items-center justify-between mb-2">
         <span className="text-[12px] font-medium">New Category</span>
         <button onClick={onClose} className="text-text-faint hover:text-text-muted cursor-pointer"><X size={12} /></button>
       </div>
-      <input type="text" placeholder="Name (e.g. travel_plans)" value={name} onChange={e => setName(e.target.value)} className="w-full bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-[#ddd] mb-2 outline-none focus:border-[#6366f1]/50" />
-      <input type="text" placeholder="Description" value={desc} onChange={e => setDesc(e.target.value)} className="w-full bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-[#ddd] mb-2 outline-none focus:border-[#6366f1]/50" />
-      <button onClick={handleCreate} disabled={!name.trim() || creating} className="px-3 py-1 bg-[#6366f1] text-white text-[11px] rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#5558e6] transition-colors">
+      <input type="text" placeholder="Name (e.g. travel_plans)" value={name} onChange={e => setName(e.target.value)} className="w-full bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-text-secondary mb-2 outline-none focus:border-accent/50" />
+      <input type="text" placeholder="Description" value={desc} onChange={e => setDesc(e.target.value)} className="w-full bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-text-secondary mb-2 outline-none focus:border-accent/50" />
+      <button onClick={handleCreate} disabled={!name.trim() || creating} className="px-3 py-1 bg-accent text-white text-[11px] rounded cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed hover:bg-accent-hover transition-colors">
         {creating ? 'Creating...' : 'Create'}
       </button>
     </div>
@@ -264,8 +264,8 @@ function Heatmap({ items, onDayClick, selectedDate }: { items: MemoryItem[]; onD
   }, [dayCounts]);
 
   const getColor = (count: number, dateStr: string) => {
-    if (selectedDate === dateStr) return '#6366f1';
-    if (count === 0) return '#161616';
+    if (selectedDate === dateStr) return 'var(--theme-accent)';
+    if (count === 0) return 'var(--theme-surface)';
     if (count <= 2) return '#f59e0b33';
     if (count <= 5) return '#f59e0b88';
     return '#f59e0b';
@@ -456,9 +456,9 @@ function TimelineView() {
     <div className="flex flex-col h-full">
       <Heatmap items={allEvents} onDayClick={handleDayClick} selectedDate={filterDate} />
       {filterDate && (
-        <div className="px-3 py-1.5 bg-[#f59e0b]/10 border-b border-border-subtle flex items-center gap-2">
-          <span className="text-[11px] text-[#f59e0b]">Showing: {filterDate}</span>
-          <button onClick={() => setFilterDate(null)} className="text-[#f59e0b] hover:text-[#fbbf24] cursor-pointer"><X size={12} /></button>
+        <div className="px-3 py-1.5 bg-warning/10 border-b border-border-subtle flex items-center gap-2">
+          <span className="text-[11px] text-warning">Showing: {filterDate}</span>
+          <button onClick={() => setFilterDate(null)} className="text-warning hover:text-warning cursor-pointer"><X size={12} /></button>
         </div>
       )}
       <div className="flex-1 overflow-y-auto p-3">
@@ -468,8 +468,8 @@ function TimelineView() {
         {grouped.map(group => (
           <div key={group.dateKey} id={`timeline-date-${group.dateKey}`} className="mb-4">
             <div className="flex items-center gap-2 mb-2 px-2">
-              <Clock size={12} className="text-[#f59e0b]" />
-              <span className="text-[12px] text-[#f59e0b] font-medium">{formatDateGroup(group.date)}</span>
+              <Clock size={12} className="text-warning" />
+              <span className="text-[12px] text-warning font-medium">{formatDateGroup(group.date)}</span>
             </div>
             <div className="border-l-2 border-border-subtle ml-3 pl-4 space-y-1">
               {group.items.map(item => {
@@ -478,7 +478,7 @@ function TimelineView() {
                 const catIds = itemCategoryMap[item.id] || [];
                 return (
                   <div key={item.id} className="group flex items-start gap-2 px-2 py-1.5 rounded hover:bg-surface-raised transition-colors">
-                    <div className="w-2 h-2 rounded-full bg-[#f59e0b] mt-1.5 shrink-0" />
+                    <div className="w-2 h-2 rounded-full bg-warning mt-1.5 shrink-0" />
                     <div className="flex-1 min-w-0">
                       <div className="text-[12px] text-text-secondary">{item.summary}</div>
                       {catIds.length > 0 && (
@@ -533,8 +533,8 @@ function SourcesView() {
       {grouped.map(group => (
         <div key={group.date}>
           <div className="flex items-center gap-2 mb-2 px-1">
-            <Clock size={12} className="text-[#3b82f6]" />
-            <span className="text-[12px] text-[#3b82f6] font-medium">{formatDateGroup(group.date)}</span>
+            <Clock size={12} className="text-info" />
+            <span className="text-[12px] text-info font-medium">{formatDateGroup(group.date)}</span>
             <span className="text-[10px] text-text-faint">{group.resources.length} sources</span>
           </div>
           <div className="space-y-2 ml-3">
@@ -578,7 +578,7 @@ function SourcesView() {
 
 const ACTION_COLORS: Record<string, string> = {
   item_created: '#22c55e',
-  item_updated: '#6366f1',
+  item_updated: 'var(--theme-accent)',
   item_deleted: '#ef4444',
   category_created: '#a855f7',
   category_updated: '#a855f7',
@@ -595,11 +595,11 @@ function LogView() {
   return (
     <div className="p-3 space-y-1">
       <div className="flex gap-2 mb-3">
-        <select value={auditFilter.action} onChange={e => setAuditFilter({ action: e.target.value })} className="bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-[#ddd] outline-none">
+        <select value={auditFilter.action} onChange={e => setAuditFilter({ action: e.target.value })} className="bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-text-secondary outline-none">
           <option value="">All actions</option>
           {Object.keys(ACTION_COLORS).map(a => <option key={a} value={a}>{a.replace(/_/g, ' ')}</option>)}
         </select>
-        <select value={auditFilter.target_type} onChange={e => setAuditFilter({ target_type: e.target.value })} className="bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-[#ddd] outline-none">
+        <select value={auditFilter.target_type} onChange={e => setAuditFilter({ target_type: e.target.value })} className="bg-surface-raised border border-border-subtle rounded px-2 py-1 text-[12px] text-text-secondary outline-none">
           <option value="">All types</option>
           <option value="item">item</option>
           <option value="category">category</option>
@@ -662,7 +662,7 @@ function Sidebar() {
       <div className="flex-1 overflow-y-auto p-3">
         <div className="text-[11px] text-text-dim uppercase tracking-wider mb-2">Categories</div>
         {selectedCategory && (
-          <button onClick={() => setSelectedCategory(null)} className="w-full text-left px-2 py-1 mb-1 text-[11px] text-[#6366f1] hover:bg-surface-raised rounded cursor-pointer transition-colors flex items-center gap-1">
+          <button onClick={() => setSelectedCategory(null)} className="w-full text-left px-2 py-1 mb-1 text-[11px] text-accent hover:bg-surface-raised rounded cursor-pointer transition-colors flex items-center gap-1">
             <X size={10} /> Clear filter
           </button>
         )}
@@ -670,7 +670,7 @@ function Sidebar() {
           {categories.map(cat => {
             const isActive = selectedCategory === cat.id;
             return (
-              <button key={cat.id} onClick={() => setSelectedCategory(isActive ? null : cat.id)} className={`w-full text-left px-2 py-1.5 rounded text-[12px] cursor-pointer transition-colors flex items-center gap-2 ${isActive ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-muted hover:bg-surface-raised hover:text-text-secondary'}`}>
+              <button key={cat.id} onClick={() => setSelectedCategory(isActive ? null : cat.id)} className={`w-full text-left px-2 py-1.5 rounded text-[12px] cursor-pointer transition-colors flex items-center gap-2 ${isActive ? 'bg-accent/15 text-accent' : 'text-text-muted hover:bg-surface-raised hover:text-text-secondary'}`}>
                 <span className="flex-1 truncate">{cat.name.replace(/_/g, ' ')}</span>
                 <span className="text-[10px] text-text-dim">{catCounts[cat.id] || 0}</span>
               </button>
@@ -724,7 +724,7 @@ export function MemuPage() {
         </div>
         <div className="flex gap-1 items-center">
           {TABS.map(tab => (
-            <button key={tab.key} onClick={() => setActiveTab(tab.key)} className={`px-3 py-1 rounded text-xs cursor-pointer transition-colors ${activeTab === tab.key ? 'bg-[#6366f1]/20 text-[#6366f1]' : 'text-text-dim hover:text-text-muted'}`}>
+            <button key={tab.key} onClick={() => setActiveTab(tab.key)} className={`px-3 py-1 rounded text-xs cursor-pointer transition-colors ${activeTab === tab.key ? 'bg-accent/20 text-accent' : 'text-text-dim hover:text-text-muted'}`}>
               {tab.key === 'log' && <History size={11} className="inline mr-1 -mt-0.5" />}{tab.label}
             </button>
           ))}
@@ -738,7 +738,7 @@ export function MemuPage() {
             <div className="px-3 py-2 border-b border-border-subtle shrink-0">
               <div className="relative">
                 <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-faint" />
-                <input type="text" value={searchQuery} onChange={e => setSearchQuery(e.target.value)} placeholder={`Search ${activeTab === 'facts' ? 'facts' : 'events'}...`} className="w-full bg-surface-raised border border-border-subtle rounded pl-8 pr-3 py-1.5 text-[12px] text-[#ddd] outline-none focus:border-border-subtle placeholder:text-text-faint" />
+                <input type="text" value={searchQuery} onChange={e => setSearchQuery(e.target.value)} placeholder={`Search ${activeTab === 'facts' ? 'facts' : 'events'}...`} className="w-full bg-surface-raised border border-border-subtle rounded pl-8 pr-3 py-1.5 text-[12px] text-text-secondary outline-none focus:border-border-subtle placeholder:text-text-faint" />
                 {searchQuery && (
                   <button onClick={() => setSearchQuery('')} className="absolute right-2 top-1/2 -translate-y-1/2 text-text-faint hover:text-text-muted cursor-pointer"><X size={12} /></button>
                 )}

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -60,7 +60,7 @@ function FreeTextInput({ onSubmit }: { onSubmit: (text: string) => void }) {
           }
           if (e.key === 'Escape') setOpen(false);
         }}
-        className="flex-1 bg-surface-raised border border-border-subtle rounded-lg px-3 py-1 text-sm text-text outline-none focus:border-[#6366f1]"
+        className="flex-1 bg-surface-raised border border-border-subtle rounded-lg px-3 py-1 text-sm text-text outline-none focus:border-accent"
         placeholder="Type your answer..."
       />
       <button
@@ -71,7 +71,7 @@ function FreeTextInput({ onSubmit }: { onSubmit: (text: string) => void }) {
             setOpen(false);
           }
         }}
-        className="px-3 py-1 bg-[#6366f1]/15 text-[#6366f1] rounded-lg text-sm border border-[#6366f1]/30 hover:bg-[#6366f1]/25 cursor-pointer"
+        className="px-3 py-1 bg-accent/15 text-accent rounded-lg text-sm border border-accent/30 hover:bg-accent/25 cursor-pointer"
       >
         Send
       </button>
@@ -119,7 +119,7 @@ function NotificationCard({ notif }: { notif: Notification }) {
       <div className="flex items-center gap-3 mt-2 text-[12px]">
         <button
           onClick={() => navigate(`/chat/${notif.session_id}`)}
-          className="text-[#6366f1] hover:underline cursor-pointer"
+          className="text-accent hover:underline cursor-pointer"
         >
           Session: {notif.session_title || notif.session_id}
         </button>
@@ -142,7 +142,7 @@ function NotificationCard({ notif }: { notif: Notification }) {
             <button
               key={opt}
               onClick={() => answerNotification(notif.id, opt)}
-              className="px-3 py-1.5 bg-[#6366f1]/15 text-[#6366f1] rounded-lg text-sm border border-[#6366f1]/30 hover:bg-[#6366f1]/25 cursor-pointer transition-colors"
+              className="px-3 py-1.5 bg-accent/15 text-accent rounded-lg text-sm border border-accent/30 hover:bg-accent/25 cursor-pointer transition-colors"
             >
               {opt}
             </button>
@@ -172,7 +172,7 @@ export function NotificationsPage() {
   return (
     <div className="h-full flex flex-col">
       <div className="border-b border-border-subtle px-6 py-3 flex items-center gap-4 bg-bg shrink-0">
-        <Bell size={18} className="text-[#6366f1]" />
+        <Bell size={18} className="text-accent" />
         <h1 className="text-lg font-semibold">Notifications</h1>
 
         {/* Status filters */}
@@ -183,7 +183,7 @@ export function NotificationsPage() {
               onClick={() => setFilter(f.value)}
               className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors
                 ${filter === f.value
-                  ? 'bg-[#6366f1]/15 text-[#6366f1] border-[#6366f1]/30'
+                  ? 'bg-accent/15 text-accent border-accent/30'
                   : 'text-text-dim border-border hover:border-border hover:text-text-muted'
                 }`}
             >
@@ -200,7 +200,7 @@ export function NotificationsPage() {
               onClick={() => setTypeFilter(f.value)}
               className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors
                 ${typeFilter === f.value
-                  ? 'bg-[#6366f1]/15 text-[#6366f1] border-[#6366f1]/30'
+                  ? 'bg-accent/15 text-accent border-accent/30'
                   : 'text-text-dim border-border hover:border-border hover:text-text-muted'
                 }`}
             >

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -121,7 +121,7 @@ export function PlanDetailPage() {
           {plan.model && <span>{plan.model}</span>}
           <button
             onClick={() => navigate(`/tasks/${plan.task_id}`)}
-            className="flex items-center gap-1 text-[#6366f1] hover:text-[#818cf8] cursor-pointer"
+            className="flex items-center gap-1 text-accent hover:text-link cursor-pointer"
           >
             <ExternalLink size={11} /> View task
           </button>
@@ -146,9 +146,9 @@ export function PlanDetailPage() {
           {/* Feedback from previous revision — quote style */}
           {plan.feedback && (
             <div className="mt-4 flex gap-0">
-              <div className="w-1 bg-[#6366f1]/40 rounded-full shrink-0" />
+              <div className="w-1 bg-accent/40 rounded-full shrink-0" />
               <div className="pl-3 py-2">
-                <div className="text-[11px] text-[#6366f1]/60 font-medium mb-1">Revision feedback</div>
+                <div className="text-[11px] text-accent/60 font-medium mb-1">Revision feedback</div>
                 <div className="text-[13px] text-text-muted leading-relaxed whitespace-pre-wrap">{plan.feedback}</div>
               </div>
             </div>
@@ -180,7 +180,7 @@ export function PlanDetailPage() {
                         <select
                           value={hoaMode}
                           onChange={e => setHoaMode(e.target.value)}
-                          className="px-2 py-1 text-[12px] bg-surface-raised border border-border-subtle rounded text-text-secondary focus:outline-none focus:border-[#6366f1]/50"
+                          className="px-2 py-1 text-[12px] bg-surface-raised border border-border-subtle rounded text-text-secondary focus:outline-none focus:border-accent/50"
                         >
                           <option value="relay">Relay</option>
                           <option value="swarm">Swarm</option>
@@ -193,7 +193,7 @@ export function PlanDetailPage() {
                           value={hoaAgents}
                           onChange={e => setHoaAgents(e.target.value)}
                           placeholder="Claude, OpenAI"
-                          className="px-2 py-1 text-[12px] bg-surface-raised border border-border-subtle rounded text-text-secondary placeholder-[#555] focus:outline-none focus:border-[#6366f1]/50 w-40"
+                          className="px-2 py-1 text-[12px] bg-surface-raised border border-border-subtle rounded text-text-secondary placeholder:text-placeholder focus:outline-none focus:border-accent/50 w-40"
                         />
                       </div>
                     </div>
@@ -232,13 +232,13 @@ export function PlanDetailPage() {
               {showFeedback && (
                 <div className="space-y-2">
                   <div className="flex gap-0">
-                    <div className="w-1 bg-[#6366f1]/30 rounded-full shrink-0" />
+                    <div className="w-1 bg-accent/30 rounded-full shrink-0" />
                     <div className="flex-1 pl-3">
                       <textarea
                         value={feedback}
                         onChange={e => setFeedback(e.target.value)}
                         placeholder="Describe what to change..."
-                        className="w-full p-3 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary placeholder-[#555] focus:outline-none focus:border-[#6366f1]/50 resize-none"
+                        className="w-full p-3 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary placeholder:text-placeholder focus:outline-none focus:border-accent/50 resize-none"
                         rows={3}
                         autoFocus
                       />
@@ -248,7 +248,7 @@ export function PlanDetailPage() {
                     <button
                       onClick={handleRevise}
                       disabled={actionLoading || !feedback.trim()}
-                      className="px-4 py-2 text-[13px] bg-[#6366f1] hover:bg-[#818cf8] disabled:opacity-50 text-white rounded-lg cursor-pointer"
+                      className="px-4 py-2 text-[13px] bg-accent hover:bg-accent-hover disabled:opacity-50 text-white rounded-lg cursor-pointer"
                     >
                       Send Revision Request
                     </button>

--- a/web/src/pages/PlansPage.tsx
+++ b/web/src/pages/PlansPage.tsx
@@ -65,7 +65,7 @@ export function PlansPage() {
   return (
     <div className="h-full flex flex-col">
       <div className="border-b border-border-subtle px-6 py-3 flex items-center gap-4 bg-bg shrink-0">
-        <Lightbulb size={18} className="text-[#6366f1]" />
+        <Lightbulb size={18} className="text-accent" />
         <h1 className="text-lg font-semibold">Plans</h1>
         <div className="flex items-center gap-1 ml-2">
           {FILTERS.map(f => (
@@ -74,7 +74,7 @@ export function PlansPage() {
               onClick={() => setFilter(f.value)}
               className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors
                 ${filter === f.value
-                  ? 'bg-[#6366f1]/15 text-[#6366f1] border-[#6366f1]/30'
+                  ? 'bg-accent/15 text-accent border-accent/30'
                   : 'text-text-dim border-border hover:border-border hover:text-text-muted'
                 }`}
             >

--- a/web/src/pages/SkillDetailPage.tsx
+++ b/web/src/pages/SkillDetailPage.tsx
@@ -100,7 +100,7 @@ export function SkillDetailPage() {
             <button
               onClick={handleSave}
               disabled={actionLoading}
-              className="flex items-center gap-1 px-2 py-1 text-xs bg-[#6366f1] text-white rounded hover:bg-[#5558e6] cursor-pointer disabled:opacity-50"
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-accent text-white rounded hover:bg-accent-hover cursor-pointer disabled:opacity-50"
             >
               <Save size={12} />
               Save
@@ -218,7 +218,7 @@ export function SkillDetailPage() {
               <h3 className="text-xs font-medium text-text-muted mb-2">References</h3>
               <div className="space-y-1">
                 {selectedSkill.references.map(ref => (
-                  <div key={ref} className="text-xs text-[#6366f1] font-mono truncate">{ref}</div>
+                  <div key={ref} className="text-xs text-accent font-mono truncate">{ref}</div>
                 ))}
               </div>
             </div>

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -12,7 +12,7 @@ function SkillCard({ skill }: { skill: Skill }) {
 
   return (
     <div
-      className="bg-surface-raised border border-border rounded-lg p-4 hover:border-[#3a3a3a] cursor-pointer transition-colors"
+      className="bg-surface-raised border border-border rounded-lg p-4 hover:border-border cursor-pointer transition-colors"
       onClick={() => navigate(`/skills/${encodeURIComponent(skill.id)}`)}
     >
       <div className="flex items-start justify-between mb-2">
@@ -87,7 +87,7 @@ function CreateSkillDialog() {
             <label className="text-xs text-text-muted block mb-1">Name</label>
             <input
               value={name} onChange={e => setName(e.target.value)}
-              className="w-full bg-bg border border-border rounded px-3 py-1.5 text-sm text-text outline-none focus:border-[#6366f1]"
+              className="w-full bg-bg border border-border rounded px-3 py-1.5 text-sm text-text outline-none focus:border-accent"
               placeholder="e.g. code-review"
               autoFocus
             />
@@ -96,7 +96,7 @@ function CreateSkillDialog() {
             <label className="text-xs text-text-muted block mb-1">Description</label>
             <textarea
               value={description} onChange={e => setDescription(e.target.value)}
-              className="w-full bg-bg border border-border rounded px-3 py-1.5 text-sm text-text outline-none focus:border-[#6366f1] min-h-[60px] resize-y"
+              className="w-full bg-bg border border-border rounded px-3 py-1.5 text-sm text-text outline-none focus:border-accent min-h-[60px] resize-y"
               placeholder='This skill should be used when the user asks to "review code"...'
             />
           </div>
@@ -104,7 +104,7 @@ function CreateSkillDialog() {
             <label className="text-xs text-text-muted block mb-1">Instructions (optional)</label>
             <textarea
               value={content} onChange={e => setContent(e.target.value)}
-              className="w-full bg-bg border border-border rounded px-3 py-1.5 text-sm text-text outline-none focus:border-[#6366f1] min-h-[120px] resize-y font-mono text-xs"
+              className="w-full bg-bg border border-border rounded px-3 py-1.5 text-sm text-text outline-none focus:border-accent min-h-[120px] resize-y font-mono text-xs"
               placeholder="Markdown instructions for the agent..."
             />
           </div>
@@ -116,7 +116,7 @@ function CreateSkillDialog() {
           <button
             onClick={handleCreate}
             disabled={!name.trim() || !description.trim() || actionLoading}
-            className="px-3 py-1.5 text-xs bg-[#6366f1] text-white rounded hover:bg-[#5558e6] disabled:opacity-50 cursor-pointer disabled:cursor-default"
+            className="px-3 py-1.5 text-xs bg-accent text-white rounded hover:bg-accent-hover disabled:opacity-50 cursor-pointer disabled:cursor-default"
           >
             {actionLoading ? 'Creating...' : 'Create Skill'}
           </button>
@@ -153,7 +153,7 @@ export function SkillsPage() {
           </button>
           <button
             onClick={() => setShowCreateDialog(true)}
-            className="flex items-center gap-1 px-2 py-1 text-xs bg-[#6366f1] text-white rounded hover:bg-[#5558e6] cursor-pointer"
+            className="flex items-center gap-1 px-2 py-1 text-xs bg-accent text-white rounded hover:bg-accent-hover cursor-pointer"
           >
             <Plus size={12} />
             New Skill
@@ -172,7 +172,7 @@ export function SkillsPage() {
             <p className="text-xs text-text-faint">
               Create skills to extend the agent with specialized workflows.
               <br />
-              Skills are stored as SKILL.md files in <code className="text-[#6366f1]">workspace/skills/</code>
+              Skills are stored as SKILL.md files in <code className="text-accent">workspace/skills/</code>
             </p>
           </div>
         ) : (

--- a/web/src/pages/SourcesPage.tsx
+++ b/web/src/pages/SourcesPage.tsx
@@ -119,7 +119,7 @@ function SourceSidebar() {
         {(['inbox', 'runs', 'consumers'] as const).map(tab => (
           <button key={tab} onClick={() => setActiveTab(tab)}
             className={`flex-1 py-2 text-[12px] font-medium transition-colors cursor-pointer
-              ${activeTab === tab ? 'text-[#6366f1] border-b-2 border-[#6366f1]' : 'text-text-dim hover:text-text-muted'}`}>
+              ${activeTab === tab ? 'text-accent border-b-2 border-accent' : 'text-text-dim hover:text-text-muted'}`}>
             {tab === 'inbox' ? 'Inbox' : tab === 'runs' ? 'Runs' : 'Consumers'}
           </button>
         ))}
@@ -129,7 +129,7 @@ function SourceSidebar() {
       <div className="p-2 space-y-1">
         <button onClick={() => setActiveSource(null)}
           className={`w-full flex items-center justify-between px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer
-            ${activeSource === null ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
+            ${activeSource === null ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
           <span className="flex items-center gap-2"><Inbox size={14} /> All</span>
           <span className="text-[11px] opacity-70 tabular-nums shrink-0">{totalMessages}</span>
         </button>
@@ -140,7 +140,7 @@ function SourceSidebar() {
             <div key={src} className="group">
               <button onClick={() => setActiveSource(src)}
                 className={`w-full flex items-center justify-between px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer
-                  ${activeSource === src ? 'bg-[#6366f1]/15 text-[#6366f1]' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
+                  ${activeSource === src ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
                 <span className="flex items-center gap-1.5 min-w-0 truncate">
                   {sourceIcon(src)}
                   <span className="truncate">{sourceLabel(src)}</span>
@@ -295,7 +295,7 @@ function MessageList() {
         return (
           <button key={`${msg.source}:${msg.id}`} onClick={() => selectMessage(msg.source, msg.id)}
             className={`w-full text-left px-3 py-2.5 border-b border-border-subtle transition-colors cursor-pointer
-              ${isSelected ? 'bg-[#6366f1]/10 border-l-2 border-l-[#6366f1]' : 'hover:bg-surface'}`}>
+              ${isSelected ? 'bg-accent/10 border-l-2 border-l-accent' : 'hover:bg-surface'}`}>
             <div className="flex items-center gap-2 mb-0.5">
               <span className={`text-[10px] px-1.5 py-0.5 rounded ${sourceBadgeColor(msg.source)}`}>
                 {msg.source.split(':')[0]}
@@ -376,7 +376,7 @@ function RunsList() {
             type="checkbox"
             checked={hideEmpty}
             onChange={(e) => setHideEmpty(e.target.checked)}
-            className="accent-[#6366f1] cursor-pointer"
+            className="accent-accent cursor-pointer"
           />
           Hide empty
         </label>
@@ -398,7 +398,7 @@ function RunsList() {
               return (
                 <tr key={run.id} onClick={() => selectRun(run)}
                   className={`border-t border-border-subtle cursor-pointer transition-colors
-                    ${isSelected ? 'bg-[#6366f1]/10' : 'hover:bg-surface'}`}>
+                    ${isSelected ? 'bg-accent/10' : 'hover:bg-surface'}`}>
                   <td className="px-3 py-2">
                     <span className="flex items-center gap-1.5">
                       {sourceIcon(run.source)}
@@ -484,7 +484,7 @@ function RunDetail() {
         {/* Session link */}
         {run.session_id && (
           <button onClick={() => navigate(`/chat/${run.session_id}`)}
-            className="flex items-center gap-1.5 mt-2 text-[12px] text-[#6366f1] hover:text-[#818cf8] transition-colors cursor-pointer">
+            className="flex items-center gap-1.5 mt-2 text-[12px] text-accent hover:text-link transition-colors cursor-pointer">
             <ExternalLink size={12} /> View processing session
           </button>
         )}
@@ -566,7 +566,7 @@ function MessageDetail() {
         {/* Session link */}
         {msg.run_session_id && (
           <button onClick={() => navigate(`/chat/${msg.run_session_id}`)}
-            className="flex items-center gap-1.5 mt-2 text-[12px] text-[#6366f1] hover:text-[#818cf8] transition-colors cursor-pointer">
+            className="flex items-center gap-1.5 mt-2 text-[12px] text-accent hover:text-link transition-colors cursor-pointer">
             <ExternalLink size={12} /> View processing session
           </button>
         )}

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -70,7 +70,7 @@ export function TaskDetailPage() {
         <span>Task not found</span>
         <button
           onClick={() => navigate('/tasks')}
-          className="text-[13px] text-[#6366f1] hover:underline cursor-pointer"
+          className="text-[13px] text-accent hover:underline cursor-pointer"
         >
           Back to tasks
         </button>
@@ -117,7 +117,7 @@ export function TaskDetailPage() {
               <button
                 onClick={handleSave}
                 disabled={saving}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] bg-[#6366f1] hover:bg-[#818cf8] text-white rounded-md cursor-pointer disabled:opacity-50"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] bg-accent hover:bg-accent-hover text-white rounded-md cursor-pointer disabled:opacity-50"
               >
                 <Save size={12} />
                 {saving ? 'Saving...' : 'Save'}
@@ -154,7 +154,7 @@ export function TaskDetailPage() {
               href={selectedTask.source_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1 text-[#6366f1] hover:underline"
+              className="flex items-center gap-1 text-accent hover:underline"
             >
               <ExternalLink size={11} /> source
             </a>

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -46,7 +46,7 @@ export function TasksPage() {
               onChange={e => handleSearchChange(e.target.value)}
               placeholder="Search..."
               className="pl-8 pr-7 py-1.5 w-48 text-[13px] bg-surface-raised border border-border-subtle rounded-lg
-                text-text-secondary placeholder-[#555] focus:outline-none focus:border-[#6366f1]/50
+                text-text-secondary placeholder:text-placeholder focus:outline-none focus:border-accent/50
                 transition-colors"
             />
             {localQuery && (
@@ -61,7 +61,7 @@ export function TasksPage() {
         </div>
         <button
           onClick={() => setShowCreateDialog(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-[#6366f1] hover:bg-[#818cf8] text-white rounded-lg cursor-pointer"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer"
         >
           <Plus size={14} /> New Task
         </button>

--- a/web/src/stores/themeStore.ts
+++ b/web/src/stores/themeStore.ts
@@ -9,7 +9,7 @@ interface ThemeState {
 }
 
 const STORAGE_KEY = 'nerve-theme';
-const CYCLE_ORDER: ThemePreference[] = ['system', 'light', 'dark'];
+const CYCLE_ORDER: ThemePreference[] = ['dark', 'light', 'system'];
 
 function applyTheme(pref: ThemePreference) {
   const el = document.documentElement;
@@ -23,7 +23,7 @@ function applyTheme(pref: ThemePreference) {
 function getInitialPreference(): ThemePreference {
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === 'light' || stored === 'dark' || stored === 'system') return stored;
-  return 'system';
+  return 'dark';
 }
 
 export const useThemeStore = create<ThemeState>((set, get) => {


### PR DESCRIPTION
## Summary

- Add 9 new CSS theme tokens (`accent`, `accent-hover`, `accent-muted`, `accent-text`, `placeholder`, `success`, `error`, `warning`, `info`) with per-theme values for dark and light
- Replace hardcoded `#6366f1` and `indigo-*` Tailwind classes across 42+ files with `accent` token
- Fix broken light-mode colors: `text-[#ddd]`, `placeholder-[#555]`, `bg-[#111118]`, `bg-[#0a0a0e]` and other dark-only hex values replaced with theme-aware tokens
- Invert chat message backgrounds in light theme — assistant messages get lighter (white) bg instead of darker
- Table row stripes use `color-mix()` for subtle auto-adapting contrast in both themes
- Default theme changed from `system` to `dark`; cycle order: dark → light → system

> *Generated by [Nerve](https://github.com/pufit/nerve)*