### PR TITLE
Fix inflated session costs from cumulative SDK cost tracking

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1752,19 +1752,32 @@ class AgentEngine:
             session_record = await self.db.get_session(session_id)
             meta = json.loads(session_record.get("metadata") or "{}") if session_record else {}
             meta["last_usage"] = usage_data
-            await self.db.update_session_metadata(session_id, meta)
 
             # Extract server_tool_use counts
             server_tool = last_usage.get("server_tool_use") or {}
             web_search = server_tool.get("web_search_requests", 0)
             web_fetch = server_tool.get("web_fetch_requests", 0)
 
-            # Use SDK-provided cost when available, otherwise estimate
+            # Calculate per-turn cost.
+            # NOTE: The SDK's total_cost_usd is *cumulative* across the
+            # entire SDK session, NOT per-invocation.  We track the last
+            # known cumulative value in session metadata so we can compute
+            # the delta for this turn.
             from nerve.db.usage import estimate_turn_cost
             sdk_cost = (result_meta or {}).get("total_cost_usd")
-            cost = sdk_cost if sdk_cost is not None else estimate_turn_cost(
-                last_usage, model=last_model,
-            )
+            current_session_cost = (
+                session_record.get("total_cost_usd", 0) if session_record else 0
+            ) or 0
+
+            if sdk_cost is not None:
+                prev_cumulative = meta.get("_sdk_cumulative_cost", 0) or 0
+                turn_cost = max(sdk_cost - prev_cumulative, 0)
+                meta["_sdk_cumulative_cost"] = sdk_cost
+            else:
+                turn_cost = estimate_turn_cost(last_usage, model=last_model)
+
+            # Save metadata (includes _sdk_cumulative_cost update)
+            await self.db.update_session_metadata(session_id, meta)
 
             # Persist per-turn usage to session_usage table
             await self.db.record_turn_usage(
@@ -1775,7 +1788,7 @@ class AgentEngine:
                 cache_read=last_usage.get("cache_read_input_tokens", 0),
                 max_context=max_context,
                 model=last_model,
-                cost_usd=cost,
+                cost_usd=turn_cost,
                 duration_ms=(result_meta or {}).get("duration_ms"),
                 duration_api_ms=(result_meta or {}).get("duration_api_ms"),
                 num_turns=num_turns,
@@ -1784,11 +1797,8 @@ class AgentEngine:
             )
 
             # Update total_cost_usd on the session
-            current_cost = (
-                session_record.get("total_cost_usd", 0) if session_record else 0
-            )
             await self.db.update_session_fields(session_id, {
-                "total_cost_usd": (current_cost or 0) + cost,
+                "total_cost_usd": current_session_cost + turn_cost,
             })
 
         await broadcaster.broadcast_done(

--- a/nerve/db/migrations/v024_fix_cumulative_cost.py
+++ b/nerve/db/migrations/v024_fix_cumulative_cost.py
@@ -1,0 +1,141 @@
+"""V24: Fix inflated session costs caused by cumulative SDK cost bug.
+
+The Claude Agent SDK's ``ResultMessage.total_cost_usd`` reports a
+*cumulative* session total, but engine.py was treating it as per-turn
+and adding it to the running session total on every invocation.  This
+caused ``session_usage.cost_usd`` to store cumulative snapshots
+instead of deltas, and ``sessions.total_cost_usd`` to be the sum of
+those snapshots (massively inflated).
+
+Fix:
+1. Recalculate every ``session_usage.cost_usd`` from its token counts
+   using model-specific pricing.
+2. Recompute every ``sessions.total_cost_usd`` as the SUM of the now-
+   correct per-turn costs.
+3. Seed ``_sdk_cumulative_cost`` in session metadata for sessions that
+   may be resumed, so the engine computes correct deltas on the first
+   turn after the upgrade.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Model pricing (per 1M tokens, USD): (input, output, cache_read, cache_write)
+# Kept in sync with nerve/db/usage.py MODEL_PRICING.
+_PRICING = {
+    "opus-4-6":  (5, 25, 0.50, 6.25),
+    "opus-4-5":  (5, 25, 0.50, 6.25),
+    "opus-4-1":  (15, 75, 1.50, 18.75),
+    "opus-4":    (15, 75, 1.50, 18.75),
+    "sonnet-4":  (3, 15, 0.30, 3.75),
+    "haiku-4-5": (1, 5, 0.10, 1.25),
+    "haiku-3-5": (0.8, 4, 0.08, 1.0),
+}
+_DEFAULT = (5, 25, 0.50, 6.25)  # Opus 4.6 fallback
+
+
+def _pricing_for(model: str | None) -> tuple[float, float, float, float]:
+    if not model:
+        return _DEFAULT
+    m = model.lower()
+    for key, p in _PRICING.items():
+        if key in m:
+            return p
+    return _DEFAULT
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # -- Step 1: recalculate session_usage.cost_usd from token counts ------
+    #
+    # We can't just do a single UPDATE with CASE on model because SQLite
+    # doesn't easily support substring matching in CASE.  Instead, fetch
+    # all distinct models, resolve pricing once per model, then bulk-update.
+
+    async with db.execute(
+        "SELECT DISTINCT model FROM session_usage"
+    ) as cur:
+        models = [row[0] for row in await cur.fetchall()]
+
+    for model in models:
+        p_in, p_out, p_cr, p_cw = _pricing_for(model)
+        if model is None:
+            where = "model IS NULL"
+            params: tuple = ()
+        else:
+            where = "model = ?"
+            params = (model,)
+
+        await db.execute(
+            f"""
+            UPDATE session_usage
+            SET cost_usd = ROUND(
+                input_tokens              * {p_in}  / 1000000.0
+              + output_tokens             * {p_out} / 1000000.0
+              + cache_read_input_tokens   * {p_cr}  / 1000000.0
+              + cache_creation_input_tokens * {p_cw} / 1000000.0,
+              6
+            )
+            WHERE {where}
+            """,
+            params,
+        )
+
+    # -- Step 2: recompute sessions.total_cost_usd from fixed per-turn costs
+    await db.execute(
+        """
+        UPDATE sessions
+        SET total_cost_usd = COALESCE(
+            (SELECT SUM(cost_usd) FROM session_usage
+             WHERE session_usage.session_id = sessions.id),
+            0
+        )
+        """
+    )
+
+    # -- Step 3: seed _sdk_cumulative_cost in metadata for resumable sessions
+    #
+    # The engine now tracks the SDK's cumulative total_cost_usd in session
+    # metadata as ``_sdk_cumulative_cost`` to compute per-turn deltas.
+    # For sessions that existed before this fix and may be resumed after
+    # upgrade, we seed the value from the last (highest) cumulative
+    # cost_usd snapshot that was stored by the old buggy code.
+    #
+    # We read the *original* max cost_usd BEFORE step 1 would have
+    # overwritten it — but step 1 already ran, so we approximate the
+    # SDK cumulative as the corrected session total.  After restart the
+    # SDK session is re-created fresh anyway (cumulative starts at 0),
+    # so this seed only matters for hot-resumed sessions (rare).
+    # Setting it to 0 is safest: on restart the SDK resets, and the
+    # first delta will be correct.  For the uncommon hot-resume case,
+    # there may be a one-time over-count on the first turn, but
+    # subsequent turns will be accurate.
+
+    async with db.execute(
+        "SELECT id, metadata FROM sessions WHERE sdk_session_id IS NOT NULL"
+    ) as cur:
+        rows = await cur.fetchall()
+
+    for sid, raw_meta in rows:
+        meta = json.loads(raw_meta) if raw_meta else {}
+        if "_sdk_cumulative_cost" not in meta:
+            # Seed to 0 — safest default since restart creates fresh SDK
+            # sessions.  The engine's max(delta, 0) clamp prevents negative
+            # costs if the SDK cumulative is lower than expected.
+            meta["_sdk_cumulative_cost"] = 0
+            await db.execute(
+                "UPDATE sessions SET metadata = ? WHERE id = ?",
+                (json.dumps(meta, default=str), sid),
+            )
+
+    await db.commit()
+    logger.info(
+        "V24 migration: recalculated session_usage.cost_usd from token "
+        "counts, recomputed sessions.total_cost_usd, and seeded "
+        "_sdk_cumulative_cost in session metadata"
+    )


### PR DESCRIPTION
## Summary

- The Claude Agent SDK's `ResultMessage.total_cost_usd` is **cumulative** across the entire SDK session, but the engine was treating it as per-turn and adding it to the running session total on every invocation
- This caused `session_usage.cost_usd` to store cumulative snapshots instead of deltas, and `sessions.total_cost_usd` to be the sum of those snapshots — massively inflated (e.g. ~$73 actual → $1,128 reported)
- All aggregation queries (`get_usage_by_period`, `get_usage_by_model`, etc.) were also affected since they `SUM(cost_usd)`

## Fix

**Engine (`engine.py`):** Track the last SDK cumulative value in session metadata (`_sdk_cumulative_cost`) and compute the per-turn delta via `max(sdk_cost - prev_cumulative, 0)`. The fallback `estimate_turn_cost()` path (used when SDK cost is unavailable) is unchanged since it already returns per-turn values.

**Migration v024:** Auto-applies on upgrade. Recalculates all `session_usage.cost_usd` from token counts using model-specific pricing, recomputes `sessions.total_cost_usd` as the SUM of corrected per-turn costs, and seeds `_sdk_cumulative_cost = 0` in metadata for resumable sessions.

## Test plan

- [x] All 344 existing tests pass
- [x] Verified migration produces correct costs by dry-running the recalculation query against live data
- [x] Confirmed per-turn token-based estimates are within ~3% of SDK-reported deltas
- [ ] After deploy: verify session costs in the diagnostics page show reasonable values

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*