### PR TITLE
Pass proxy base URL to SDK environment

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -823,6 +823,10 @@ class AgentEngine:
             api_key = self.config.effective_api_key
             if api_key:
                 env["ANTHROPIC_API_KEY"] = api_key
+            if self.config.proxy.enabled:
+                env["ANTHROPIC_BASE_URL"] = (
+                    f"http://{self.config.proxy.host}:{self.config.proxy.port}"
+                )
         return env
 
     def _build_mcp_servers(self, session_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

When proxy is enabled in config, the SDK subprocess doesn't know about it — API calls go directly to Anthropic, bypassing the proxy.

This adds `ANTHROPIC_BASE_URL` to the subprocess environment in `_build_env()`, pointing it at the configured proxy host/port so all SDK API calls are routed through the proxy.

## Changes

- `nerve/agent/engine.py`: set `ANTHROPIC_BASE_URL` env var when `config.proxy.enabled` is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)