### PR TITLE
Fix task_create retry loop from false-positive duplicate detection

### DIFF
--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -128,10 +128,13 @@ async def _find_duplicate_tasks(title: str, source_url: str = "") -> list[dict]:
         if url_matches:
             return url_matches
     # Fallback: fuzzy OR-based FTS search ranked by relevance.
-    # Uses OR semantics so "backend escalation #7104" matches
-    # "backend support escalation #7104 TTLDelete" even without
-    # every word being present.
-    return await _db.search_tasks_similar(query=title, limit=10)
+    # Uses OR semantics so partial word overlap still matches.
+    # rank_threshold filters out weak false-positives that share
+    # only common words, which would otherwise cause the model to
+    # see "duplicates" on every call and never use confirm_duplicate.
+    return await _db.search_tasks_similar(
+        query=title, limit=10, rank_threshold=-5.0,
+    )
 
 
 @tool(

--- a/nerve/db/tasks.py
+++ b/nerve/db/tasks.py
@@ -263,24 +263,38 @@ class TaskStore:
 
     async def search_tasks_similar(
         self, query: str, limit: int = 10,
+        rank_threshold: float | None = None,
     ) -> list[dict]:
         """Find tasks similar to query using OR semantics + FTS5 ranking.
 
         Unlike search_tasks (AND, strict), this uses OR (any word matches)
         and orders by BM25 relevance.  Designed for duplicate detection —
         searches all statuses including done.
+
+        Args:
+            rank_threshold: If set, only return matches with BM25 rank
+                below this value (more negative = better match).  Filters
+                out weak false-positives that share only generic words.
         """
         fts_query = self._build_fts_query(query, mode="or")
         if not fts_query:
             return []
 
-        async with self.db.execute(
+        sql = (
             "SELECT t.* FROM tasks t "
             "JOIN tasks_fts f ON f.task_id = REPLACE(t.id, '-', ' ') "
             "WHERE tasks_fts MATCH ? "
-            "ORDER BY f.rank LIMIT ?",
-            (fts_query, limit),
-        ) as cursor:
+        )
+        params: list = [fts_query]
+
+        if rank_threshold is not None:
+            sql += "AND f.rank < ? "
+            params.append(rank_threshold)
+
+        sql += "ORDER BY f.rank LIMIT ?"
+        params.append(limit)
+
+        async with self.db.execute(sql, tuple(params)) as cursor:
             return [dict(row) async for row in cursor]
 
     async def find_tasks_by_source_url(


### PR DESCRIPTION
## Problem

`task_create` was being called 5 times in a row for the same task during CI scan crons. The model kept retrying because FTS duplicate detection returned false-positive matches — tasks sharing common words (like "CI", "flaky", "PR") scored above the implicit threshold of 0, so every new task looked like a duplicate.

The model would see "similar tasks found", decide not to use `confirm_duplicate=true`, rephrase and retry — 5 times — until it finally gave up and forced creation.

## Fix

**`nerve/db/tasks.py`** — Added `rank_threshold` parameter to `search_tasks_similar()`. Only results with an FTS5 rank better (more negative) than the threshold are returned. Default is `None` (no filtering) for backward compat.

**`nerve/agent/tools.py`** — Passes `rank_threshold=-5.0` in `_find_duplicate_tasks()`, filtering out weak matches that share only generic words.

## Impact

Tasks with genuinely similar titles still get caught. Tasks that only share common filler words no longer trigger false duplicate warnings. The 5x retry loop is eliminated.