### PR TITLE
Cache notification messages for reaction context

### DIFF
--- a/nerve/notifications/service.py
+++ b/nerve/notifications/service.py
@@ -308,10 +308,17 @@ class NotificationService:
         logger.warning("No telegram_chat_id configured for notifications")
         return None
 
-    def _get_telegram_bot(self):
-        """Get the Telegram bot instance, or None if unavailable."""
+    def _get_telegram_channel(self):
+        """Get the TelegramChannel instance, or None if unavailable."""
         channel = self.engine.router.get_channel("telegram")
         if not channel or not hasattr(channel, '_app') or channel._app is None:
+            return None
+        return channel
+
+    def _get_telegram_bot(self):
+        """Get the Telegram bot instance, or None if unavailable."""
+        channel = self._get_telegram_channel()
+        if not channel:
             return None
         return channel._app.bot
 
@@ -348,12 +355,20 @@ class NotificationService:
             text += f"\n\nSession: {session_id}"
 
         if notif_type == "question" and options:
-            return await self._send_telegram_inline(
+            msg_id = await self._send_telegram_inline(
                 chat_id, notification_id, text, options, silent=silent,
             )
         else:
             msg = await self._send_telegram_html(bot, chat_id, text, silent=silent)
-            return str(msg.message_id)
+            msg_id = str(msg.message_id)
+
+        # Cache for reaction context lookups
+        if msg_id:
+            channel = self._get_telegram_channel()
+            if channel:
+                channel._cache_message(int(msg_id), chat_id, text)
+
+        return msg_id
 
     @staticmethod
     async def _send_telegram_html(


### PR DESCRIPTION
## Summary
- Notifications sent via `NotificationService._deliver_telegram()` bypassed `TelegramChannel.send()` and went directly through `bot.send_message()`, so they were never stored in `_message_cache`
- When reacting to a notification, the reaction handler couldn't find the original text — showed `[Reaction: 👎]` without context instead of `[Reaction: 👎 on message: "..."]`
- Added `_get_telegram_channel()` helper and a `_cache_message()` call after sending, covering both regular and inline (question) notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)