### PR TITLE
Add file management: upload, download, and send_file tool

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1247,6 +1247,7 @@ class AgentEngine:
         model: str | None = None,
         internal: bool = False,
         images: list[dict[str, Any]] | None = None,
+        image_refs: list[dict[str, Any]] | None = None,
     ) -> str:
         """Run the agent for a user message and return the final text response.
 
@@ -1256,6 +1257,8 @@ class AgentEngine:
                       DB or shown in the UI.
             images: Optional list of image dicts with keys ``type``,
                     ``media_type``, and ``data`` (base64-encoded).
+            image_refs: Optional metadata about uploaded files for persisting
+                        in the user message blocks column (web uploads only).
         """
         # Serialize runs per session — messages for the same session wait
         # in order instead of failing with "already running".
@@ -1281,6 +1284,7 @@ class AgentEngine:
                     return await self._run_inner(
                         session_id, user_message, source, channel, model,
                         internal=internal, images=images,
+                        image_refs=image_refs,
                     )
                 finally:
                     self.sessions.mark_not_running(session_id)
@@ -1301,6 +1305,7 @@ class AgentEngine:
         model: str | None,
         internal: bool = False,
         images: list[dict[str, Any]] | None = None,
+        image_refs: list[dict[str, Any]] | None = None,
     ) -> str:
         # Ensure session exists in DB
         await self.sessions.get_or_create(session_id, source=source)
@@ -1330,10 +1335,14 @@ class AgentEngine:
             # Store user message in DB (note attached images for display)
             db_text = user_message
             if images:
-                suffix = f"\n[{len(images)} image(s) attached]"
-                db_text = (user_message + suffix) if user_message else suffix.strip()
+                # Count only image/pdf entries, not text_file entries
+                img_count = sum(1 for img in images if img.get("type") != "text_file")
+                if img_count:
+                    suffix = f"\n[{img_count} image(s) attached]"
+                    db_text = (user_message + suffix) if user_message else suffix.strip()
             await self.sessions.add_message(
                 session_id, "user", db_text, channel=channel,
+                blocks=image_refs,
             )
 
         full_response_text = ""
@@ -1383,6 +1392,16 @@ class AgentEngine:
                 if query_text:
                     content_blocks.append({"type": "text", "text": query_text})
                 for img in images:
+                    # Text files are inlined as text context blocks
+                    if img.get("type") == "text_file":
+                        fname = img.get("filename", "file")
+                        content = img.get("content", "")
+                        content_blocks.append({
+                            "type": "text",
+                            "text": f"--- Attached: {fname} ---\n{content}",
+                        })
+                        continue
+
                     # PDFs use "document" content block; images use "image"
                     block_type = "document" if img["media_type"] == "application/pdf" else "image"
 

--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -2157,9 +2157,49 @@ def create_session_mcp_server(session_id: str):
             parts.append(f"stderr:\n{result.stderr_log[:2000]}")
             return _hoa_text("\n\n".join(parts))
 
+    _SEND_FILE_SCHEMA = {
+        "file_path": {"type": "string", "description": "Absolute path to the file to send to the user"},
+    }
+
+    @tool(
+        "send_file",
+        "Send a file to the user as a downloadable attachment in the chat. "
+        "The file will appear inline as a download card. Use this when the user asks "
+        "you to share, export, or send them a file.",
+        _SEND_FILE_SCHEMA,
+    )
+    async def session_send_file(args: dict) -> dict:
+        from nerve.agent.streaming import broadcaster
+
+        file_path = args.get("file_path", "")
+        if not file_path:
+            return {"content": [{"type": "text", "text": "Error: file_path is required."}]}
+
+        resolved = Path(file_path).resolve()
+        if not resolved.exists() or not resolved.is_file():
+            return {"content": [{"type": "text", "text": f"Error: file not found: {file_path}"}]}
+
+        # Security: must be within workspace
+        if _workspace and not str(resolved).startswith(str(_workspace.resolve())):
+            return {"content": [{"type": "text", "text": "Error: file must be within the workspace."}]}
+
+        filename = resolved.name
+        file_size = resolved.stat().st_size
+
+        # Broadcast a file_attachment event so the frontend renders a download card
+        await broadcaster.broadcast(session_id, {
+            "type": "file_attachment",
+            "session_id": session_id,
+            "path": str(resolved),
+            "filename": filename,
+            "size": file_size,
+        })
+
+        return {"content": [{"type": "text", "text": f"Sent file: {filename} ({file_size:,} bytes)"}]}
+
     # Shared tools (don't need session context) + session-scoped tools
     shared_tools = [t for t in ALL_TOOLS if t.name not in ("notify", "ask_user", "react", "send_sticker")]
-    session_tools: list[SdkMcpTool] = [session_notify, session_ask_user, session_react, session_send_sticker]
+    session_tools: list[SdkMcpTool] = [session_notify, session_ask_user, session_react, session_send_sticker, session_send_file]
 
     # Only include houseofagents tools when enabled — saves context tokens otherwise
     hoa_enabled = _config and _config.houseofagents.enabled

--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -2169,8 +2169,6 @@ def create_session_mcp_server(session_id: str):
         _SEND_FILE_SCHEMA,
     )
     async def session_send_file(args: dict) -> dict:
-        from nerve.agent.streaming import broadcaster
-
         file_path = args.get("file_path", "")
         if not file_path:
             return {"content": [{"type": "text", "text": "Error: file_path is required."}]}
@@ -2186,15 +2184,8 @@ def create_session_mcp_server(session_id: str):
         filename = resolved.name
         file_size = resolved.stat().st_size
 
-        # Broadcast a file_attachment event so the frontend renders a download card
-        await broadcaster.broadcast(session_id, {
-            "type": "file_attachment",
-            "session_id": session_id,
-            "path": str(resolved),
-            "filename": filename,
-            "size": file_size,
-        })
-
+        # The tool_call block persists in DB — frontend renders it
+        # as an inline download card via SendFileBlock.
         return {"content": [{"type": "text", "text": f"Sent file: {filename} ({file_size:,} bytes)"}]}
 
     # Shared tools (don't need session context) + session-scoped tools

--- a/nerve/db/base.py
+++ b/nerve/db/base.py
@@ -17,6 +17,7 @@ import aiosqlite
 
 from nerve.db.audit import AuditStore
 from nerve.db.cron import CronStore
+from nerve.db.files import FileStore
 from nerve.db.mcp import McpStore
 from nerve.db.messages import MessageStore
 from nerve.db.migrations.runner import discover_migrations, run_migrations
@@ -47,6 +48,7 @@ class Database(
     McpStore,
     AuditStore,
     UsageStore,
+    FileStore,
 ):
     """Async SQLite database wrapper.
 

--- a/nerve/db/files.py
+++ b/nerve/db/files.py
@@ -1,0 +1,59 @@
+"""Uploaded file data access methods."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+
+class FileStore:
+    """Mixin providing uploaded file CRUD operations."""
+
+    async def save_uploaded_file(
+        self,
+        file_id: str,
+        session_id: str,
+        filename: str,
+        media_type: str,
+        file_type: str,
+        file_size: int,
+        disk_path: str,
+    ) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        await self.db.execute(
+            """INSERT INTO uploaded_files (id, session_id, filename, media_type, file_type, file_size, disk_path, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (file_id, session_id, filename, media_type, file_type, file_size, disk_path, now),
+        )
+        await self.db.commit()
+
+    async def get_uploaded_file(self, file_id: str) -> dict | None:
+        async with self.db.execute(
+            "SELECT * FROM uploaded_files WHERE id = ?", (file_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            return dict(row) if row else None
+
+    async def get_uploaded_files_by_ids(self, file_ids: list[str]) -> list[dict]:
+        if not file_ids:
+            return []
+        placeholders = ",".join("?" for _ in file_ids)
+        async with self.db.execute(
+            f"SELECT * FROM uploaded_files WHERE id IN ({placeholders})",
+            file_ids,
+        ) as cursor:
+            return [dict(row) async for row in cursor]
+
+    async def delete_uploaded_files(self, session_id: str) -> list[str]:
+        """Delete all uploaded file records for a session. Returns disk paths for cleanup."""
+        async with self.db.execute(
+            "SELECT disk_path FROM uploaded_files WHERE session_id = ?",
+            (session_id,),
+        ) as cursor:
+            paths = [row[0] async for row in cursor]
+        await self.db.execute(
+            "DELETE FROM uploaded_files WHERE session_id = ?",
+            (session_id,),
+        )
+        await self.db.commit()
+        return paths

--- a/nerve/db/migrations/v022_uploaded_files.py
+++ b/nerve/db/migrations/v022_uploaded_files.py
@@ -1,0 +1,22 @@
+"""v022: Add uploaded_files table for web chat file management."""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.executescript("""
+        CREATE TABLE IF NOT EXISTS uploaded_files (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            media_type TEXT NOT NULL,
+            file_type TEXT NOT NULL,
+            file_size INTEGER NOT NULL,
+            disk_path TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_uploaded_files_session
+            ON uploaded_files(session_id);
+    """)

--- a/nerve/gateway/auth.py
+++ b/nerve/gateway/auth.py
@@ -46,7 +46,7 @@ def decode_token(token: str, jwt_secret: str) -> dict:
 
 
 def get_token_from_request(request: Request) -> str:
-    """Extract JWT token from cookie or Authorization header."""
+    """Extract JWT token from cookie, Authorization header, or query param."""
     # Try cookie first
     token = request.cookies.get("nerve_token")
     if token:
@@ -56,6 +56,11 @@ def get_token_from_request(request: Request) -> str:
     auth = request.headers.get("Authorization", "")
     if auth.startswith("Bearer "):
         return auth[7:]
+
+    # Try query parameter (for <img src> and <a download> that can't set headers)
+    token = request.query_params.get("token")
+    if token:
+        return token
 
     raise HTTPException(status_code=401, detail="Not authenticated")
 

--- a/nerve/gateway/routes/__init__.py
+++ b/nerve/gateway/routes/__init__.py
@@ -24,6 +24,7 @@ from nerve.gateway.routes import (
     sources,
     notifications,
     houseofagents,
+    files,
 )
 
 __all__ = [
@@ -49,4 +50,5 @@ def register_all_routes() -> APIRouter:
     router.include_router(sources.router)
     router.include_router(notifications.router)
     router.include_router(houseofagents.router)
+    router.include_router(files.router)
     return router

--- a/nerve/gateway/routes/files.py
+++ b/nerve/gateway/routes/files.py
@@ -1,0 +1,158 @@
+"""File upload and download routes."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+from nerve.config import get_config
+from nerve.gateway.auth import require_auth
+from nerve.gateway.routes._deps import get_deps
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+MAX_FILE_SIZE = 20 * 1024 * 1024  # 20 MB per file
+MAX_TOTAL_SIZE = 50 * 1024 * 1024  # 50 MB per request
+
+IMAGE_TYPES = {"image/png", "image/jpeg", "image/gif", "image/webp"}
+PDF_TYPES = {"application/pdf"}
+
+
+def _classify_file(media_type: str) -> str:
+    """Classify an uploaded file as image, pdf, or text."""
+    if media_type in IMAGE_TYPES:
+        return "image"
+    if media_type in PDF_TYPES:
+        return "pdf"
+    return "text"
+
+
+def _uploads_dir() -> Path:
+    """Return the uploads root directory."""
+    config = get_config()
+    return config.workspace / ".uploads"
+
+
+@router.post("/api/files/upload")
+async def upload_files(
+    files: list[UploadFile] = File(...),
+    session_id: str = Form(...),
+    user: dict = Depends(require_auth),
+):
+    """Upload one or more files, store on disk and track in DB."""
+    deps = get_deps()
+
+    # Validate session exists
+    session = await deps.db.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Read all files and validate sizes
+    file_data: list[tuple[UploadFile, bytes]] = []
+    total_size = 0
+    for f in files:
+        data = await f.read()
+        if len(data) > MAX_FILE_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"File '{f.filename}' exceeds {MAX_FILE_SIZE // (1024*1024)}MB limit",
+            )
+        total_size += len(data)
+        if total_size > MAX_TOTAL_SIZE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Total upload size exceeds {MAX_TOTAL_SIZE // (1024*1024)}MB limit",
+            )
+        file_data.append((f, data))
+
+    # Store files on disk and in DB
+    upload_dir = _uploads_dir() / session_id
+    upload_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for f, data in file_data:
+        file_id = uuid.uuid4().hex[:16]
+        filename = f.filename or "unnamed"
+        # Sanitize filename
+        filename = Path(filename).name  # strip directory components
+        media_type = f.content_type or "application/octet-stream"
+        file_type = _classify_file(media_type)
+
+        disk_path = upload_dir / f"{file_id}_{filename}"
+        disk_path.write_bytes(data)
+
+        await deps.db.save_uploaded_file(
+            file_id=file_id,
+            session_id=session_id,
+            filename=filename,
+            media_type=media_type,
+            file_type=file_type,
+            file_size=len(data),
+            disk_path=str(disk_path),
+        )
+
+        results.append({
+            "id": file_id,
+            "filename": filename,
+            "media_type": media_type,
+            "file_type": file_type,
+            "size": len(data),
+        })
+
+    return {"files": results}
+
+
+@router.get("/api/files/uploads/{file_id}")
+async def get_uploaded_file(
+    file_id: str,
+    user: dict = Depends(require_auth),
+):
+    """Serve an uploaded file by its ID (for image display in chat history)."""
+    deps = get_deps()
+    record = await deps.db.get_uploaded_file(file_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    disk_path = Path(record["disk_path"])
+    if not disk_path.exists():
+        raise HTTPException(status_code=404, detail="File not found on disk")
+
+    return FileResponse(
+        path=str(disk_path),
+        media_type=record["media_type"],
+        filename=record["filename"],
+    )
+
+
+@router.get("/api/files/download")
+async def download_file(
+    path: str,
+    user: dict = Depends(require_auth),
+):
+    """Download a workspace file by absolute path."""
+    config = get_config()
+    workspace_root = config.workspace.resolve()
+
+    resolved = Path(path).resolve()
+    if not resolved.is_relative_to(workspace_root):
+        raise HTTPException(status_code=403, detail="Access denied: path outside workspace")
+
+    if not resolved.exists() or not resolved.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    import mimetypes
+    media_type, _ = mimetypes.guess_type(str(resolved))
+
+    return FileResponse(
+        path=str(resolved),
+        media_type=media_type or "application/octet-stream",
+        filename=resolved.name,
+        headers={"Content-Disposition": f'attachment; filename="{resolved.name}"'},
+    )

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -20,6 +20,27 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+async def _cleanup_uploaded_files(db: object, session_id: str) -> None:
+    """Delete uploaded files from DB and disk for a deleted session."""
+    try:
+        disk_paths = await db.delete_uploaded_files(session_id)  # type: ignore[attr-defined]
+        for p in disk_paths:
+            try:
+                Path(p).unlink(missing_ok=True)
+            except Exception:
+                pass
+        # Try to remove session upload dir if empty
+        config = get_config()
+        session_dir = config.workspace / ".uploads" / session_id
+        if session_dir.exists():
+            try:
+                session_dir.rmdir()
+            except OSError:
+                pass  # Not empty — that's fine
+    except Exception as e:
+        logger.warning("Failed to cleanup uploaded files for session %s: %s", session_id, e)
+
+
 # --- Request/Response models ---
 
 class MessageRequest(BaseModel):
@@ -141,6 +162,8 @@ async def delete_session(session_id: str, user: dict = Depends(require_auth)):
         messages = await db.get_messages(session_id, limit=10000) if connected_at else []
         # Delete from DB immediately (fast)
         await db.delete_session(session_id)
+        # Cleanup uploaded files for this session
+        await _cleanup_uploaded_files(db, session_id)
         # Memorize in background from snapshot
         if messages and connected_at and engine._memory_bridge and engine._memory_bridge.available:
             async def _bg_memorize():
@@ -159,6 +182,7 @@ async def delete_session(session_id: str, user: dict = Depends(require_auth)):
             asyncio.create_task(_bg_memorize())
     else:
         await db.delete_session(session_id)
+        await _cleanup_uploaded_files(db, session_id)
     return {"deleted": True}
 
 

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -295,6 +295,7 @@ def create_app() -> FastAPI:
                     # User sent a chat message
                     user_text = data.get("content", "")
                     session_id = data.get("session_id", active_session)
+                    file_ids = data.get("file_ids", [])
 
                     if session_id != active_session:
                         # Switch sessions
@@ -303,6 +304,14 @@ def create_app() -> FastAPI:
                         await broadcaster.register(active_session, client_id, ws_broadcast)
                         await router.switch_session("web:default", session_id)
 
+                    # Load uploaded files if any
+                    images = None
+                    image_refs = None
+                    if file_ids:
+                        images, image_refs = await _load_uploaded_files(
+                            _engine.db, file_ids,
+                        )
+
                     # Run agent in background, store task for stop support
                     task = asyncio.create_task(
                         _engine.run(
@@ -310,6 +319,8 @@ def create_app() -> FastAPI:
                             user_message=user_text,
                             source="web",
                             channel="web",
+                            images=images or None,
+                            image_refs=image_refs or None,
                         )
                     )
                     _engine.register_task(session_id, task)
@@ -433,6 +444,67 @@ def create_app() -> FastAPI:
             return FileResponse(str(web_dist / "index.html"))
 
     return app
+
+
+async def _load_uploaded_files(
+    db: Database, file_ids: list[str],
+) -> tuple[list[dict], list[dict]]:
+    """Load uploaded files from DB/disk into the engine image format.
+
+    Returns:
+        (images, image_refs) where images is the list for engine.run(images=...)
+        and image_refs is metadata for storing in the user message blocks column.
+    """
+    import base64
+
+    records = await db.get_uploaded_files_by_ids(file_ids)
+    images: list[dict] = []
+    image_refs: list[dict] = []
+
+    for rec in records:
+        disk_path = Path(rec["disk_path"])
+        if not disk_path.exists():
+            logger.warning("Uploaded file not found on disk: %s", disk_path)
+            continue
+
+        data = disk_path.read_bytes()
+        file_type = rec["file_type"]
+        media_type = rec["media_type"]
+        file_id = rec["id"]
+        filename = rec["filename"]
+
+        if file_type in ("image", "pdf"):
+            b64 = base64.b64encode(data).decode("utf-8")
+            images.append({
+                "type": "base64",
+                "media_type": media_type,
+                "data": b64,
+            })
+            image_refs.append({
+                "type": "image" if file_type == "image" else "file",
+                "url": f"/api/files/uploads/{file_id}",
+                "filename": filename,
+                "media_type": media_type,
+            })
+        else:
+            # Text file — will be appended to user message by the engine
+            try:
+                text_content = data.decode("utf-8")
+            except UnicodeDecodeError:
+                text_content = f"[Binary file: {filename}, {len(data)} bytes]"
+            images.append({
+                "type": "text_file",
+                "filename": filename,
+                "content": text_content,
+            })
+            image_refs.append({
+                "type": "file",
+                "url": f"/api/files/uploads/{file_id}",
+                "filename": filename,
+                "media_type": media_type,
+            })
+
+    return images, image_refs
 
 
 def run_server(config: NerveConfig | None = None) -> None:

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -306,4 +306,31 @@ export const api = {
   installHoaBinary: () =>
     request<{ installed: boolean; path: string; version: string }>('/houseofagents/install', { method: 'POST' }),
 
+  // Files
+  uploadFiles: async (files: File[], sessionId: string): Promise<{ files: Array<{ id: string; filename: string; media_type: string; file_type: string; size: number }> }> => {
+    const formData = new FormData();
+    formData.append('session_id', sessionId);
+    files.forEach(f => formData.append('files', f));
+
+    const headers: Record<string, string> = {};
+    if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+    const res = await fetch(`${API_BASE}/files/upload`, {
+      method: 'POST',
+      headers,
+      body: formData,
+    });
+
+    if (res.status === 401) {
+      clearToken();
+      window.location.reload();
+      throw new Error('Unauthorized');
+    }
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`${res.status}: ${body}`);
+    }
+    return res.json();
+  },
+
 };

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -25,7 +25,6 @@ export type WSMessage =
   | { type: 'session_running'; session_id: string; is_running: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'timeout' }[] }
   | { type: 'hoa_progress'; session_id: string; event: Record<string, unknown> }
-  | { type: 'file_attachment'; session_id: string; path: string; filename: string; size: number }
   | { type: 'pong' };
 
 type MessageHandler = (msg: WSMessage) => void;

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -89,8 +89,12 @@ export class NerveWebSocket {
     }
   }
 
-  sendMessage(content: string, sessionId: string) {
-    this.send({ type: 'message', content, session_id: sessionId });
+  sendMessage(content: string, sessionId: string, fileIds?: string[]) {
+    const msg: Record<string, unknown> = { type: 'message', content, session_id: sessionId };
+    if (fileIds && fileIds.length > 0) {
+      msg.file_ids = fileIds;
+    }
+    this.send(msg);
   }
 
   switchSession(sessionId: string) {

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -25,6 +25,7 @@ export type WSMessage =
   | { type: 'session_running'; session_id: string; is_running: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'timeout' }[] }
   | { type: 'hoa_progress'; session_id: string; event: Record<string, unknown> }
+  | { type: 'file_attachment'; session_id: string; path: string; filename: string; size: number }
   | { type: 'pong' };
 
 type MessageHandler = (msg: WSMessage) => void;

--- a/web/src/components/Chat/BlockRenderer.tsx
+++ b/web/src/components/Chat/BlockRenderer.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
+import { Download, FileText } from 'lucide-react';
 import type { MessageBlock } from '../../types/chat';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolCallBlock } from './ToolCallBlock';
 import { ToolCallGroupBlock } from './ToolCallGroupBlock';
 import { MarkdownContent } from './MarkdownContent';
 import { groupToolCalls } from '../../utils/groupToolCalls';
+import { getToken } from '../../api/client';
 
 interface BlockRendererProps {
   blocks: MessageBlock[];
@@ -53,6 +55,29 @@ export function BlockRenderer({
               <div key={i}>{inner}</div>
             );
           }
+          case 'image':
+            return (
+              <div key={i} className="my-2">
+                <a href={item.url} target="_blank" rel="noopener noreferrer" className="inline-block rounded-lg overflow-hidden border border-border hover:border-accent/50 transition-colors">
+                  <img src={item.url} alt={item.filename} className="max-w-[300px] max-h-[300px] object-contain" />
+                </a>
+              </div>
+            );
+          case 'file':
+            return (
+              <div key={i} className="my-2">
+                <a
+                  href={`${item.url}${item.url.includes('?') ? '&' : '?'}token=${getToken()}`}
+                  download={item.filename}
+                  className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-surface hover:bg-surface-hover transition-colors text-sm text-text-secondary"
+                >
+                  <FileText size={14} />
+                  <span className="truncate max-w-[200px]">{item.filename}</span>
+                  {item.size != null && <span className="text-text-muted text-xs">({(item.size / 1024).toFixed(1)}KB)</span>}
+                  <Download size={12} className="text-text-muted" />
+                </a>
+              </div>
+            );
           default:
             return null;
         }

--- a/web/src/components/Chat/BlockRenderer.tsx
+++ b/web/src/components/Chat/BlockRenderer.tsx
@@ -55,14 +55,16 @@ export function BlockRenderer({
               <div key={i}>{inner}</div>
             );
           }
-          case 'image':
+          case 'image': {
+            const imgUrl = `${item.url}${item.url.includes('?') ? '&' : '?'}token=${getToken()}`;
             return (
               <div key={i} className="my-2">
-                <a href={item.url} target="_blank" rel="noopener noreferrer" className="inline-block rounded-lg overflow-hidden border border-border hover:border-accent/50 transition-colors">
-                  <img src={item.url} alt={item.filename} className="max-w-[300px] max-h-[300px] object-contain" />
+                <a href={imgUrl} target="_blank" rel="noopener noreferrer" className="inline-block rounded-lg overflow-hidden border border-border hover:border-accent/50 transition-colors">
+                  <img src={imgUrl} alt={item.filename} className="max-w-[300px] max-h-[300px] object-contain" />
                 </a>
               </div>
             );
+          }
           case 'file':
             return (
               <div key={i} className="my-2">

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
-import { Send, Square, X, Plus, Trash2, Sparkles, HelpCircle, StickyNote } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback, type KeyboardEvent, type ClipboardEvent, type DragEvent } from 'react';
+import { Send, Square, X, Plus, Trash2, Sparkles, HelpCircle, StickyNote, Paperclip, FileText, Loader2 } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 import type { QuoteAction, QuoteEntry } from '../../stores/chatStore';
+import { api } from '../../api/client';
 
 const ACTION_CONFIG: Record<QuoteAction, { icon: typeof Plus; label: string; color: string; placeholder: string }> = {
   add:      { icon: Plus,       label: 'Add',     color: 'var(--theme-accent)', placeholder: 'Instructions...' },
@@ -14,20 +15,35 @@ const ACTION_CONFIG: Record<QuoteAction, { icon: typeof Plus; label: string; col
 // Actions that auto-focus the instruction input (need user input)
 const FOCUS_ACTIONS = new Set<QuoteAction>(['add', 'question', 'note']);
 
+interface AttachmentFile {
+  id: string;
+  file: File;
+  preview?: string;
+  uploading: boolean;
+  uploadedId?: string;
+  uploadedMeta?: { filename: string; media_type: string; file_type: string };
+  error?: string;
+}
+
 export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
-  onSend: (message: string) => void;
+  onSend: (message: string, fileIds?: string[], imageBlocks?: Array<{ url: string; filename: string; media_type: string }>) => void;
   onStop: () => void;
   isStreaming: boolean;
   disabled?: boolean;
 }) {
   const [input, setInput] = useState('');
+  const [attachments, setAttachments] = useState<AttachmentFile[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lastInstructionRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragCountRef = useRef(0);
 
   const quotes = useChatStore(s => s.quotes);
   const removeQuote = useChatStore(s => s.removeQuote);
   const updateQuoteInstruction = useChatStore(s => s.updateQuoteInstruction);
   const clearQuotes = useChatStore(s => s.clearQuotes);
+  const activeSession = useChatStore(s => s.activeSession);
 
   const [prevQuoteCount, setPrevQuoteCount] = useState(0);
 
@@ -36,12 +52,62 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
     if (quotes.length > prevQuoteCount && quotes.length > 0) {
       const last = quotes[quotes.length - 1];
       if (FOCUS_ACTIONS.has(last.action)) {
-        // Focus the instruction input of the last quote
         setTimeout(() => lastInstructionRef.current?.focus(), 0);
       }
     }
     setPrevQuoteCount(quotes.length);
   }, [quotes.length, prevQuoteCount, quotes]);
+
+  // Cleanup object URLs on unmount
+  useEffect(() => {
+    return () => {
+      attachments.forEach(a => { if (a.preview) URL.revokeObjectURL(a.preview); });
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const addFiles = useCallback(async (files: File[]) => {
+    const newAttachments: AttachmentFile[] = files.map(file => ({
+      id: crypto.randomUUID(),
+      file,
+      preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
+      uploading: true,
+    }));
+
+    setAttachments(prev => [...prev, ...newAttachments]);
+
+    // Upload all files
+    try {
+      const result = await api.uploadFiles(files, activeSession);
+      setAttachments(prev => prev.map(a => {
+        const idx = newAttachments.findIndex(n => n.id === a.id);
+        if (idx >= 0 && result.files[idx]) {
+          const meta = result.files[idx];
+          return {
+            ...a,
+            uploading: false,
+            uploadedId: meta.id,
+            uploadedMeta: { filename: meta.filename, media_type: meta.media_type, file_type: meta.file_type },
+          };
+        }
+        return a;
+      }));
+    } catch (err) {
+      setAttachments(prev => prev.map(a => {
+        if (newAttachments.some(n => n.id === a.id)) {
+          return { ...a, uploading: false, error: String(err) };
+        }
+        return a;
+      }));
+    }
+  }, [activeSession]);
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments(prev => {
+      const removed = prev.find(a => a.id === id);
+      if (removed?.preview) URL.revokeObjectURL(removed.preview);
+      return prev.filter(a => a.id !== id);
+    });
+  }, []);
 
   const composeMessage = (): string => {
     const parts: string[] = [];
@@ -63,14 +129,29 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
     return parts.join('\n\n');
   };
 
-  const canSend = !disabled && !isStreaming && (input.trim() || quotes.length > 0);
+  const allUploaded = attachments.length === 0 || attachments.every(a => !a.uploading);
+  const hasContent = input.trim() || quotes.length > 0 || attachments.some(a => a.uploadedId);
+  const canSend = !disabled && !isStreaming && hasContent && allUploaded;
 
   const handleSend = () => {
     const message = composeMessage();
-    if (!message) return;
-    onSend(message);
+    if (!message && attachments.length === 0) return;
+
+    const fileIds = attachments.filter(a => a.uploadedId).map(a => a.uploadedId!);
+    const imageBlocks = attachments
+      .filter(a => a.uploadedId && a.uploadedMeta?.file_type === 'image')
+      .map(a => ({
+        url: `/api/files/uploads/${a.uploadedId}`,
+        filename: a.uploadedMeta!.filename,
+        media_type: a.uploadedMeta!.media_type,
+      }));
+
+    onSend(message, fileIds.length > 0 ? fileIds : undefined, imageBlocks.length > 0 ? imageBlocks : undefined);
     setInput('');
     clearQuotes();
+    // Clean up previews
+    attachments.forEach(a => { if (a.preview) URL.revokeObjectURL(a.preview); });
+    setAttachments([]);
     if (textareaRef.current) textareaRef.current.style.height = 'auto';
   };
 
@@ -78,6 +159,60 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (canSend) handleSend();
+    }
+  };
+
+  const handlePaste = (e: ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const files: File[] = [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.kind === 'file') {
+        const file = item.getAsFile();
+        if (file) files.push(file);
+      }
+    }
+
+    if (files.length > 0) {
+      e.preventDefault();
+      addFiles(files);
+    }
+  };
+
+  const handleDragEnter = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCountRef.current++;
+    if (e.dataTransfer.types.includes('Files')) {
+      setIsDragging(true);
+    }
+  };
+
+  const handleDragLeave = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCountRef.current--;
+    if (dragCountRef.current === 0) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCountRef.current = 0;
+    setIsDragging(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length > 0) {
+      addFiles(files);
     }
   };
 
@@ -90,7 +225,20 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
   };
 
   return (
-    <div className="border-t border-border-subtle bg-bg shrink-0">
+    <div
+      className="border-t border-border-subtle bg-bg shrink-0 relative"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {/* Drag overlay */}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 bg-accent/10 border-2 border-dashed border-accent rounded-lg flex items-center justify-center">
+          <span className="text-accent font-medium text-sm">Drop files here</span>
+        </div>
+      )}
+
       {/* Quote cards */}
       {quotes.length > 0 && (
         <div className="px-4 pt-3 pb-1">
@@ -109,15 +257,48 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
         </div>
       )}
 
+      {/* Attachment previews */}
+      {attachments.length > 0 && (
+        <div className="px-4 pt-3 pb-1">
+          <div className="max-w-3xl mx-auto flex gap-2 flex-wrap">
+            {attachments.map(a => (
+              <AttachmentPreview key={a.id} attachment={a} onRemove={() => removeAttachment(a.id)} />
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Main input */}
       <div className="px-4 py-3">
         <div className="max-w-3xl mx-auto flex gap-3 items-end">
+          {/* File attach button */}
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled || isStreaming}
+            className="w-10 h-10 text-text-muted hover:text-text-secondary rounded-xl flex items-center justify-center cursor-pointer transition-colors shrink-0 disabled:opacity-30"
+            title="Attach files"
+          >
+            <Paperclip size={18} />
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            onChange={(e) => {
+              const files = Array.from(e.target.files || []);
+              if (files.length > 0) addFiles(files);
+              e.target.value = '';
+            }}
+          />
+
           <textarea
             ref={textareaRef}
             value={input}
             onChange={(e) => { setInput(e.target.value); handleInput(); }}
             onKeyDown={handleKeyDown}
-            placeholder={quotes.length > 0 ? 'Add context (optional)...' : 'Send a message...'}
+            onPaste={handlePaste}
+            placeholder={quotes.length > 0 ? 'Add context (optional)...' : attachments.length > 0 ? 'Add a message (optional)...' : 'Send a message...'}
             rows={1}
             disabled={disabled}
             className="flex-1 px-4 py-3 bg-surface-raised border border-border rounded-xl text-[15px] text-text outline-none focus:border-accent/50 resize-none disabled:opacity-50 placeholder:text-text-faint"
@@ -141,6 +322,41 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+
+function AttachmentPreview({ attachment, onRemove }: { attachment: AttachmentFile; onRemove: () => void }) {
+  const isImage = attachment.file.type.startsWith('image/');
+
+  return (
+    <div className="relative group rounded-lg border border-border bg-surface overflow-hidden flex items-center gap-2">
+      {isImage && attachment.preview ? (
+        <img src={attachment.preview} alt={attachment.file.name} className="w-16 h-16 object-cover" />
+      ) : (
+        <div className="w-16 h-16 flex items-center justify-center bg-surface-raised">
+          <FileText size={20} className="text-text-muted" />
+        </div>
+      )}
+      <div className="pr-7 py-1.5 min-w-0">
+        <div className="text-[12px] text-text-secondary truncate max-w-[120px]">{attachment.file.name}</div>
+        <div className="text-[11px] text-text-muted">
+          {attachment.uploading ? (
+            <span className="flex items-center gap-1"><Loader2 size={10} className="animate-spin" /> Uploading...</span>
+          ) : attachment.error ? (
+            <span className="text-error">Failed</span>
+          ) : (
+            <span className="text-success">Ready</span>
+          )}
+        </div>
+      </div>
+      <button
+        onClick={onRemove}
+        className="absolute top-1 right-1 w-5 h-5 rounded-full bg-bg/80 text-text-muted hover:text-text flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+      >
+        <X size={12} />
+      </button>
     </div>
   );
 }

--- a/web/src/components/Chat/ToolCallBlock.tsx
+++ b/web/src/components/Chat/ToolCallBlock.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { ChevronRight, ChevronDown, Terminal, FileText, Search, Globe, Loader2 } from 'lucide-react';
+import { ChevronRight, ChevronDown, Terminal, FileText, Search, Globe, Loader2, Download } from 'lucide-react';
 import { getToolSummary } from '../../utils/toolSummary';
 import type { ToolCallBlockData } from '../../types/chat';
+import { getToken } from '../../api/client';
 import { EditToolBlock } from './tools/EditToolBlock';
 import { BashToolBlock } from './tools/BashToolBlock';
 import { FileToolBlock } from './tools/FileToolBlock';
@@ -51,6 +52,11 @@ export function ToolCallBlock({ block }: { block: ToolCallBlockData }) {
     return <HoAToolBlock block={block} />;
   }
 
+  // send_file — render as inline download card, no tool chrome
+  if (block.tool.includes('send_file')) {
+    return <SendFileBlock block={block} />;
+  }
+
   // Notification tools
   if (block.tool.includes('notify') || block.tool.includes('ask_user')) {
     return <NotificationToolBlock block={block} />;
@@ -75,6 +81,43 @@ export function ToolCallBlock({ block }: { block: ToolCallBlockData }) {
 
   // Generic fallback
   return <GenericToolBlock block={block} />;
+}
+
+function SendFileBlock({ block }: { block: ToolCallBlockData }) {
+  const filePath = block.input?.file_path as string || '';
+  const filename = filePath.split('/').pop() || 'file';
+  const downloadUrl = `/api/files/download?path=${encodeURIComponent(filePath)}`;
+  const isRunning = block.status === 'running';
+
+  if (isRunning) {
+    return (
+      <div className="my-1.5 inline-flex items-center gap-2 px-3 py-2 text-sm text-text-muted">
+        <Loader2 size={14} className="animate-spin" /> Sending file...
+      </div>
+    );
+  }
+
+  if (block.isError) {
+    return (
+      <div className="my-1.5 inline-flex items-center gap-2 px-3 py-2 text-sm text-error">
+        <FileText size={14} /> Failed to send file
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2">
+      <a
+        href={`${downloadUrl}&token=${getToken()}`}
+        download={filename}
+        className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-surface hover:bg-surface-hover transition-colors text-sm text-text-secondary"
+      >
+        <FileText size={14} />
+        <span className="truncate max-w-[200px]">{filename}</span>
+        <Download size={12} className="text-text-muted" />
+      </a>
+    </div>
+  );
 }
 
 function GenericToolBlock({ block }: { block: ToolCallBlockData }) {

--- a/web/src/components/Chat/UserMessage.tsx
+++ b/web/src/components/Chat/UserMessage.tsx
@@ -1,7 +1,11 @@
-import type { ChatMessage } from '../../types/chat';
+import type { ChatMessage, ImageBlockData, FileBlockData } from '../../types/chat';
+import { Download, FileText } from 'lucide-react';
+import { getToken } from '../../api/client';
 
 export function UserMessage({ message }: { message: ChatMessage }) {
   const text = message.blocks.find(b => b.type === 'text')?.content || '';
+  const images = message.blocks.filter(b => b.type === 'image') as ImageBlockData[];
+  const files = message.blocks.filter(b => b.type === 'file') as FileBlockData[];
 
   return (
     <div className="py-4 px-5">
@@ -10,7 +14,48 @@ export function UserMessage({ message }: { message: ChatMessage }) {
           <div className="w-7 h-7 rounded-full bg-surface-raised flex items-center justify-center text-xs font-medium text-text-muted shrink-0 mt-0.5">
             U
           </div>
-          <div className="whitespace-pre-wrap text-[15px] leading-relaxed pt-0.5">{text}</div>
+          <div className="min-w-0 flex-1">
+            {text && <div className="whitespace-pre-wrap text-[15px] leading-relaxed pt-0.5">{text}</div>}
+
+            {/* Attached images */}
+            {images.length > 0 && (
+              <div className="flex gap-2 flex-wrap mt-2">
+                {images.map((img, idx) => (
+                  <a
+                    key={idx}
+                    href={img.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-lg overflow-hidden border border-border hover:border-accent/50 transition-colors"
+                  >
+                    <img
+                      src={img.url}
+                      alt={img.filename}
+                      className="max-w-[200px] max-h-[200px] object-cover"
+                    />
+                  </a>
+                ))}
+              </div>
+            )}
+
+            {/* Attached non-image files */}
+            {files.length > 0 && (
+              <div className="flex gap-2 flex-wrap mt-2">
+                {files.map((file, idx) => (
+                  <a
+                    key={idx}
+                    href={`${file.url}${file.url.includes('?') ? '&' : '?'}token=${getToken()}`}
+                    download={file.filename}
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-surface hover:bg-surface-hover transition-colors text-sm text-text-secondary"
+                  >
+                    <FileText size={14} />
+                    <span className="truncate max-w-[150px]">{file.filename}</span>
+                    <Download size={12} className="text-text-muted" />
+                  </a>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/components/Chat/UserMessage.tsx
+++ b/web/src/components/Chat/UserMessage.tsx
@@ -2,6 +2,12 @@ import type { ChatMessage, ImageBlockData, FileBlockData } from '../../types/cha
 import { Download, FileText } from 'lucide-react';
 import { getToken } from '../../api/client';
 
+function authUrl(url: string): string {
+  const token = getToken();
+  if (!token) return url;
+  return `${url}${url.includes('?') ? '&' : '?'}token=${token}`;
+}
+
 export function UserMessage({ message }: { message: ChatMessage }) {
   const text = message.blocks.find(b => b.type === 'text')?.content || '';
   const images = message.blocks.filter(b => b.type === 'image') as ImageBlockData[];
@@ -23,13 +29,13 @@ export function UserMessage({ message }: { message: ChatMessage }) {
                 {images.map((img, idx) => (
                   <a
                     key={idx}
-                    href={img.url}
+                    href={authUrl(img.url)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="block rounded-lg overflow-hidden border border-border hover:border-accent/50 transition-colors"
                   >
                     <img
-                      src={img.url}
+                      src={authUrl(img.url)}
                       alt={img.filename}
                       className="max-w-[200px] max-h-[200px] object-cover"
                     />

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -428,15 +428,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
     set({ searchQuery: '', searchResults: null, searchLoading: false });
   },
 
-  sendMessage: (content: string) => {
+  sendMessage: (content: string, fileIds?: string[], imageBlocks?: Array<{ url: string; filename: string; media_type: string }>) => {
     const session = get().activeSession;
+    const blocks: import('../types/chat').MessageBlock[] = [];
+    if (content) blocks.push({ type: 'text', content });
+    if (imageBlocks) {
+      for (const img of imageBlocks) {
+        blocks.push({ type: 'image', url: img.url, filename: img.filename, media_type: img.media_type });
+      }
+    }
     set((state) => ({
-      messages: [...state.messages, { role: 'user', blocks: [{ type: 'text', content }] }],
+      messages: [...state.messages, { role: 'user', blocks }],
       streamingBlocks: [],
       isStreaming: true,
       agentStatus: { state: 'thinking' },
     }));
-    ws.sendMessage(content, session);
+    ws.sendMessage(content, session, fileIds);
   },
 
   stopSession: () => {

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -11,7 +11,7 @@ import { extractTodosFromMessages } from './helpers/bufferReplay';
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleAnswerInjected } from './handlers/sessionHandlers';
 import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress } from './handlers/panelHandlers';
-import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
+import { handleInteraction, handleFileChanged, handleFileAttachment, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
 
 export interface TodoItem {
   content: string;
@@ -482,6 +482,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Auxiliary
       case 'interaction':              return handleInteraction(msg, get, set);
       case 'file_changed':             return handleFileChanged(msg, get, set);
+      case 'file_attachment':          return handleFileAttachment(msg, get, set);
       case 'notification':             return handleNotification(msg, get, set);
       case 'notification_answered':    return handleNotificationAnswered(msg, get, set);
       case 'background_tasks_update':  return handleBackgroundTasksUpdate(msg, get, set);

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -11,7 +11,7 @@ import { extractTodosFromMessages } from './helpers/bufferReplay';
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleAnswerInjected } from './handlers/sessionHandlers';
 import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress } from './handlers/panelHandlers';
-import { handleInteraction, handleFileChanged, handleFileAttachment, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
+import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
 
 export interface TodoItem {
   content: string;
@@ -482,7 +482,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Auxiliary
       case 'interaction':              return handleInteraction(msg, get, set);
       case 'file_changed':             return handleFileChanged(msg, get, set);
-      case 'file_attachment':          return handleFileAttachment(msg, get, set);
       case 'notification':             return handleNotification(msg, get, set);
       case 'notification_answered':    return handleNotificationAnswered(msg, get, set);
       case 'background_tasks_update':  return handleBackgroundTasksUpdate(msg, get, set);

--- a/web/src/stores/handlers/auxiliaryHandlers.ts
+++ b/web/src/stores/handlers/auxiliaryHandlers.ts
@@ -54,6 +54,25 @@ export function handleFileChanged(
   });
 }
 
+export function handleFileAttachment(
+  msg: Extract<WSMessage, { type: 'file_attachment' }>,
+  _get: Get,
+  set: Set,
+): void {
+  // Inject a downloadable file block into the streaming assistant message
+  set(s => {
+    if (!s.isStreaming) return {};
+    const downloadUrl = `/api/files/download?path=${encodeURIComponent(msg.path)}`;
+    return {
+      streamingBlocks: [...s.streamingBlocks, {
+        type: 'file' as const,
+        url: downloadUrl,
+        filename: msg.filename,
+      }],
+    };
+  });
+}
+
 export function handleNotification(
   msg: Extract<WSMessage, { type: 'notification' }>,
   _get: Get,

--- a/web/src/stores/handlers/auxiliaryHandlers.ts
+++ b/web/src/stores/handlers/auxiliaryHandlers.ts
@@ -54,25 +54,6 @@ export function handleFileChanged(
   });
 }
 
-export function handleFileAttachment(
-  msg: Extract<WSMessage, { type: 'file_attachment' }>,
-  _get: Get,
-  set: Set,
-): void {
-  // Inject a downloadable file block into the streaming assistant message
-  set(s => {
-    if (!s.isStreaming) return {};
-    const downloadUrl = `/api/files/download?path=${encodeURIComponent(msg.path)}`;
-    return {
-      streamingBlocks: [...s.streamingBlocks, {
-        type: 'file' as const,
-        url: downloadUrl,
-        filename: msg.filename,
-      }],
-    };
-  });
-}
-
 export function handleNotification(
   msg: Extract<WSMessage, { type: 'notification' }>,
   _get: Get,

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -20,7 +20,21 @@ export interface ToolCallBlockData {
   hoaEvents?: Record<string, unknown>[];
 }
 
-export type MessageBlock = ThinkingBlockData | TextBlockData | ToolCallBlockData;
+export interface ImageBlockData {
+  type: 'image';
+  url: string;
+  filename: string;
+  media_type: string;
+}
+
+export interface FileBlockData {
+  type: 'file';
+  url: string;
+  filename: string;
+  size?: number;
+}
+
+export type MessageBlock = ThinkingBlockData | TextBlockData | ToolCallBlockData | ImageBlockData | FileBlockData;
 
 export interface ChatMessage {
   id?: number;

--- a/web/src/utils/hydrateMessage.ts
+++ b/web/src/utils/hydrateMessage.ts
@@ -2,10 +2,21 @@ import type { ChatMessage, MessageBlock } from '../types/chat';
 
 export function hydrateMessage(raw: any): ChatMessage {
   if (raw.role === 'user') {
+    const userBlocks: MessageBlock[] = [{ type: 'text', content: raw.content || '' }];
+    // Restore image/file blocks from DB (uploaded files)
+    if (raw.blocks && Array.isArray(raw.blocks)) {
+      for (const b of raw.blocks) {
+        if (b.type === 'image') {
+          userBlocks.push({ type: 'image', url: b.url || '', filename: b.filename || '', media_type: b.media_type || '' });
+        } else if (b.type === 'file') {
+          userBlocks.push({ type: 'file', url: b.url || '', filename: b.filename || '', size: b.size });
+        }
+      }
+    }
     return {
       id: raw.id,
       role: 'user',
-      blocks: [{ type: 'text', content: raw.content || '' }],
+      blocks: userBlocks,
       channel: raw.channel,
       created_at: raw.created_at,
     };
@@ -27,6 +38,12 @@ export function hydrateMessage(raw: any): ChatMessage {
           isError: b.is_error,
           status: 'complete' as const,
         };
+      }
+      if (b.type === 'image') {
+        return { type: 'image' as const, url: b.url || '', filename: b.filename || '', media_type: b.media_type || '' };
+      }
+      if (b.type === 'file') {
+        return { type: 'file' as const, url: b.url || '', filename: b.filename || '', size: b.size };
       }
       // Default: text
       return { type: 'text' as const, content: b.content || '' };


### PR DESCRIPTION
## Summary
- **Upload files/images via web chat**: paperclip button, drag-and-drop, clipboard paste (Ctrl+V) with preview strip and upload progress
- **Download workspace files**: authenticated `GET /api/files/download` endpoint with path traversal protection
- **`send_file` tool**: agent can send files as inline download cards in chat — persists across page reload
- **Auth fix**: JWT token accepted via query param for `<img src>` and `<a download>` that can't set headers

## Backend
- DB migration v022: `uploaded_files` table + `FileStore` mixin
- `POST /api/files/upload`: multipart upload → disk + DB index
- `GET /api/files/uploads/{id}`: serve uploaded files for chat history
- `GET /api/files/download`: serve workspace files with path traversal protection
- WebSocket `message` handler accepts `file_ids`, loads files and passes to `engine.run(images=...)` reusing the Telegram pipeline
- `engine.py` stores image refs in user message `blocks` column for persistence
- `send_file` session-scoped tool in `tools.py`
- Session deletion cleans up uploaded files from disk and DB

## Frontend
- `ImageBlockData` and `FileBlockData` types added to `MessageBlock` union
- `ChatInput`: paperclip file picker, drag-and-drop overlay, clipboard paste (`onPaste` handler)
- `UserMessage`: renders attached images as thumbnails, files as download cards
- `BlockRenderer`: handles `image` and `file` block types
- `ToolCallBlock`: `SendFileBlock` renders `send_file` tool calls as clean download cards (no generic tool chrome)
- `chatStore.sendMessage` extended with `fileIds` and `imageBlocks`
- `hydrateMessage`: restores image/file blocks from DB for chat history

## Test plan
- [x] All 326 tests pass
- [x] Frontend builds clean (tsc + vite)
- [x] Upload image via file picker → appears in chat as thumbnail → Claude receives and describes it
- [x] Paste screenshot (Ctrl+V) → same flow
- [x] `send_file` tool → download card appears inline → download works
- [x] Reload page → uploaded images and sent files still display
- [x] No secrets in diff (scanned)

> *Generated by [Nerve](https://github.com/pufit/nerve)*