### PR TITLE
Fix diff panel and subagent colors in dark mode

### DIFF
--- a/web/src/components/Chat/DiffView.tsx
+++ b/web/src/components/Chat/DiffView.tsx
@@ -8,7 +8,7 @@ import type { FileDiff, DiffHunk, DiffLine as DiffLineType } from '../../types/c
 function HunkHeader({ hunk }: { hunk: DiffHunk }) {
   return (
     <div className="bg-accent/10 text-[11px] px-3 py-1 border-y border-accent/20 select-none flex items-center gap-2 sticky top-0 z-[1]">
-      <span className="text-accent font-mono">
+      <span className="text-link font-mono">
         @@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@
       </span>
       {hunk.header && (

--- a/web/src/components/Chat/SidePanel.tsx
+++ b/web/src/components/Chat/SidePanel.tsx
@@ -17,7 +17,7 @@ const TAB_ICONS: Record<string, typeof Bot> = {
 const TAB_COLORS: Record<string, string> = {
   Plan: 'text-amber-400',
   Explore: 'text-cyan-400',
-  'general-purpose': 'text-accent',
+  'general-purpose': 'text-link',
   files: 'text-teal-400',
 };
 
@@ -130,7 +130,7 @@ function TabHeader({ tab, onClose }: { tab: PanelTab; onClose: () => void }) {
 // ------------------------------------------------------------------ //
 
 function TabContent({ tab, containerRef }: { tab: PanelTab; containerRef: React.RefObject<HTMLDivElement | null> }) {
-  const cursorColor = tab.type === 'plan' ? 'bg-amber-400' : 'bg-accent';
+  const cursorColor = tab.type === 'plan' ? 'bg-amber-400' : 'bg-link';
   const hasBlocks = tab.blocks.length > 0;
   const endRef = useRef<HTMLDivElement>(null);
   const isNearBottom = useRef(true);

--- a/web/src/components/Chat/tools/SubagentToolBlock.tsx
+++ b/web/src/components/Chat/tools/SubagentToolBlock.tsx
@@ -14,7 +14,7 @@ const AGENT_ICONS: Record<string, typeof Bot> = {
 const AGENT_COLORS: Record<string, string> = {
   Explore: 'text-cyan-400',
   Plan: 'text-amber-400',
-  'general-purpose': 'text-accent',
+  'general-purpose': 'text-link',
 };
 
 export function SubagentToolBlock({ block }: { block: ToolCallBlockData }) {


### PR DESCRIPTION
## Summary

- Fix diff hunk header, SidePanel agent tab, and subagent block using `text-accent` (#6366f1) instead of the intended lighter `text-link` (#818cf8) in dark mode
- `indigo-400` was intentionally lighter for readability on dark backgrounds — `accent` is too dark there, `link` provides the correct per-theme mapping

Follow-up to #30.

> *Generated by [Nerve](https://github.com/pufit/nerve)*