### PR TITLE
Disable --thinking-display on Bedrock to fix session hang

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -771,7 +771,13 @@ class AgentEngine:
         # thinking blocks with only a signature (for multi-turn continuity).
         # Force "summarized" so the UI actually has thinking text to render.
         # The CLI ignores this flag when thinking is disabled.
-        if thinking_config and thinking_config.get("type") != "disabled":
+        # NOTE: --thinking-display hangs on Bedrock (multi-turn after ToolSearch
+        # never returns). Disabled for Bedrock until the provider bug is fixed.
+        if (
+            thinking_config
+            and thinking_config.get("type") != "disabled"
+            and not self.config.provider.is_bedrock
+        ):
             extra_args["thinking-display"] = "summarized"
 
         return ClaudeAgentOptions(


### PR DESCRIPTION
## Summary
- `--thinking-display summarized` causes Bedrock to hang on multi-turn conversations after ToolSearch — the second API call (with newly loaded deferred tools) never returns
- Skip the flag for Bedrock provider until the upstream bug is fixed
- Non-Bedrock (direct Anthropic API) continues to use `--thinking-display` as before

## Test plan
- [x] Verified: sessions hang with `--thinking-display` on Bedrock + Opus 4.7
- [x] Verified: sessions complete normally without it
- [x] Cron jobs (scan, task-worker, pr-monitor) all completing after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)