### PR TITLE
Add theme-aware color tokens for diffs and UI indicators

### DIFF
--- a/web/src/components/Auth/LoginPage.tsx
+++ b/web/src/components/Auth/LoginPage.tsx
@@ -25,7 +25,7 @@ export function LoginPage() {
           autoFocus
           className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded text-text outline-none focus:border-accent mb-4"
         />
-        {error && <p className="text-red-400 text-sm mb-3">{error}</p>}
+        {error && <p className="text-hue-red text-sm mb-3">{error}</p>}
         <button
           type="submit"
           disabled={loading}

--- a/web/src/components/Chat/BackgroundJobs.tsx
+++ b/web/src/components/Chat/BackgroundJobs.tsx
@@ -18,9 +18,9 @@ function toolIcon(tool: string) {
 }
 
 const STATUS_COLORS = {
-  running: 'text-emerald-400',
+  running: 'text-hue-emerald',
   done: 'text-text-faint',
-  timeout: 'text-amber-400',
+  timeout: 'text-hue-amber',
 } as const;
 
 export function BackgroundJobs({ sessions, activeSession, onSelect }: {
@@ -56,7 +56,7 @@ export function BackgroundJobs({ sessions, activeSession, onSelect }: {
       {/* Badge */}
       <div className={`flex items-center gap-1.5 px-2 py-1 rounded text-[12px] cursor-default ${
         runningTasks.length > 0
-          ? 'text-emerald-400 bg-emerald-400/10'
+          ? 'text-hue-emerald bg-emerald-400/10'
           : 'text-text-faint bg-surface-raised'
       }`}>
         {runningTasks.length > 0 ? (
@@ -98,11 +98,11 @@ export function BackgroundJobs({ sessions, activeSession, onSelect }: {
                     className="flex items-center gap-2 px-3 py-1.5 text-[12px]"
                   >
                     {task.status === 'running' ? (
-                      <Loader2 size={12} className="shrink-0 text-emerald-400 animate-spin" />
+                      <Loader2 size={12} className="shrink-0 text-hue-emerald animate-spin" />
                     ) : task.status === 'done' ? (
-                      <Check size={12} className="shrink-0 text-emerald-500" />
+                      <Check size={12} className="shrink-0 text-hue-emerald" />
                     ) : (
-                      <AlertTriangle size={12} className="shrink-0 text-amber-400" />
+                      <AlertTriangle size={12} className="shrink-0 text-hue-amber" />
                     )}
                     <span className={`flex-1 min-w-0 truncate ${statusColor}`}>
                       {task.label}
@@ -130,7 +130,7 @@ export function BackgroundJobs({ sessions, activeSession, onSelect }: {
                   onClick={() => { setHovering(false); onSelect(s.id); }}
                   className="w-full flex items-center gap-2 px-3 py-1.5 text-left text-[12px] text-text-muted hover:bg-border-subtle hover:text-text transition-colors cursor-pointer"
                 >
-                  <Loader2 size={12} className="shrink-0 text-emerald-400 animate-spin" />
+                  <Loader2 size={12} className="shrink-0 text-hue-emerald animate-spin" />
                   <span className="flex-1 min-w-0 truncate">{s.title || s.id}</span>
                   <span className="shrink-0 text-[10px] text-text-faint">
                     {s.source || 'web'}

--- a/web/src/components/Chat/CodeBlock.tsx
+++ b/web/src/components/Chat/CodeBlock.tsx
@@ -22,7 +22,7 @@ export function CodeBlock({ className, children }: { className?: string; childre
           className="text-text-dim hover:text-text-muted cursor-pointer p-1"
           title="Copy"
         >
-          {copied ? <Check size={14} className="text-emerald-400" /> : <Copy size={14} />}
+          {copied ? <Check size={14} className="text-hue-emerald" /> : <Copy size={14} />}
         </button>
       </div>
       <pre className="!mt-0 !rounded-t-none !border-t-0">

--- a/web/src/components/Chat/DiffView.tsx
+++ b/web/src/components/Chat/DiffView.tsx
@@ -23,15 +23,15 @@ function HunkHeader({ hunk }: { hunk: DiffHunk }) {
 // ------------------------------------------------------------------ //
 
 const LINE_STYLES: Record<string, string> = {
-  addition: 'bg-green-500/15',
-  deletion: 'bg-red-500/15',
+  addition: 'bg-diff-add-bg/25',
+  deletion: 'bg-diff-del-bg/25',
   context: '',
   info: '',
 };
 
 const TEXT_STYLES: Record<string, string> = {
-  addition: 'text-green-600',
-  deletion: 'text-red-600',
+  addition: 'text-diff-add/90',
+  deletion: 'text-diff-del/90',
   context: 'text-text-muted',
   info: 'text-text-faint italic',
 };
@@ -44,8 +44,8 @@ const PREFIX: Record<string, string> = {
 };
 
 const GUTTER_STYLES: Record<string, string> = {
-  addition: 'bg-green-500/10 border-green-500/20',
-  deletion: 'bg-red-500/10 border-red-500/20',
+  addition: 'bg-diff-add-bg/15 border-diff-add-bg/30',
+  deletion: 'bg-diff-del-bg/15 border-diff-del-bg/30',
   context: 'border-surface-raised',
   info: 'border-surface-raised',
 };

--- a/web/src/components/Chat/DiffView.tsx
+++ b/web/src/components/Chat/DiffView.tsx
@@ -8,7 +8,7 @@ import type { FileDiff, DiffHunk, DiffLine as DiffLineType } from '../../types/c
 function HunkHeader({ hunk }: { hunk: DiffHunk }) {
   return (
     <div className="bg-accent/10 text-[11px] px-3 py-1 border-y border-accent/20 select-none flex items-center gap-2 sticky top-0 z-[1]">
-      <span className="text-accent font-mono">
+      <span className="text-link font-mono">
         @@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@
       </span>
       {hunk.header && (

--- a/web/src/components/Chat/FileChangesPanel.tsx
+++ b/web/src/components/Chat/FileChangesPanel.tsx
@@ -17,9 +17,9 @@ const STATUS_ICON: Record<string, typeof FileEdit> = {
 };
 
 const STATUS_COLOR: Record<string, string> = {
-  created: 'text-green-400',
-  modified: 'text-amber-400',
-  deleted: 'text-red-400',
+  created: 'text-diff-add',
+  modified: 'text-warning',
+  deleted: 'text-diff-del',
 };
 
 const STATUS_BADGE: Record<string, string> = {
@@ -61,10 +61,10 @@ function FileCard({ file, onClick }: { file: ModifiedFileSummary; onClick: () =>
         </div>
         <div className="flex items-center gap-1.5 shrink-0 text-[11px] font-mono tabular-nums">
           {file.stats.additions > 0 && (
-            <span className="text-green-400">+{file.stats.additions}</span>
+            <span className="text-diff-add">+{file.stats.additions}</span>
           )}
           {file.stats.deletions > 0 && (
-            <span className="text-red-400">&minus;{file.stats.deletions}</span>
+            <span className="text-diff-del">&minus;{file.stats.deletions}</span>
           )}
         </div>
       </div>
@@ -110,10 +110,10 @@ function FileDetailView({ file, onBack }: { file: ModifiedFileSummary; onBack: (
         <span className={`text-[13px] font-medium ${color}`}>{fileName}</span>
         <div className="flex items-center gap-1.5 text-[11px] font-mono tabular-nums">
           {diff?.stats && diff.stats.additions > 0 && (
-            <span className="text-green-400">+{diff.stats.additions}</span>
+            <span className="text-diff-add">+{diff.stats.additions}</span>
           )}
           {diff?.stats && diff.stats.deletions > 0 && (
-            <span className="text-red-400">&minus;{diff.stats.deletions}</span>
+            <span className="text-diff-del">&minus;{diff.stats.deletions}</span>
           )}
         </div>
       </div>
@@ -130,7 +130,7 @@ function FileDetailView({ file, onBack }: { file: ModifiedFileSummary; onBack: (
           </div>
         )}
         {error && (
-          <div className="px-4 py-4 text-[13px] text-red-400">Failed to load diff: {error}</div>
+          <div className="px-4 py-4 text-[13px] text-hue-red">Failed to load diff: {error}</div>
         )}
         {diff && !loading && <DiffView diff={diff} />}
       </div>
@@ -178,8 +178,8 @@ export function FileChangesPanel() {
       <div className="flex items-center justify-between px-4 py-2 border-b border-border-subtle bg-bg-sunken shrink-0">
         <div className="flex items-center gap-2 text-[12px] text-text-muted">
           <span>{modifiedFiles.length} file{modifiedFiles.length !== 1 ? 's' : ''}</span>
-          {totalAdd > 0 && <span className="text-green-400 font-mono">+{totalAdd}</span>}
-          {totalDel > 0 && <span className="text-red-400 font-mono">&minus;{totalDel}</span>}
+          {totalAdd > 0 && <span className="text-hue-green font-mono">+{totalAdd}</span>}
+          {totalDel > 0 && <span className="text-hue-red font-mono">&minus;{totalDel}</span>}
         </div>
         <button
           onClick={handleRefresh}

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -277,7 +277,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
                     System ({systemSessions.length})
                   </span>
                   {runningSystemCount > 0 && (
-                    <span className="ml-auto flex items-center gap-1 text-[10px] text-emerald-500">
+                    <span className="ml-auto flex items-center gap-1 text-[10px] text-hue-emerald">
                       <span className="relative flex h-1.5 w-1.5">
                         <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
                         <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
@@ -424,7 +424,7 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, onRenam
         }`}
     >
       {isImplementSession(session)
-        ? <Hammer size={13} className="shrink-0 text-violet-400/60" />
+        ? <Hammer size={13} className="shrink-0 text-hue-violet/60" />
         : <MessageSquare size={13} className="shrink-0 opacity-50" />
       }
       <div className="flex-1 min-w-0">
@@ -447,13 +447,13 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, onRenam
           onClick={(e) => { e.stopPropagation(); setMenuOpen(!menuOpen); }}
           className={`p-0.5 cursor-pointer transition-opacity ${
             session.starred
-              ? 'text-yellow-500 opacity-100 [&>*:first-child]:block [&>*:last-child]:hidden hover:[&>*:first-child]:hidden hover:[&>*:last-child]:block hover:text-text-muted'
+              ? 'text-hue-yellow opacity-100 [&>*:first-child]:block [&>*:last-child]:hidden hover:[&>*:first-child]:hidden hover:[&>*:last-child]:block hover:text-text-muted'
               : 'text-border-subtle opacity-0 group-hover:opacity-100 hover:text-text-muted'
           }`}
         >
           {session.starred ? (
             <>
-              <Star size={13} className="fill-yellow-500" />
+              <Star size={13} className="fill-hue-yellow" />
               <MoreHorizontal size={14} />
             </>
           ) : (
@@ -471,7 +471,7 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, onRenam
               }}
               className="flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-text-secondary hover:bg-border-subtle cursor-pointer transition-colors"
             >
-              <Star size={14} className={session.starred ? 'text-yellow-500 fill-yellow-500' : ''} />
+              <Star size={14} className={session.starred ? 'text-hue-yellow fill-hue-yellow' : ''} />
               {session.starred ? 'Unstar' : 'Star'}
             </button>
             <button
@@ -493,7 +493,7 @@ function SessionItem({ session, isActive, isRunning, onSelect, onDelete, onRenam
                 setMenuOpen(false);
                 onDelete(session.id);
               }}
-              className="flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-red-400 hover:bg-border-subtle cursor-pointer transition-colors"
+              className="flex items-center gap-2.5 w-full px-3 py-1.5 text-[13px] text-hue-red hover:bg-border-subtle cursor-pointer transition-colors"
             >
               <Trash2 size={14} />
               Delete

--- a/web/src/components/Chat/SidePanel.tsx
+++ b/web/src/components/Chat/SidePanel.tsx
@@ -15,10 +15,10 @@ const TAB_ICONS: Record<string, typeof Bot> = {
 };
 
 const TAB_COLORS: Record<string, string> = {
-  Plan: 'text-amber-400',
-  Explore: 'text-cyan-400',
+  Plan: 'text-hue-amber',
+  Explore: 'text-hue-cyan',
   'general-purpose': 'text-link',
-  files: 'text-teal-400',
+  files: 'text-hue-teal',
 };
 
 function formatElapsed(startedAt: number, completedAt?: number): string {
@@ -68,7 +68,7 @@ function TabBar({ panels, activeId, onFocus, onClose }: {
           >
             {tab.status === 'running'
               ? <Loader2 size={11} className={`animate-spin ${color}`} />
-              : <Icon size={11} className={tab.isError ? 'text-red-400' : color} />
+              : <Icon size={11} className={tab.isError ? 'text-hue-red' : color} />
             }
             <span className="truncate max-w-[100px]">{tab.label}</span>
             {tab.status !== 'running' && tab.completedAt && (
@@ -100,7 +100,7 @@ function TabHeader({ tab, onClose }: { tab: PanelTab; onClose: () => void }) {
       <div className="flex items-center gap-2 min-w-0">
         {tab.status === 'running'
           ? <Loader2 size={14} className={`animate-spin shrink-0 ${color}`} />
-          : <Icon size={14} className={`shrink-0 ${tab.isError ? 'text-red-400' : color}`} />
+          : <Icon size={14} className={`shrink-0 ${tab.isError ? 'text-hue-red' : color}`} />
         }
         <span className="text-[13px] font-medium text-text-secondary">{tab.label}</span>
         {tab.description && (

--- a/web/src/components/Chat/SidePanel.tsx
+++ b/web/src/components/Chat/SidePanel.tsx
@@ -17,7 +17,7 @@ const TAB_ICONS: Record<string, typeof Bot> = {
 const TAB_COLORS: Record<string, string> = {
   Plan: 'text-amber-400',
   Explore: 'text-cyan-400',
-  'general-purpose': 'text-accent',
+  'general-purpose': 'text-link',
   files: 'text-teal-400',
 };
 
@@ -130,7 +130,7 @@ function TabHeader({ tab, onClose }: { tab: PanelTab; onClose: () => void }) {
 // ------------------------------------------------------------------ //
 
 function TabContent({ tab, containerRef }: { tab: PanelTab; containerRef: React.RefObject<HTMLDivElement | null> }) {
-  const cursorColor = tab.type === 'plan' ? 'bg-amber-400' : 'bg-accent';
+  const cursorColor = tab.type === 'plan' ? 'bg-amber-400' : 'bg-link';
   const hasBlocks = tab.blocks.length > 0;
   const endRef = useRef<HTMLDivElement>(null);
   const isNearBottom = useRef(true);

--- a/web/src/components/Chat/TodoPanel.tsx
+++ b/web/src/components/Chat/TodoPanel.tsx
@@ -63,7 +63,7 @@ function TodoRow({ todo }: { todo: TodoItem }) {
   return (
     <div className={`todo-row flex items-center gap-2 py-0.5 text-[13px] transition-opacity duration-300 ${isCompleted ? 'opacity-50' : ''}`}>
       {isCompleted ? (
-        <CheckCircle2 size={14} className="text-green-500 shrink-0 todo-icon-enter" />
+        <CheckCircle2 size={14} className="text-hue-green shrink-0 todo-icon-enter" />
       ) : isActive ? (
         <Loader2 size={14} className="text-accent shrink-0 animate-spin" />
       ) : (

--- a/web/src/components/Chat/ToolCallBlock.tsx
+++ b/web/src/components/Chat/ToolCallBlock.tsx
@@ -91,7 +91,7 @@ function GenericToolBlock({ block }: { block: ToolCallBlockData }) {
       >
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-text-muted'}`} />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-text-muted'}`} />
         }
         <span className="text-[13px] font-mono font-medium text-text-secondary">{block.tool}</span>
         {summary && <span className="text-[12px] text-text-dim truncate font-mono">{summary}</span>}
@@ -116,7 +116,7 @@ function GenericToolBlock({ block }: { block: ToolCallBlockData }) {
               <div className="text-[10px] uppercase tracking-wider text-text-faint mb-1">
                 {block.isError ? 'Error' : 'Result'}
               </div>
-              <pre className={`text-[12px] font-mono whitespace-pre-wrap overflow-x-auto max-h-80 overflow-y-auto bg-bg rounded p-2 border border-border-subtle ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+              <pre className={`text-[12px] font-mono whitespace-pre-wrap overflow-x-auto max-h-80 overflow-y-auto bg-bg rounded p-2 border border-border-subtle ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
                 {block.result}
               </pre>
             </div>

--- a/web/src/components/Chat/ToolCallGroupBlock.tsx
+++ b/web/src/components/Chat/ToolCallGroupBlock.tsx
@@ -44,7 +44,7 @@ export function ToolCallGroupBlock({ group }: { group: ToolCallGroup }) {
         >
           {hasRunning
             ? <Loader2 size={12} className="text-accent animate-spin shrink-0" />
-            : <Icon size={12} className={`shrink-0 ${hasError ? 'text-red-400' : 'text-text-faint'}`} />
+            : <Icon size={12} className={`shrink-0 ${hasError ? 'text-hue-red' : 'text-text-faint'}`} />
           }
           <span className="font-mono font-medium">
             {expanded ? 'Collapse' : `Show ${hiddenCount} more`}

--- a/web/src/components/Chat/tools/BashToolBlock.tsx
+++ b/web/src/components/Chat/tools/BashToolBlock.tsx
@@ -16,9 +16,9 @@ export function BashToolBlock({ block }: { block: ToolCallBlockData }) {
       >
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <Terminal size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-emerald-400'}`} />
+          : <Terminal size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-hue-emerald'}`} />
         }
-        <span className="text-emerald-500 text-[13px] font-mono select-none">$</span>
+        <span className="text-hue-emerald text-[13px] font-mono select-none">$</span>
         <span className="text-[13px] font-mono text-text-secondary truncate">{truncatedCmd}</span>
         <div className="ml-auto shrink-0">
           {expanded ? <ChevronDown size={14} className="text-text-faint" /> : <ChevronRight size={14} className="text-text-faint" />}
@@ -36,7 +36,7 @@ export function BashToolBlock({ block }: { block: ToolCallBlockData }) {
 
           {/* Output */}
           {block.result !== undefined && (
-            <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+            <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
               {block.result}
             </pre>
           )}

--- a/web/src/components/Chat/tools/EditToolBlock.tsx
+++ b/web/src/components/Chat/tools/EditToolBlock.tsx
@@ -20,7 +20,7 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
       >
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <FileEdit size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-amber-400'}`} />
+          : <FileEdit size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-hue-amber'}`} />
         }
         <span className="text-[13px] font-mono font-medium text-text-secondary">Edit</span>
         <span className="text-[12px] text-text-dim truncate font-mono">{filePath}</span>
@@ -34,13 +34,13 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
           {/* Diff view */}
           <div className="font-mono text-[12px] overflow-x-auto max-h-80 overflow-y-auto">
             {oldLines.map((line, i) => (
-              <div key={`old-${i}`} className="px-3 py-0.5 bg-red-500/15 text-red-600">
-                <span className="select-none text-red-500/50 mr-2">-</span>{line}
+              <div key={`old-${i}`} className="px-3 py-0.5 bg-diff-del-bg/15 text-diff-del/80">
+                <span className="select-none text-diff-del/40 mr-2">-</span>{line}
               </div>
             ))}
             {newLines.map((line, i) => (
-              <div key={`new-${i}`} className="px-3 py-0.5 bg-green-500/15 text-green-600">
-                <span className="select-none text-green-500/50 mr-2">+</span>{line}
+              <div key={`new-${i}`} className="px-3 py-0.5 bg-diff-add-bg/15 text-diff-add/80">
+                <span className="select-none text-diff-add/40 mr-2">+</span>{line}
               </div>
             ))}
           </div>
@@ -48,7 +48,7 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
           {/* Error */}
           {block.isError && block.result && (
             <div className="px-3 py-2 border-t border-border-subtle">
-              <pre className="text-[12px] font-mono text-red-400 whitespace-pre-wrap">{block.result}</pre>
+              <pre className="text-[12px] font-mono text-hue-red whitespace-pre-wrap">{block.result}</pre>
             </div>
           )}
 

--- a/web/src/components/Chat/tools/FileToolBlock.tsx
+++ b/web/src/components/Chat/tools/FileToolBlock.tsx
@@ -20,7 +20,7 @@ export function FileToolBlock({ block }: { block: ToolCallBlockData }) {
       >
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-blue-400'}`} />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-hue-blue'}`} />
         }
         <span className="text-[13px] font-mono font-medium text-text-secondary">{block.tool}</span>
         <span className="text-[12px] text-text-dim truncate font-mono">{filePath}</span>
@@ -35,7 +35,7 @@ export function FileToolBlock({ block }: { block: ToolCallBlockData }) {
       {expanded && (
         <div className="border-t border-border">
           {block.result !== undefined && (
-            <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto bg-bg ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+            <pre className={`px-3 py-2 text-[12px] font-mono whitespace-pre-wrap max-h-80 overflow-y-auto bg-bg ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
               {block.result}
             </pre>
           )}

--- a/web/src/components/Chat/tools/HoAToolBlock.tsx
+++ b/web/src/components/Chat/tools/HoAToolBlock.tsx
@@ -4,9 +4,9 @@ import type { ToolCallBlockData } from '../../../types/chat';
 import { MarkdownContent } from '../MarkdownContent';
 
 const PROVIDER_COLORS: Record<string, string> = {
-  anthropic: 'bg-orange-400/20 text-orange-300 border-orange-400/30',
-  openai: 'bg-emerald-400/20 text-emerald-300 border-emerald-400/30',
-  gemini: 'bg-blue-400/20 text-blue-300 border-blue-400/30',
+  anthropic: 'bg-orange-400/20 text-hue-orange border-orange-400/30',
+  openai: 'bg-emerald-400/20 text-hue-emerald border-emerald-400/30',
+  gemini: 'bg-blue-400/20 text-hue-blue border-blue-400/30',
 };
 
 function getProviderStyle(kind?: string) {
@@ -49,14 +49,14 @@ export function HoAToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-amber-400 animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-hue-amber animate-spin shrink-0" />
           : block.isError
-            ? <X size={14} className="text-red-400 shrink-0" />
-            : <Check size={14} className="text-emerald-400 shrink-0" />
+            ? <X size={14} className="text-hue-red shrink-0" />
+            : <Check size={14} className="text-hue-emerald shrink-0" />
         }
-        <Users size={14} className="text-amber-400 shrink-0" />
+        <Users size={14} className="text-hue-amber shrink-0" />
         <span className="text-[13px] font-mono font-medium text-text-secondary">hoa_execute</span>
-        <span className="text-[12px] text-amber-400/60 font-mono">{mode}</span>
+        <span className="text-[12px] text-hue-amber/60 font-mono">{mode}</span>
         {activeLabel && isRunning && <span className="text-[12px] text-text-muted">· {activeLabel}</span>}
         {agents && !activeLabel && <span className="text-[12px] text-text-faint font-mono truncate">{agents}</span>}
 
@@ -130,7 +130,7 @@ export function HoAToolBlock({ block }: { block: ToolCallBlockData }) {
                 {block.isError ? 'Error' : 'Result'}
               </div>
               {block.isError ? (
-                <pre className="text-[12px] font-mono whitespace-pre-wrap overflow-x-auto max-h-80 overflow-y-auto bg-bg rounded p-2 border border-border-subtle text-red-400">
+                <pre className="text-[12px] font-mono whitespace-pre-wrap overflow-x-auto max-h-80 overflow-y-auto bg-bg rounded p-2 border border-border-subtle text-hue-red">
                   {block.result}
                 </pre>
               ) : (

--- a/web/src/components/Chat/tools/MemoryToolBlock.tsx
+++ b/web/src/components/Chat/tools/MemoryToolBlock.tsx
@@ -38,10 +38,10 @@ function parseMemoryItems(text: string): MemoryItem[] {
 }
 
 const TYPE_COLORS: Record<string, string> = {
-  event: 'text-blue-400 bg-blue-500/10',
-  profile: 'text-green-400 bg-green-500/10',
-  knowledge: 'text-amber-400 bg-amber-500/10',
-  behavior: 'text-purple-400 bg-purple-500/10',
+  event: 'text-hue-blue bg-blue-500/10',
+  profile: 'text-hue-green bg-green-500/10',
+  knowledge: 'text-hue-amber bg-amber-500/10',
+  behavior: 'text-hue-purple bg-purple-500/10',
 };
 
 export function MemoryToolBlock({ block }: { block: ToolCallBlockData }) {
@@ -81,13 +81,13 @@ export function MemoryToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-purple-400 animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-purple-400'}`} />
+          ? <Loader2 size={14} className="text-hue-purple animate-spin shrink-0" />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-hue-purple'}`} />
         }
-        <span className="text-[13px] font-medium text-purple-300">{label}</span>
+        <span className="text-[13px] font-medium text-hue-purple">{label}</span>
         {truncatedQuery && <span className="text-[12px] text-text-dim truncate">{truncatedQuery}</span>}
         {count && !isRunning && (
-          <span className="text-[10px] text-purple-400/60 shrink-0">{count} items</span>
+          <span className="text-[10px] text-hue-purple/60 shrink-0">{count} items</span>
         )}
         <div className="ml-auto shrink-0">
           {expanded ? <ChevronDown size={14} className="text-text-faint" /> : <ChevronRight size={14} className="text-text-faint" />}
@@ -100,8 +100,8 @@ export function MemoryToolBlock({ block }: { block: ToolCallBlockData }) {
           {isMemorize && query && (
             <div className="px-3 py-2 text-[12px] text-text-secondary">
               <div className="flex items-center gap-1.5 mb-1">
-                <Brain size={11} className="text-purple-400" />
-                <span className="text-[10px] uppercase tracking-wider text-purple-400/60">Memorized</span>
+                <Brain size={11} className="text-hue-purple" />
+                <span className="text-[10px] uppercase tracking-wider text-hue-purple/60">Memorized</span>
               </div>
               <p className="leading-relaxed">{String(query)}</p>
               {block.input.memory_type ? (
@@ -125,19 +125,19 @@ export function MemoryToolBlock({ block }: { block: ToolCallBlockData }) {
               ))}
             </div>
           ) : resultText && !isMemorize ? (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
               {resultText}
             </pre>
           ) : null}
 
           {/* Success/error feedback for memorize */}
           {isMemorize && resultText && !block.isError && (
-            <div className="px-3 py-1.5 text-[11px] text-green-400/70 border-t border-purple-500/10">
+            <div className="px-3 py-1.5 text-[11px] text-hue-green/70 border-t border-purple-500/10">
               Saved to memory
             </div>
           )}
           {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-purple-500/10">
+            <pre className="px-3 py-2 text-[12px] text-hue-red whitespace-pre-wrap border-t border-purple-500/10">
               {resultText}
             </pre>
           )}

--- a/web/src/components/Chat/tools/NotificationToolBlock.tsx
+++ b/web/src/components/Chat/tools/NotificationToolBlock.tsx
@@ -30,7 +30,7 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
   const body = String(block.input.body || '');
 
   const Icon = isAsk ? HelpCircle : Bell;
-  const iconColor = block.isError ? 'text-red-400' : isAsk ? 'text-blue-400' : 'text-amber-400';
+  const iconColor = block.isError ? 'text-hue-red' : isAsk ? 'text-hue-blue' : 'text-hue-amber';
   const label = isNotify ? 'Notify' : 'Ask User';
 
   const resultText = block.result ? extractText(block.result) : '';
@@ -50,18 +50,18 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
         {title && <span className="text-[12px] text-text-muted truncate">{title}</span>}
         {priority !== 'normal' && (
           <span className={`text-[10px] px-1.5 py-0.5 rounded shrink-0 ${
-            priority === 'urgent' ? 'bg-red-500/15 text-red-400' :
-            priority === 'high' ? 'bg-orange-400/15 text-orange-400' :
+            priority === 'urgent' ? 'bg-red-500/15 text-hue-red' :
+            priority === 'high' ? 'bg-orange-400/15 text-hue-orange' :
             'bg-border-subtle text-text-muted'
           }`}>
             {priority}
           </span>
         )}
         {wait && isAsk && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-400 shrink-0">blocking</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/15 text-hue-blue shrink-0">blocking</span>
         )}
         {isSent && !isRunning && (
-          <span className="text-[10px] text-emerald-400/70 shrink-0">sent</span>
+          <span className="text-[10px] text-hue-emerald/70 shrink-0">sent</span>
         )}
         <div className="ml-auto shrink-0">
           {expanded ? <ChevronDown size={14} className="text-text-faint" /> : <ChevronRight size={14} className="text-text-faint" />}
@@ -89,7 +89,7 @@ export function NotificationToolBlock({ block }: { block: ToolCallBlockData }) {
           {/* Result */}
           {resultText && (
             <div className="px-3 py-2 border-t border-border-subtle">
-              <pre className={`text-[12px] font-mono whitespace-pre-wrap ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+              <pre className={`text-[12px] font-mono whitespace-pre-wrap ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
                 {resultText}
               </pre>
             </div>

--- a/web/src/components/Chat/tools/PlanApprovalBlock.tsx
+++ b/web/src/components/Chat/tools/PlanApprovalBlock.tsx
@@ -24,8 +24,8 @@ export function PlanApprovalBlock({ block }: { block: ToolCallBlockData }) {
       <div className="my-1.5 border border-border rounded-lg bg-surface overflow-hidden">
         <div className="px-3 py-2.5 flex items-center gap-2">
           {wasApproved
-            ? <Check size={14} className="text-green-400" />
-            : <Ban size={14} className="text-red-400" />
+            ? <Check size={14} className="text-hue-green" />
+            : <Ban size={14} className="text-hue-red" />
           }
           <span className="text-[13px] font-medium text-text-secondary">
             {isExitPlan ? 'Plan' : 'Plan mode'} {wasApproved ? 'approved' : 'declined'}

--- a/web/src/components/Chat/tools/PlanToolBlock.tsx
+++ b/web/src/components/Chat/tools/PlanToolBlock.tsx
@@ -45,10 +45,10 @@ function parsePlanList(text: string): ParsedPlan[] {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-500/15 text-yellow-400',
-  approved: 'bg-green-500/15 text-green-400',
-  implementing: 'bg-blue-500/15 text-blue-400',
-  declined: 'bg-red-500/15 text-red-400',
+  pending: 'bg-yellow-500/15 text-hue-yellow',
+  approved: 'bg-green-500/15 text-hue-green',
+  implementing: 'bg-blue-500/15 text-hue-blue',
+  declined: 'bg-red-500/15 text-hue-red',
   superseded: 'bg-border-subtle text-text-muted',
 };
 
@@ -103,10 +103,10 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
   else if (planId) summary = planId;
 
   // Icon color
-  const iconColor = block.isError ? 'text-red-400'
-    : toolName === 'plan_approve' ? 'text-emerald-400'
-    : toolName === 'plan_decline' ? 'text-red-400'
-    : 'text-amber-400';
+  const iconColor = block.isError ? 'text-hue-red'
+    : toolName === 'plan_approve' ? 'text-hue-emerald'
+    : toolName === 'plan_decline' ? 'text-hue-red'
+    : 'text-hue-amber';
 
   return (
     <div className="my-1.5 border border-amber-500/20 rounded-lg bg-surface overflow-hidden">
@@ -115,7 +115,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-amber-400 animate-spin shrink-0" />
+          ? <Loader2 size={14} className="text-hue-amber animate-spin shrink-0" />
           : <Icon size={14} className={`shrink-0 ${iconColor}`} />
         }
         <span className="text-[13px] font-medium text-amber-300">{config.label}</span>
@@ -140,13 +140,13 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
               {proposedPlanId && !block.isError && (
                 <button
                   onClick={(e) => { e.stopPropagation(); navigate(`/plans/${proposedPlanId}`); }}
-                  className="mt-2 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
+                  className="mt-2 flex items-center gap-1 text-[11px] text-hue-amber hover:text-amber-300 cursor-pointer"
                 >
                   <ExternalLink size={10} /> Review plan
                 </button>
               )}
               {proposedPlanId && !block.isError && (
-                <div className="mt-1 text-[11px] text-green-400/70">
+                <div className="mt-1 text-[11px] text-hue-green/70">
                   Plan proposed — awaiting review
                 </div>
               )}
@@ -171,7 +171,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
               ))}
             </div>
           ) : resultText ? (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
               {resultText}
             </pre>
           ) : null)}
@@ -192,7 +192,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
               {planId && (
                 <button
                   onClick={(e) => { e.stopPropagation(); navigate(`/plans/${planId}`); }}
-                  className="mt-2 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
+                  className="mt-2 flex items-center gap-1 text-[11px] text-hue-amber hover:text-amber-300 cursor-pointer"
                 >
                   <ExternalLink size={10} /> Open plan
                 </button>
@@ -203,14 +203,14 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
           {/* ── plan_approve ── */}
           {toolName === 'plan_approve' && resultText && !block.isError && (
             <div className="px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px] text-emerald-400">
+              <div className="flex items-center gap-2 text-[12px] text-hue-emerald">
                 <Check size={12} />
                 <span>Plan approved</span>
               </div>
               {implSessionId && (
                 <button
                   onClick={(e) => { e.stopPropagation(); navigate(`/chat/${implSessionId}`); }}
-                  className="mt-2 flex items-center gap-1 text-[11px] text-blue-400 hover:text-blue-300 cursor-pointer"
+                  className="mt-2 flex items-center gap-1 text-[11px] text-hue-blue hover:text-hue-blue cursor-pointer"
                 >
                   <MessageSquare size={10} /> Watch implementation
                 </button>
@@ -218,7 +218,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
               {planId && (
                 <button
                   onClick={(e) => { e.stopPropagation(); navigate(`/plans/${planId}`); }}
-                  className="mt-1 flex items-center gap-1 text-[11px] text-amber-400 hover:text-amber-300 cursor-pointer"
+                  className="mt-1 flex items-center gap-1 text-[11px] text-hue-amber hover:text-amber-300 cursor-pointer"
                 >
                   <ExternalLink size={10} /> View plan
                 </button>
@@ -229,7 +229,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
           {/* ── plan_decline ── */}
           {toolName === 'plan_decline' && resultText && !block.isError && (
             <div className="px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px] text-red-400">
+              <div className="flex items-center gap-2 text-[12px] text-hue-red">
                 <X size={12} />
                 <span>Plan declined</span>
               </div>
@@ -245,7 +245,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
           {/* ── plan_revise ── */}
           {toolName === 'plan_revise' && resultText && !block.isError && (
             <div className="px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px] text-amber-400">
+              <div className="flex items-center gap-2 text-[12px] text-hue-amber">
                 <MessageSquare size={12} />
                 <span>Revision requested</span>
               </div>
@@ -260,7 +260,7 @@ export function PlanToolBlock({ block }: { block: ToolCallBlockData }) {
 
           {/* ── Error fallback ── */}
           {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-amber-500/10">
+            <pre className="px-3 py-2 text-[12px] text-hue-red whitespace-pre-wrap border-t border-amber-500/10">
               {resultText}
             </pre>
           )}

--- a/web/src/components/Chat/tools/QuestionBlock.tsx
+++ b/web/src/components/Chat/tools/QuestionBlock.tsx
@@ -184,8 +184,8 @@ export function QuestionBlock({ block }: { block: ToolCallBlockData }) {
         {/* Answered confirmation */}
         {submitted && (
           <div className="px-4 py-2 border-t border-accent/10 flex items-center gap-2">
-            <Check size={12} className="text-green-400" />
-            <span className="text-[11px] text-green-400/70">Answered</span>
+            <Check size={12} className="text-hue-green" />
+            <span className="text-[11px] text-hue-green/70">Answered</span>
           </div>
         )}
       </div>

--- a/web/src/components/Chat/tools/SkillToolBlock.tsx
+++ b/web/src/components/Chat/tools/SkillToolBlock.tsx
@@ -75,13 +75,13 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
       >
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-purple-400'}`} />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-hue-purple'}`} />
         }
         <span className="text-[13px] font-medium text-text-secondary">{label}</span>
 
         {/* Skill name badge */}
         {skillName && (
-          <span className="text-[11px] font-mono bg-purple-500/10 text-purple-300 px-1.5 py-0.5 rounded truncate max-w-[200px]">
+          <span className="text-[11px] font-mono bg-purple-500/10 text-hue-purple px-1.5 py-0.5 rounded truncate max-w-[200px]">
             {skillName}
           </span>
         )}
@@ -113,7 +113,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
             <div className="px-3 py-2 space-y-1.5 max-h-60 overflow-y-auto">
               {skillList.map((s) => (
                 <div key={s.id} className="flex items-start gap-2 text-[12px]">
-                  <Sparkles size={11} className="text-purple-400 mt-0.5 shrink-0" />
+                  <Sparkles size={11} className="text-hue-purple mt-0.5 shrink-0" />
                   <div className="min-w-0">
                     <div className="flex items-center gap-1.5">
                       <span className="text-text-secondary font-medium">{s.name}</span>
@@ -131,7 +131,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
             <div className="max-h-80 overflow-y-auto">
               {loadedSkillTitle && (
                 <div className="px-3 py-1.5 border-b border-border-subtle flex items-center gap-2">
-                  <Sparkles size={11} className="text-purple-400" />
+                  <Sparkles size={11} className="text-hue-purple" />
                   <span className="text-[12px] text-text-secondary font-medium">{loadedSkillTitle}</span>
                 </div>
               )}
@@ -170,7 +170,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
             <div className="px-3 py-2">
               {skillName && (
                 <div className="flex items-center gap-2 mb-1.5">
-                  <Plus size={11} className="text-purple-400" />
+                  <Plus size={11} className="text-hue-purple" />
                   <span className="text-[12px] text-text-secondary font-medium">{skillName}</span>
                 </div>
               )}
@@ -183,7 +183,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
                 </pre>
               )}
               {resultText && !block.isError && (
-                <div className="mt-2 text-[11px] text-emerald-400/70 flex items-center gap-1">
+                <div className="mt-2 text-[11px] text-hue-emerald/70 flex items-center gap-1">
                   <Sparkles size={10} /> {resultText}
                 </div>
               )}
@@ -199,7 +199,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
                 </pre>
               )}
               {resultText && !block.isError && (
-                <div className="mt-2 text-[11px] text-emerald-400/70 flex items-center gap-1">
+                <div className="mt-2 text-[11px] text-hue-emerald/70 flex items-center gap-1">
                   <Sparkles size={10} /> {resultText}
                 </div>
               )}
@@ -215,7 +215,7 @@ export function SkillToolBlock({ block }: { block: ToolCallBlockData }) {
 
           {/* Error */}
           {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-border-subtle">
+            <pre className="px-3 py-2 text-[12px] text-hue-red whitespace-pre-wrap border-t border-border-subtle">
               {resultText}
             </pre>
           )}

--- a/web/src/components/Chat/tools/SourceToolBlock.tsx
+++ b/web/src/components/Chat/tools/SourceToolBlock.tsx
@@ -21,9 +21,9 @@ function extractText(result: string): string {
 function sourceIcon(source: string) {
   const type = source.split(':')[0];
   switch (type) {
-    case 'gmail': return <Mail size={12} className="text-red-400" />;
-    case 'github': return <Github size={12} className="text-purple-400" />;
-    case 'telegram': return <MessageCircle size={12} className="text-blue-400" />;
+    case 'gmail': return <Mail size={12} className="text-hue-red" />;
+    case 'github': return <Github size={12} className="text-hue-purple" />;
+    case 'telegram': return <MessageCircle size={12} className="text-hue-blue" />;
     default: return <Inbox size={12} className="text-text-dim" />;
   }
 }
@@ -154,13 +154,13 @@ export function SourceToolBlock({ block }: { block: ToolCallBlockData }) {
         className="flex items-center gap-2 w-full px-3 py-2 text-left cursor-pointer hover:bg-surface-raised transition-colors"
       >
         {isRunning
-          ? <Loader2 size={14} className="text-cyan-400 animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : 'text-cyan-400'}`} />
+          ? <Loader2 size={14} className="text-hue-cyan animate-spin shrink-0" />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : 'text-hue-cyan'}`} />
         }
         <span className="text-[13px] font-medium text-cyan-300">{label}</span>
         {summary && <span className="text-[12px] text-text-dim truncate">{summary}</span>}
         {(isPoll || isRead) && messageCount > 0 && !isRunning && (
-          <span className="text-[10px] text-cyan-400/60 shrink-0">{messageCount} msg</span>
+          <span className="text-[10px] text-hue-cyan/60 shrink-0">{messageCount} msg</span>
         )}
         <div className="ml-auto shrink-0">
           {expanded ? <ChevronDown size={14} className="text-text-faint" /> : <ChevronRight size={14} className="text-text-faint" />}
@@ -178,7 +178,7 @@ export function SourceToolBlock({ block }: { block: ToolCallBlockData }) {
                   <span className="text-text-secondary font-mono">{entry.name}</span>
                   {entry.messageCount && <span className="text-text-dim">{entry.messageCount} msgs</span>}
                   {entry.unread && parseInt(entry.unread) > 0 && (
-                    <span className="text-amber-400 font-medium">{entry.unread} unread</span>
+                    <span className="text-hue-amber font-medium">{entry.unread} unread</span>
                   )}
                   {entry.unread === '0' && (
                     <span className="text-text-faint">0 unread</span>
@@ -222,7 +222,7 @@ export function SourceToolBlock({ block }: { block: ToolCallBlockData }) {
 
           {/* Fallback: raw text for unparsed results */}
           {!isList && parsedMessages.length === 0 && !isNoMessages && resultText && (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
               {resultText}
             </pre>
           )}
@@ -236,7 +236,7 @@ export function SourceToolBlock({ block }: { block: ToolCallBlockData }) {
 
           {/* Error */}
           {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-cyan-500/10">
+            <pre className="px-3 py-2 text-[12px] text-hue-red whitespace-pre-wrap border-t border-cyan-500/10">
               {resultText}
             </pre>
           )}

--- a/web/src/components/Chat/tools/SubagentToolBlock.tsx
+++ b/web/src/components/Chat/tools/SubagentToolBlock.tsx
@@ -12,8 +12,8 @@ const AGENT_ICONS: Record<string, typeof Bot> = {
 };
 
 const AGENT_COLORS: Record<string, string> = {
-  Explore: 'text-cyan-400',
-  Plan: 'text-amber-400',
+  Explore: 'text-hue-cyan',
+  Plan: 'text-hue-amber',
   'general-purpose': 'text-link',
 };
 
@@ -74,7 +74,7 @@ export function SubagentToolBlock({ block }: { block: ToolCallBlockData }) {
       <div className="flex items-center gap-2 px-3 py-2">
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : color}`} />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : color}`} />
         }
         <span className={`text-[13px] font-medium ${color}`}>{subagentType}</span>
         {description && <span className="text-[12px] text-text-muted truncate flex-1">{description}</span>}
@@ -137,7 +137,7 @@ export function SubagentToolBlock({ block }: { block: ToolCallBlockData }) {
           )}
 
           {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap">
+            <pre className="px-3 py-2 text-[12px] text-hue-red whitespace-pre-wrap">
               {resultText}
             </pre>
           )}

--- a/web/src/components/Chat/tools/SubagentToolBlock.tsx
+++ b/web/src/components/Chat/tools/SubagentToolBlock.tsx
@@ -14,7 +14,7 @@ const AGENT_ICONS: Record<string, typeof Bot> = {
 const AGENT_COLORS: Record<string, string> = {
   Explore: 'text-cyan-400',
   Plan: 'text-amber-400',
-  'general-purpose': 'text-accent',
+  'general-purpose': 'text-link',
 };
 
 export function SubagentToolBlock({ block }: { block: ToolCallBlockData }) {

--- a/web/src/components/Chat/tools/TaskToolBlock.tsx
+++ b/web/src/components/Chat/tools/TaskToolBlock.tsx
@@ -3,11 +3,11 @@ import { ChevronRight, ChevronDown, CheckSquare, ListTodo, Plus, CheckCircle, Pe
 import type { ToolCallBlockData } from '../../../types/chat';
 
 const STATUS_COLORS: Record<string, string> = {
-  pending: 'bg-yellow-500/15 text-yellow-400',
-  'in-progress': 'bg-blue-500/15 text-blue-400',
-  'in_progress': 'bg-blue-500/15 text-blue-400',
-  done: 'bg-green-500/15 text-green-400',
-  completed: 'bg-green-500/15 text-green-400',
+  pending: 'bg-yellow-500/15 text-hue-yellow',
+  'in-progress': 'bg-blue-500/15 text-hue-blue',
+  'in_progress': 'bg-blue-500/15 text-hue-blue',
+  done: 'bg-green-500/15 text-hue-green',
+  completed: 'bg-green-500/15 text-hue-green',
   deferred: 'bg-border-subtle text-text-muted',
 };
 
@@ -93,7 +93,7 @@ export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
       >
         {isRunning
           ? <Loader2 size={14} className="text-accent animate-spin shrink-0" />
-          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-red-400' : isDone ? 'text-green-400' : isCreate ? 'text-blue-400' : 'text-text-muted'}`} />
+          : <Icon size={14} className={`shrink-0 ${block.isError ? 'text-hue-red' : isDone ? 'text-hue-green' : isCreate ? 'text-hue-blue' : 'text-text-muted'}`} />
         }
         <span className="text-[13px] font-medium text-text-secondary shrink-0 whitespace-nowrap">{label}</span>
         {title && <span className="text-[12px] text-text-muted truncate">{title}</span>}
@@ -116,7 +116,7 @@ export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
           {isCreate && title && (
             <div className="px-3 py-2">
               <div className="text-[12px] text-text-secondary flex items-center gap-2">
-                <Plus size={11} className="text-blue-400" />
+                <Plus size={11} className="text-hue-blue" />
                 <span className="font-medium">{title}</span>
               </div>
               {block.input.content ? (
@@ -150,20 +150,20 @@ export function TaskToolBlock({ block }: { block: ToolCallBlockData }) {
               ))}
             </div>
           ) : resultText && !isCreate && !isDone && !isUpdate ? (
-            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-red-400' : 'text-text-muted'}`}>
+            <pre className={`px-3 py-2 text-[12px] whitespace-pre-wrap max-h-60 overflow-y-auto ${block.isError ? 'text-hue-red' : 'text-text-muted'}`}>
               {resultText}
             </pre>
           ) : null}
 
           {/* Success message */}
           {(isCreate || isDone) && resultText && !block.isError && !taskList.length && (
-            <div className="px-3 py-1.5 text-[11px] text-green-400/70 border-t border-border-subtle">
+            <div className="px-3 py-1.5 text-[11px] text-hue-green/70 border-t border-border-subtle">
               {isDone ? 'Task completed' : 'Task created'}
             </div>
           )}
 
           {block.isError && resultText && (
-            <pre className="px-3 py-2 text-[12px] text-red-400 whitespace-pre-wrap border-t border-border-subtle">
+            <pre className="px-3 py-2 text-[12px] text-hue-red whitespace-pre-wrap border-t border-border-subtle">
               {resultText}
             </pre>
           )}

--- a/web/src/components/Diagnostics/DiagnosticsPanel.tsx
+++ b/web/src/components/Diagnostics/DiagnosticsPanel.tsx
@@ -33,7 +33,7 @@ export function DiagnosticsPanel() {
   }, []);
 
   if (loading) return <div className="p-4 text-text-faint">Loading...</div>;
-  if (!data) return <div className="p-4 text-red-400">Failed to load diagnostics</div>;
+  if (!data) return <div className="p-4 text-hue-red">Failed to load diagnostics</div>;
 
   const syncEntries = Object.entries(data.sync || {}) as [string, SourceStatus | string][];
 
@@ -83,9 +83,9 @@ export function DiagnosticsPanel() {
                   <div className="flex items-center justify-between">
                     <span className="font-medium">{source}</span>
                     {hasError ? (
-                      <span className="text-xs text-red-400">error</span>
+                      <span className="text-xs text-hue-red">error</span>
                     ) : lastRun ? (
-                      <span className="text-xs text-green-400">{processed}/{fetched} records</span>
+                      <span className="text-xs text-hue-green">{processed}/{fetched} records</span>
                     ) : (
                       <span className="text-xs text-text-dim">never run</span>
                     )}
@@ -96,7 +96,7 @@ export function DiagnosticsPanel() {
                     </div>
                   )}
                   {hasError && (
-                    <div className="text-xs text-red-400 mt-1">{status!.error}</div>
+                    <div className="text-xs text-hue-red mt-1">{status!.error}</div>
                   )}
                 </div>
               );
@@ -124,7 +124,7 @@ export function DiagnosticsPanel() {
             </div>
             <div className="p-2 bg-surface-raised rounded">
               <div className="text-xs text-text-dim">FTS Status</div>
-              <div className={data.tasks.fts_ok ? 'text-green-400' : 'text-red-400'}>
+              <div className={data.tasks.fts_ok ? 'text-hue-green' : 'text-hue-red'}>
                 {data.tasks.fts_ok ? '✓ in sync' : '✗ mismatch'}
               </div>
             </div>
@@ -143,12 +143,12 @@ export function DiagnosticsPanel() {
               <div key={log.id} className="p-2 bg-surface-raised rounded text-sm">
                 <div className="flex items-center justify-between">
                   <span className="font-medium">{log.job_id}</span>
-                  <span className={`text-xs ${log.status === 'success' ? 'text-green-400' : 'text-red-400'}`}>
+                  <span className={`text-xs ${log.status === 'success' ? 'text-hue-green' : 'text-hue-red'}`}>
                     {log.status}
                   </span>
                 </div>
                 <div className="text-xs text-text-dim mt-1">{log.started_at}</div>
-                {log.error && <div className="text-xs text-red-400 mt-1">{log.error}</div>}
+                {log.error && <div className="text-xs text-hue-red mt-1">{log.error}</div>}
               </div>
             ))}
           </div>

--- a/web/src/components/Notifications/NotificationToast.tsx
+++ b/web/src/components/Notifications/NotificationToast.tsx
@@ -36,7 +36,7 @@ export function NotificationToast() {
           >
             <div className="flex items-start gap-2">
               {isQuestion ? (
-                <HelpCircle size={16} className="text-blue-400 shrink-0 mt-0.5" />
+                <HelpCircle size={16} className="text-hue-blue shrink-0 mt-0.5" />
               ) : (
                 <Bell size={16} className="text-accent shrink-0 mt-0.5" />
               )}

--- a/web/src/components/Sources/renderers/GitHubRenderer.tsx
+++ b/web/src/components/Sources/renderers/GitHubRenderer.tsx
@@ -20,7 +20,7 @@ export function GitHubRenderer({ content, metadata, summary: _summary }: Props) 
       {(repoName || subjectUrl) && (
         <div className="mb-4 p-3 bg-surface border border-border-subtle rounded-lg">
           <div className="flex items-center gap-2 mb-1 flex-wrap">
-            <Github size={14} className="text-purple-400 shrink-0" />
+            <Github size={14} className="text-hue-purple shrink-0" />
             <span className="text-[13px] text-text-secondary font-medium">{repoName}</span>
             {subjectType && (
               <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/15 text-purple-600">

--- a/web/src/components/Tasks/TaskCard.tsx
+++ b/web/src/components/Tasks/TaskCard.tsx
@@ -3,9 +3,9 @@ import { Calendar, ExternalLink } from 'lucide-react';
 import type { Task } from '../../stores/taskStore';
 
 const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  in_progress: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  done: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
+  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
+  in_progress: 'bg-blue-400/10 text-hue-blue border-blue-400/20',
+  done: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
   deferred: 'bg-border-subtle/50 text-text-muted border-border-subtle',
 };
 

--- a/web/src/components/Tasks/TaskList.tsx
+++ b/web/src/components/Tasks/TaskList.tsx
@@ -11,9 +11,9 @@ interface Task {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  pending: 'text-yellow-400',
-  in_progress: 'text-blue-400',
-  done: 'text-green-400',
+  pending: 'text-hue-yellow',
+  in_progress: 'text-hue-blue',
+  done: 'text-hue-green',
   deferred: 'text-text-muted',
 };
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -32,6 +32,24 @@
   --color-error: var(--theme-error);
   --color-warning: var(--theme-warning);
   --color-info: var(--theme-info);
+  /* Diff */
+  --color-diff-add: var(--theme-diff-add);
+  --color-diff-del: var(--theme-diff-del);
+  --color-diff-add-bg: var(--theme-diff-add-bg);
+  --color-diff-del-bg: var(--theme-diff-del-bg);
+  /* Hue indicators — theme-adaptive shades for badges, status, tool identity */
+  --color-hue-yellow: var(--theme-hue-yellow);
+  --color-hue-blue: var(--theme-hue-blue);
+  --color-hue-emerald: var(--theme-hue-emerald);
+  --color-hue-green: var(--theme-hue-green);
+  --color-hue-red: var(--theme-hue-red);
+  --color-hue-purple: var(--theme-hue-purple);
+  --color-hue-amber: var(--theme-hue-amber);
+  --color-hue-cyan: var(--theme-hue-cyan);
+  --color-hue-orange: var(--theme-hue-orange);
+  --color-hue-teal: var(--theme-hue-teal);
+  --color-hue-sky: var(--theme-hue-sky);
+  --color-hue-violet: var(--theme-hue-violet);
 }
 
 /* ── Dark palette (default) ── */
@@ -60,6 +78,23 @@
   --theme-error: #f87171;
   --theme-warning: #fbbf24;
   --theme-info: #60a5fa;
+  --theme-diff-add: var(--color-green-300);    /* original: light pastel text */
+  --theme-diff-del: var(--color-red-300);      /* original: light pastel text */
+  --theme-diff-add-bg: var(--color-green-950); /* original: very dark tint base */
+  --theme-diff-del-bg: var(--color-red-950);   /* original: very dark tint base */
+  /* Hue indicators: -400 for dark mode (bright on dark bg) */
+  --theme-hue-yellow: var(--color-yellow-400);
+  --theme-hue-blue: var(--color-blue-400);
+  --theme-hue-emerald: var(--color-emerald-400);
+  --theme-hue-green: var(--color-green-400);
+  --theme-hue-red: var(--color-red-400);
+  --theme-hue-purple: var(--color-purple-400);
+  --theme-hue-amber: var(--color-amber-400);
+  --theme-hue-cyan: var(--color-cyan-400);
+  --theme-hue-orange: var(--color-orange-400);
+  --theme-hue-teal: var(--color-teal-400);
+  --theme-hue-sky: var(--color-sky-400);
+  --theme-hue-violet: var(--color-violet-400);
 }
 
 /* ── Light palette (explicit) ── */
@@ -88,6 +123,23 @@
   --theme-error: #dc2626;
   --theme-warning: #d97706;
   --theme-info: #2563eb;
+  --theme-diff-add: var(--color-green-800);    /* dark text on light bg */
+  --theme-diff-del: var(--color-red-800);      /* dark text on light bg */
+  --theme-diff-add-bg: var(--color-green-300); /* light tint base */
+  --theme-diff-del-bg: var(--color-red-300);   /* light tint base */
+  /* Hue indicators: -600 for light mode (dark on light bg) */
+  --theme-hue-yellow: var(--color-yellow-600);
+  --theme-hue-blue: var(--color-blue-600);
+  --theme-hue-emerald: var(--color-emerald-600);
+  --theme-hue-green: var(--color-green-600);
+  --theme-hue-red: var(--color-red-600);
+  --theme-hue-purple: var(--color-purple-600);
+  --theme-hue-amber: var(--color-amber-600);
+  --theme-hue-cyan: var(--color-cyan-600);
+  --theme-hue-orange: var(--color-orange-400);
+  --theme-hue-teal: var(--color-teal-600);
+  --theme-hue-sky: var(--color-sky-600);
+  --theme-hue-violet: var(--color-violet-600);
 }
 
 /* ── System preference (when no explicit data-theme) ── */
@@ -117,6 +169,22 @@
     --theme-error: #dc2626;
     --theme-warning: #d97706;
     --theme-info: #2563eb;
+    --theme-diff-add: var(--color-green-800);    /* dark text on light bg */
+    --theme-diff-del: var(--color-red-800);      /* dark text on light bg */
+    --theme-diff-add-bg: var(--color-green-300); /* light tint base */
+    --theme-diff-del-bg: var(--color-red-300);   /* light tint base */
+    --theme-hue-yellow: var(--color-yellow-600);
+    --theme-hue-blue: var(--color-blue-600);
+    --theme-hue-emerald: var(--color-emerald-600);
+    --theme-hue-green: var(--color-green-600);
+    --theme-hue-red: var(--color-red-600);
+    --theme-hue-purple: var(--color-purple-600);
+    --theme-hue-amber: var(--color-amber-600);
+    --theme-hue-cyan: var(--color-cyan-600);
+    --theme-hue-orange: var(--color-orange-400);
+    --theme-hue-teal: var(--color-teal-600);
+    --theme-hue-sky: var(--color-sky-600);
+    --theme-hue-violet: var(--color-violet-600);
   }
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -130,7 +130,7 @@ export function ChatPage() {
                   onClick={openFilesPanel}
                   className={`flex items-center gap-1.5 px-2 py-1 rounded text-[12px] transition-colors cursor-pointer ${
                     filesPanelActive
-                      ? 'text-teal-400 bg-teal-400/10'
+                      ? 'text-hue-teal bg-teal-400/10'
                       : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'
                   }`}
                   title="Modified files"

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -66,8 +66,8 @@ function formatSchedule(schedule: string): string {
 
 function jobTypeIcon(type: string) {
   switch (type) {
-    case 'cron': return <Clock size={14} className="text-amber-400" />;
-    case 'source': return <Inbox size={14} className="text-blue-400" />;
+    case 'cron': return <Clock size={14} className="text-hue-amber" />;
+    case 'source': return <Inbox size={14} className="text-hue-blue" />;
     default: return <Clock size={14} className="text-text-dim" />;
   }
 }
@@ -312,7 +312,7 @@ function LogRow({ log, showJobColumn }: { log: CronLog; showJobColumn: boolean }
         <td className="px-3 py-2 text-text-muted">{formatRelativeTime(log.started_at)}</td>
         <td className="px-3 py-2 text-text-dim">
           {!log.finished_at ? (
-            <span className="flex items-center gap-1 text-amber-400">
+            <span className="flex items-center gap-1 text-hue-amber">
               <Loader2 size={12} className="animate-spin" /> running
             </span>
           ) : (
@@ -321,15 +321,15 @@ function LogRow({ log, showJobColumn }: { log: CronLog; showJobColumn: boolean }
         </td>
         <td className="px-3 py-2">
           {log.status === 'success' ? (
-            <span className="flex items-center gap-1 text-emerald-400"><CheckCircle2 size={12} /> ok</span>
+            <span className="flex items-center gap-1 text-hue-emerald"><CheckCircle2 size={12} /> ok</span>
           ) : log.status === 'error' ? (
-            <span className="flex items-center gap-1 text-red-400"><XCircle size={12} /> error</span>
+            <span className="flex items-center gap-1 text-hue-red"><XCircle size={12} /> error</span>
           ) : (
             <span className="text-text-dim">{log.status || '—'}</span>
           )}
         </td>
         <td className="px-3 py-2 text-text-dim max-w-[300px]">
-          <span className={`truncate block ${log.error ? 'text-red-400/70' : ''}`}>
+          <span className={`truncate block ${log.error ? 'text-hue-red/70' : ''}`}>
             {preview}{isLong && !expanded ? '…' : ''}
           </span>
         </td>

--- a/web/src/pages/DiagnosticsPage.tsx
+++ b/web/src/pages/DiagnosticsPage.tsx
@@ -73,7 +73,7 @@ export function DiagnosticsPage() {
   useEffect(() => { load(); }, []);
 
   if (loading) return <div className="flex-1 flex items-center justify-center text-text-faint">Loading...</div>;
-  if (!data) return <div className="flex-1 flex items-center justify-center text-red-400">Failed to load</div>;
+  if (!data) return <div className="flex-1 flex items-center justify-center text-hue-red">Failed to load</div>;
 
   return (
     <div className="h-full overflow-y-auto">
@@ -175,11 +175,11 @@ export function DiagnosticsPage() {
                       </td>
                       <td className="px-4 py-2">
                         {stats.error_count > 0
-                          ? <span className="text-red-400">{stats.error_count}</span>
+                          ? <span className="text-hue-red">{stats.error_count}</span>
                           : <span className="text-text-dim">0</span>
                         }
                       </td>
-                      <td className="px-4 py-2 text-red-400 text-[12px] truncate max-w-xs">{stats.last_error || ''}</td>
+                      <td className="px-4 py-2 text-hue-red text-[12px] truncate max-w-xs">{stats.last_error || ''}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -218,7 +218,7 @@ export function DiagnosticsPage() {
                   </div>
                 )}
                 {data.memorization.last_result?.error && (
-                  <div className="text-[12px] text-red-400 mt-1 truncate">
+                  <div className="text-[12px] text-hue-red mt-1 truncate">
                     Error: {data.memorization.last_result.error}
                   </div>
                 )}
@@ -256,12 +256,12 @@ export function DiagnosticsPage() {
                       <td className="px-4 py-2 font-mono text-text-secondary">{log.job_id}</td>
                       <td className="px-4 py-2">
                         {log.status === 'success'
-                          ? <span className="flex items-center gap-1 text-emerald-400"><CheckCircle2 size={12} /> ok</span>
-                          : <span className="flex items-center gap-1 text-red-400"><XCircle size={12} /> error</span>
+                          ? <span className="flex items-center gap-1 text-hue-emerald"><CheckCircle2 size={12} /> ok</span>
+                          : <span className="flex items-center gap-1 text-hue-red"><XCircle size={12} /> error</span>
                         }
                       </td>
                       <td className="px-4 py-2 text-text-dim">{log.started_at}</td>
-                      <td className="px-4 py-2 text-red-400 text-[12px] truncate max-w-xs">{log.error || ''}</td>
+                      <td className="px-4 py-2 text-hue-red text-[12px] truncate max-w-xs">{log.error || ''}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/web/src/pages/HouseOfAgentsPage.tsx
+++ b/web/src/pages/HouseOfAgentsPage.tsx
@@ -42,7 +42,7 @@ export function HouseOfAgentsPage() {
           <Users size={48} className="text-text-faint mx-auto" />
           <h2 className="text-lg text-text-muted">houseofagents is not enabled</h2>
           <p className="text-[13px] text-text-faint max-w-md">
-            Enable multi-agent execution by adding <code className="bg-surface-raised px-1.5 py-0.5 rounded text-amber-400">houseofagents.enabled: true</code> to your config.yaml
+            Enable multi-agent execution by adding <code className="bg-surface-raised px-1.5 py-0.5 rounded text-hue-amber">houseofagents.enabled: true</code> to your config.yaml
           </p>
         </div>
       </div>
@@ -55,10 +55,10 @@ export function HouseOfAgentsPage() {
       <div className="border-b border-border-subtle px-6 py-4 bg-bg shrink-0">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Users size={20} className="text-amber-400" />
+            <Users size={20} className="text-hue-amber" />
             <h1 className="text-lg font-semibold text-text">House of Agents</h1>
             {status.available ? (
-              <span className="px-2 py-0.5 text-[11px] rounded-full bg-emerald-400/10 text-emerald-400 border border-emerald-400/20">
+              <span className="px-2 py-0.5 text-[11px] rounded-full bg-emerald-400/10 text-hue-emerald border border-emerald-400/20">
                 <Check size={10} className="inline mr-1" />
                 {status.version || 'Installed'}
               </span>
@@ -138,7 +138,7 @@ export function HouseOfAgentsPage() {
             <>
               <div className="border-b border-border-subtle px-4 py-2 flex items-center justify-between bg-bg">
                 <div className="flex items-center gap-2">
-                  <FileText size={14} className="text-amber-400" />
+                  <FileText size={14} className="text-hue-amber" />
                   <span className="text-[13px] text-text-secondary font-mono">{selectedPipeline.id}.toml</span>
                 </div>
                 <div className="flex items-center gap-2">

--- a/web/src/pages/McpServerDetailPage.tsx
+++ b/web/src/pages/McpServerDetailPage.tsx
@@ -6,10 +6,10 @@ import { formatMcpName } from '../utils/formatMcpName';
 
 const TYPE_COLORS: Record<string, string> = {
   sdk: 'text-accent bg-accent/10',
-  stdio: 'text-emerald-400 bg-emerald-400/10',
-  sse: 'text-amber-400 bg-amber-400/10',
-  http: 'text-sky-400 bg-sky-400/10',
-  plugin: 'text-violet-400 bg-violet-400/10',
+  stdio: 'text-hue-emerald bg-emerald-400/10',
+  sse: 'text-hue-amber bg-amber-400/10',
+  http: 'text-hue-sky bg-sky-400/10',
+  plugin: 'text-hue-violet bg-violet-400/10',
 };
 
 function UsageBar({ total, success }: { total: number; success: number }) {
@@ -67,7 +67,7 @@ export function McpServerDetailPage() {
             {s.type}
           </span>
           {!s.enabled && (
-            <span className="text-[10px] text-amber-500/70 bg-amber-500/10 px-1.5 py-0.5 rounded">
+            <span className="text-[10px] text-hue-amber/70 bg-amber-500/10 px-1.5 py-0.5 rounded">
               disabled
             </span>
           )}
@@ -100,7 +100,7 @@ export function McpServerDetailPage() {
                       </span>
                       <span className="text-text-dim tabular-nums">{t.invocations} calls</span>
                       {tRate !== null && (
-                        <span className={`tabular-nums ${tRate >= 90 ? 'text-emerald-500' : 'text-amber-500'}`}>
+                        <span className={`tabular-nums ${tRate >= 90 ? 'text-hue-emerald' : 'text-hue-amber'}`}>
                           {tRate}%
                         </span>
                       )}
@@ -129,8 +129,8 @@ export function McpServerDetailPage() {
                     className="flex items-center gap-3 px-3 py-1.5 text-[11px] bg-surface-raised border border-border rounded"
                   >
                     {u.success
-                      ? <CheckCircle size={10} className="text-emerald-500 shrink-0" />
-                      : <XCircle size={10} className="text-red-500 shrink-0" />}
+                      ? <CheckCircle size={10} className="text-hue-emerald shrink-0" />
+                      : <XCircle size={10} className="text-hue-red shrink-0" />}
                     <span className="text-text font-mono truncate flex-1">
                       {u.tool_name}
                     </span>
@@ -161,7 +161,7 @@ export function McpServerDetailPage() {
                   <>
                     <div className="flex justify-between">
                       <span className="text-text-muted">Success Rate</span>
-                      <span className={successRate >= 90 ? 'text-emerald-400' : 'text-amber-400'}>
+                      <span className={successRate >= 90 ? 'text-hue-emerald' : 'text-hue-amber'}>
                         {successRate}%
                       </span>
                     </div>

--- a/web/src/pages/McpServersPage.tsx
+++ b/web/src/pages/McpServersPage.tsx
@@ -6,10 +6,10 @@ import { formatMcpName } from '../utils/formatMcpName';
 
 const TYPE_COLORS: Record<string, string> = {
   sdk: 'text-accent bg-accent/10',
-  stdio: 'text-emerald-400 bg-emerald-400/10',
-  sse: 'text-amber-400 bg-amber-400/10',
-  http: 'text-sky-400 bg-sky-400/10',
-  plugin: 'text-violet-400 bg-violet-400/10',
+  stdio: 'text-hue-emerald bg-emerald-400/10',
+  sse: 'text-hue-amber bg-amber-400/10',
+  http: 'text-hue-sky bg-sky-400/10',
+  plugin: 'text-hue-violet bg-violet-400/10',
 };
 
 function ServerCard({ server }: { server: McpServer }) {
@@ -34,7 +34,7 @@ function ServerCard({ server }: { server: McpServer }) {
           </div>
         </div>
         {!server.enabled && (
-          <span className="text-[10px] text-amber-500/70 bg-amber-500/10 px-1.5 py-0.5 rounded ml-2">
+          <span className="text-[10px] text-hue-amber/70 bg-amber-500/10 px-1.5 py-0.5 rounded ml-2">
             disabled
           </span>
         )}
@@ -54,8 +54,8 @@ function ServerCard({ server }: { server: McpServer }) {
         {successRate !== null && (
           <div className="flex items-center gap-1">
             {successRate >= 90
-              ? <CheckCircle size={10} className="text-emerald-500" />
-              : <XCircle size={10} className="text-amber-500" />}
+              ? <CheckCircle size={10} className="text-hue-emerald" />
+              : <XCircle size={10} className="text-hue-amber" />}
             <span>{successRate}%</span>
           </div>
         )}

--- a/web/src/pages/MemuPage.tsx
+++ b/web/src/pages/MemuPage.tsx
@@ -151,7 +151,7 @@ function ItemRow({ item, isEditing, isDeleting, onEdit, onDelete, onSave, onCanc
       <span className="text-[12px] text-text-secondary flex-1">{item.summary}</span>
       <div className="shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
         <button onClick={onEdit} className="p-1 rounded hover:bg-surface-raised text-text-dim hover:text-text-muted cursor-pointer transition-colors" title="Edit"><Pencil size={12} /></button>
-        <button onClick={onDelete} className="p-1 rounded hover:bg-surface-raised text-text-dim hover:text-red-400 cursor-pointer transition-colors" title="Delete"><Trash2 size={12} /></button>
+        <button onClick={onDelete} className="p-1 rounded hover:bg-surface-raised text-text-dim hover:text-hue-red cursor-pointer transition-colors" title="Delete"><Trash2 size={12} /></button>
       </div>
     </div>
   );
@@ -489,7 +489,7 @@ function TimelineView() {
                     </div>
                     <div className="shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                       <button onClick={() => setEditingItemId(item.id)} className="p-1 rounded hover:bg-surface-raised text-text-dim hover:text-text-muted cursor-pointer transition-colors" title="Edit"><Pencil size={12} /></button>
-                      <button onClick={() => setDeletingItemId(item.id)} className="p-1 rounded hover:bg-surface-raised text-text-dim hover:text-red-400 cursor-pointer transition-colors" title="Delete"><Trash2 size={12} /></button>
+                      <button onClick={() => setDeletingItemId(item.id)} className="p-1 rounded hover:bg-surface-raised text-text-dim hover:text-hue-red cursor-pointer transition-colors" title="Delete"><Trash2 size={12} /></button>
                     </div>
                   </div>
                 );

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -4,8 +4,8 @@ import { Bell, X, CheckCheck, EyeOff } from 'lucide-react';
 import { useNotificationStore, type Notification } from '../stores/notificationStore';
 
 const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  answered: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
+  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
+  answered: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
   expired: 'bg-border-subtle/50 text-text-muted border-border-subtle',
   dismissed: 'bg-border-subtle/50 text-text-dim border-border-subtle',
 };
@@ -109,7 +109,7 @@ function NotificationCard({ notif }: { notif: Notification }) {
           <span className={`px-2 py-0.5 rounded-full border ${STATUS_STYLES[notif.status] || STATUS_STYLES.dismissed}`}>
             {notif.status}
           </span>
-          <span className={`px-2 py-0.5 rounded-full border ${notif.type === 'question' ? 'bg-blue-400/10 text-blue-400 border-blue-400/20' : 'bg-border-subtle/50 text-text-muted border-border-subtle'}`}>
+          <span className={`px-2 py-0.5 rounded-full border ${notif.type === 'question' ? 'bg-blue-400/10 text-hue-blue border-blue-400/20' : 'bg-border-subtle/50 text-text-muted border-border-subtle'}`}>
             {notif.type}
           </span>
         </div>
@@ -153,7 +153,7 @@ function NotificationCard({ notif }: { notif: Notification }) {
 
       {/* Show answer if answered */}
       {notif.status === 'answered' && (
-        <div className="mt-2 text-sm text-emerald-400">
+        <div className="mt-2 text-sm text-hue-emerald">
           Answer: {notif.answer} <span className="text-text-faint">(via {notif.answered_by})</span>
         </div>
       )}

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -6,17 +6,17 @@ import { MarkdownContent } from '../components/Chat/MarkdownContent';
 import { api } from '../api/client';
 
 const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  approved: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  implementing: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  declined: 'bg-red-400/10 text-red-400 border-red-400/20',
+  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
+  approved: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
+  implementing: 'bg-blue-400/10 text-hue-blue border-blue-400/20',
+  declined: 'bg-red-400/10 text-hue-red border-red-400/20',
   superseded: 'bg-border-subtle/50 text-text-muted border-border-subtle',
-  failed: 'bg-red-400/10 text-red-400 border-red-400/20',
+  failed: 'bg-red-400/10 text-hue-red border-red-400/20',
 };
 
 const TYPE_STYLES: Record<string, { label: string; className: string }> = {
-  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-purple-400 border-purple-400/20' },
-  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-purple-300 border-purple-400/20' },
+  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-hue-purple border-purple-400/20' },
+  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-hue-purple border-purple-400/20' },
 };
 
 interface HoaStatus {
@@ -128,7 +128,7 @@ export function PlanDetailPage() {
           {isImplementing && plan.impl_session_id && (
             <button
               onClick={() => navigate(`/chat/${plan.impl_session_id}`)}
-              className="flex items-center gap-1 text-blue-400 hover:text-blue-300 cursor-pointer"
+              className="flex items-center gap-1 text-hue-blue hover:text-hue-blue cursor-pointer"
             >
               <MessageSquare size={11} /> Watch implementation
             </button>
@@ -164,7 +164,7 @@ export function PlanDetailPage() {
                     onClick={() => setUseMultiAgent(!useMultiAgent)}
                     className={`flex items-center gap-2 px-3 py-1.5 text-[12px] rounded-lg border cursor-pointer transition-colors ${
                       useMultiAgent
-                        ? 'bg-amber-400/10 text-amber-400 border-amber-400/30'
+                        ? 'bg-amber-400/10 text-hue-amber border-amber-400/30'
                         : 'bg-surface-raised text-text-dim border-border-subtle hover:border-border'
                     }`}
                   >

--- a/web/src/pages/PlansPage.tsx
+++ b/web/src/pages/PlansPage.tsx
@@ -4,17 +4,17 @@ import { Lightbulb } from 'lucide-react';
 import { usePlanStore, type Plan } from '../stores/planStore';
 
 const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  approved: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
-  implementing: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  declined: 'bg-red-400/10 text-red-400 border-red-400/20',
+  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
+  approved: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
+  implementing: 'bg-blue-400/10 text-hue-blue border-blue-400/20',
+  declined: 'bg-red-400/10 text-hue-red border-red-400/20',
   superseded: 'bg-border-subtle/50 text-text-muted border-border-subtle',
-  failed: 'bg-red-400/10 text-red-400 border-red-400/20',
+  failed: 'bg-red-400/10 text-hue-red border-red-400/20',
 };
 
 const TYPE_STYLES: Record<string, { label: string; className: string }> = {
-  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-purple-400 border-purple-400/20' },
-  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-purple-300 border-purple-400/20' },
+  'skill-create': { label: 'Skill', className: 'bg-purple-400/10 text-hue-purple border-purple-400/20' },
+  'skill-update': { label: 'Skill Update', className: 'bg-purple-400/10 text-hue-purple border-purple-400/20' },
 };
 
 const FILTERS = [

--- a/web/src/pages/SkillDetailPage.tsx
+++ b/web/src/pages/SkillDetailPage.tsx
@@ -108,7 +108,7 @@ export function SkillDetailPage() {
           )}
           <button
             onClick={() => setShowDeleteConfirm(true)}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-red-400 hover:bg-red-900/20 rounded cursor-pointer"
+            className="flex items-center gap-1 px-2 py-1 text-xs text-hue-red hover:bg-red-900/20 rounded cursor-pointer"
           >
             <Trash2 size={12} />
           </button>
@@ -122,7 +122,7 @@ export function SkillDetailPage() {
           <div className="px-4 py-2 border-b border-border flex items-center gap-2">
             <FileText size={12} className="text-text-dim" />
             <span className="text-xs text-text-muted">SKILL.md</span>
-            {hasChanges && <span className="text-[10px] text-amber-400">unsaved</span>}
+            {hasChanges && <span className="text-[10px] text-hue-amber">unsaved</span>}
           </div>
           <textarea
             value={editContent}
@@ -158,7 +158,7 @@ export function SkillDetailPage() {
                       <CheckCircle size={10} />
                       <span>Success Rate</span>
                     </div>
-                    <span className={`text-xs font-mono ${successRate >= 90 ? 'text-emerald-400' : 'text-amber-400'}`}>
+                    <span className={`text-xs font-mono ${successRate >= 90 ? 'text-hue-emerald' : 'text-hue-amber'}`}>
                       {successRate}%
                     </span>
                   </div>
@@ -189,13 +189,13 @@ export function SkillDetailPage() {
             <div className="space-y-2 text-xs">
               <div className="flex justify-between">
                 <span className="text-text-dim">User Invocable</span>
-                <span className={selectedSkill.user_invocable ? 'text-emerald-400' : 'text-text-dim'}>
+                <span className={selectedSkill.user_invocable ? 'text-hue-emerald' : 'text-text-dim'}>
                   {selectedSkill.user_invocable ? 'Yes' : 'No'}
                 </span>
               </div>
               <div className="flex justify-between">
                 <span className="text-text-dim">Model Invocable</span>
-                <span className={selectedSkill.model_invocable ? 'text-emerald-400' : 'text-text-dim'}>
+                <span className={selectedSkill.model_invocable ? 'text-hue-emerald' : 'text-text-dim'}>
                   {selectedSkill.model_invocable ? 'Yes' : 'No'}
                 </span>
               </div>
@@ -233,9 +233,9 @@ export function SkillDetailPage() {
                   <div key={u.id} className="flex items-center justify-between text-[10px]">
                     <div className="flex items-center gap-1.5">
                       {u.success ? (
-                        <CheckCircle size={10} className="text-emerald-500" />
+                        <CheckCircle size={10} className="text-hue-emerald" />
                       ) : (
-                        <XCircle size={10} className="text-red-500" />
+                        <XCircle size={10} className="text-hue-red" />
                       )}
                       <span className="text-text-muted">{u.invoked_by}</span>
                     </div>

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -43,7 +43,7 @@ function SkillCard({ skill }: { skill: Skill }) {
         </div>
         {successRate !== null && (
           <div className="flex items-center gap-1">
-            {successRate >= 90 ? <CheckCircle size={10} className="text-emerald-500" /> : <XCircle size={10} className="text-amber-500" />}
+            {successRate >= 90 ? <CheckCircle size={10} className="text-hue-emerald" /> : <XCircle size={10} className="text-hue-amber" />}
             <span>{successRate}%</span>
           </div>
         )}
@@ -54,7 +54,7 @@ function SkillCard({ skill }: { skill: Skill }) {
           </div>
         )}
         {!skill.enabled && (
-          <span className="text-amber-500/70">disabled</span>
+          <span className="text-hue-amber/70">disabled</span>
         )}
       </div>
     </div>

--- a/web/src/pages/SourcesPage.tsx
+++ b/web/src/pages/SourcesPage.tsx
@@ -32,9 +32,9 @@ function formatBytes(bytes: number): string {
 function sourceIcon(source: string) {
   const type = source.split(':')[0];
   switch (type) {
-    case 'gmail': return <Mail size={14} className="text-red-400" />;
-    case 'github': return <Github size={14} className="text-purple-400" />;
-    case 'telegram': return <MessageCircle size={14} className="text-blue-400" />;
+    case 'gmail': return <Mail size={14} className="text-hue-red" />;
+    case 'github': return <Github size={14} className="text-hue-purple" />;
+    case 'telegram': return <MessageCircle size={14} className="text-hue-blue" />;
     default: return <Inbox size={14} className="text-text-dim" />;
   }
 }
@@ -148,7 +148,7 @@ function SourceSidebar() {
                 </span>
                 <span className="shrink-0 flex items-center gap-1.5">
                   {unread > 0 && (
-                    <span className="text-[10px] tabular-nums bg-amber-500/20 text-amber-400 px-1 py-0.5 rounded-full leading-none font-medium">
+                    <span className="text-[10px] tabular-nums bg-amber-500/20 text-hue-amber px-1 py-0.5 rounded-full leading-none font-medium">
                       {unread}
                     </span>
                   )}
@@ -188,7 +188,7 @@ function SourceSidebar() {
               else setPurgeConfirm(activeSource);
             }}
               className={`flex-1 flex items-center justify-center gap-1 px-2 py-1 text-[11px] rounded transition-colors cursor-pointer
-                ${purgeConfirm === activeSource ? 'bg-red-500/15 text-red-600 border border-red-500/30' : 'text-text-dim hover:text-red-400 bg-surface border border-border-subtle'}`}>
+                ${purgeConfirm === activeSource ? 'bg-red-500/15 text-red-600 border border-red-500/30' : 'text-text-dim hover:text-hue-red bg-surface border border-border-subtle'}`}>
               <Trash2 size={10} /> {purgeConfirm === activeSource ? 'Confirm?' : 'Purge source'}
             </button>
           ) : (
@@ -197,7 +197,7 @@ function SourceSidebar() {
               else setPurgeConfirm('_all');
             }}
               className={`flex-1 flex items-center justify-center gap-1 px-2 py-1 text-[11px] rounded transition-colors cursor-pointer
-                ${purgeConfirm === '_all' ? 'bg-red-500/15 text-red-600 border border-red-500/30' : 'text-text-dim hover:text-red-400 bg-surface border border-border-subtle'}`}>
+                ${purgeConfirm === '_all' ? 'bg-red-500/15 text-red-600 border border-red-500/30' : 'text-text-dim hover:text-hue-red bg-surface border border-border-subtle'}`}>
               <Trash2 size={10} /> {purgeConfirm === '_all' ? 'Confirm purge all?' : 'Purge all'}
             </button>
           )}
@@ -212,7 +212,7 @@ function SourceSidebar() {
 
         {/* Health summary */}
         {sourceHealth && Object.values(sourceHealth).some(h => h.state !== 'healthy') && (
-          <div className="text-[11px] text-amber-400 flex items-center gap-1 pt-1">
+          <div className="text-[11px] text-hue-amber flex items-center gap-1 pt-1">
             <AlertTriangle size={10} />
             {Object.values(sourceHealth).filter(h => h.state !== 'healthy').length} source(s) unhealthy
           </div>
@@ -232,7 +232,7 @@ function SourceStats({ info }: { info: SourceOverviewEntry }) {
         <span className="text-text-dim">24h runs</span><span className="text-text-muted">{info.stats_24h.runs}</span>
         <span className="text-text-dim">24h fetched</span><span className="text-text-muted">{info.stats_24h.fetched}</span>
         {info.stats_24h.errors > 0 && <>
-          <span className="text-text-dim">24h errors</span><span className="text-red-400">{info.stats_24h.errors}</span>
+          <span className="text-text-dim">24h errors</span><span className="text-hue-red">{info.stats_24h.errors}</span>
         </>}
       </div>
     </div>
@@ -259,7 +259,7 @@ function AggregateStats({ sources }: { sources: Record<string, SourceOverviewEnt
         <span className="text-text-dim">24h runs</span><span className="text-text-muted">{totals.runs_24h}</span>
         <span className="text-text-dim">24h fetched</span><span className="text-text-muted">{totals.fetched_24h}</span>
         {totals.errors_24h > 0 && <>
-          <span className="text-text-dim">24h errors</span><span className="text-red-400">{totals.errors_24h}</span>
+          <span className="text-text-dim">24h errors</span><span className="text-hue-red">{totals.errors_24h}</span>
         </>}
       </div>
     </div>
@@ -409,9 +409,9 @@ function RunsList() {
                   <td className="px-3 py-2 text-text-muted">{run.records_fetched}/{run.records_processed}</td>
                   <td className="px-3 py-2">
                     {run.error ? (
-                      <span className="flex items-center gap-1 text-red-400"><XCircle size={12} /> error</span>
+                      <span className="flex items-center gap-1 text-hue-red"><XCircle size={12} /> error</span>
                     ) : (
-                      <span className="flex items-center gap-1 text-emerald-400"><CheckCircle2 size={12} /> ok</span>
+                      <span className="flex items-center gap-1 text-hue-emerald"><CheckCircle2 size={12} /> ok</span>
                     )}
                   </td>
                 </tr>
@@ -455,9 +455,9 @@ function RunDetail() {
           {sourceIcon(run.source)}
           <span className="text-[14px] text-text-secondary font-medium">{sourceLabel(run.source)}</span>
           {run.error ? (
-            <span className="flex items-center gap-1 text-[11px] text-red-400"><XCircle size={11} /> error</span>
+            <span className="flex items-center gap-1 text-[11px] text-hue-red"><XCircle size={11} /> error</span>
           ) : (
-            <span className="flex items-center gap-1 text-[11px] text-emerald-400"><CheckCircle2 size={11} /> ok</span>
+            <span className="flex items-center gap-1 text-[11px] text-hue-emerald"><CheckCircle2 size={11} /> ok</span>
           )}
         </div>
         <div className="text-[12px] text-text-dim">{new Date(run.ran_at).toLocaleString()}</div>
@@ -662,7 +662,7 @@ function ConsumersList() {
                 </td>
                 <td className="px-3 py-2 text-right">
                   {c.unread > 0 ? (
-                    <span className="text-amber-400 font-medium tabular-nums">{c.unread}</span>
+                    <span className="text-hue-amber font-medium tabular-nums">{c.unread}</span>
                   ) : (
                     <span className="text-text-faint tabular-nums">0</span>
                   )}
@@ -710,7 +710,7 @@ function ConsumersDetail() {
               </div>
               <div className="flex items-center gap-3 mt-1.5 text-[11px] text-text-dim">
                 <span>{cursorsForSession.length} source{cursorsForSession.length !== 1 ? 's' : ''}</span>
-                {totalUnread > 0 && <span className="text-amber-400">{totalUnread} unread</span>}
+                {totalUnread > 0 && <span className="text-hue-amber">{totalUnread} unread</span>}
               </div>
             </button>
           );

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -5,9 +5,9 @@ import { useTaskStore } from '../stores/taskStore';
 import { MarkdownContent } from '../components/Chat/MarkdownContent';
 
 const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-yellow-400 border-yellow-400/20',
-  in_progress: 'bg-blue-400/10 text-blue-400 border-blue-400/20',
-  done: 'bg-emerald-400/10 text-emerald-400 border-emerald-400/20',
+  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
+  in_progress: 'bg-blue-400/10 text-hue-blue border-blue-400/20',
+  done: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
   deferred: 'bg-border-subtle/50 text-text-muted border-border-subtle',
 };
 


### PR DESCRIPTION
## Summary
- Restores original diff colors (dark `-950/25` bg + `-300/90` text scheme) broken by f7f408a, adds proper light-mode variants (flipped `-300/25` bg + `-800/90` text)
- Adds 4 diff tokens (`diff-add`, `diff-del`, `diff-add-bg`, `diff-del-bg`) and 12 hue indicator tokens (`hue-yellow`, `hue-blue`, `hue-emerald`, etc.) that map `-400` in dark → `-600` in light
- Replaces hardcoded `text-{color}-{300,400,500}` across 43 files with theme-aware `text-hue-{color}` tokens
- Fixes EditToolBlock inline diffs to use diff tokens instead of hardcoded Tailwind classes

## Test plan
- [ ] Verify diff panel colors match original dark design (dark `-950` tinted backgrounds, `-300` pastel text)
- [ ] Toggle to light theme — diffs should use inverted scheme (light tinted bg, dark text)
- [ ] Check status badges (tasks, plans, notifications) are readable in both themes
- [ ] Check tool blocks (memory, source, skill, HoA) have proper indicator colors in both themes
- [ ] Run `npm run build` — clean build, no TS errors

> *Generated by [Nerve](https://github.com/pufit/nerve)*