### PR TITLE
Cap adaptive-thinking effort per model's supported levels

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -953,37 +953,38 @@ class AgentEngine:
             logger.warning("Unknown thinking config '%s', using adaptive", value)
             return {"type": "adaptive"}
 
-    # Adaptive-thinking effort levels accepted per Claude model.
-    # Sonnet/Haiku tiers top out at "high"; only Opus advertises xhigh/max.
-    # Kept in sync with Anthropic model capabilities and the CLIProxyAPI
-    # registry (internal/registry/models/models.json).
+    # Effort levels accepted per Claude model — substring-matched against the
+    # full model name so dated aliases (e.g. "claude-opus-4-7-20260416") resolve.
+    # Ordered most-specific to least-specific; first match wins. Mirrors the
+    # pattern used by MODEL_PRICING in nerve/db/usage.py.
     _MODEL_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
-        "claude-opus-4-7": ("low", "medium", "high", "xhigh", "max"),
-        "claude-opus-4-6": ("low", "medium", "high", "max"),
-        "claude-sonnet-4-6": ("low", "medium", "high"),
+        "opus-4-7":   ("low", "medium", "high", "xhigh", "max"),
+        "opus-4-6":   ("low", "medium", "high", "max"),
+        "sonnet-4-6": ("low", "medium", "high"),
     }
     _EFFORT_RANK: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
     @staticmethod
-    def _effective_effort(value: str, model: str | None) -> str | None:
-        """Return the effort level to send to the SDK, capped to what ``model`` supports.
-
-        Global ``agent.effort`` (e.g. ``"max"``) is shared across the main agent
-        and auxiliary models (``cron_model``, memU recall/memorize). Tiers below
-        Opus cap at ``"high"``, so forwarding ``max`` unmodified triggers a 400
-        from the upstream (or from CLIProxyAPI's tier validation). This caps
-        to the highest level the target model advertises.
-        """
+    def _effective_effort(value: str, model: str | None = None) -> str | None:
+        """Return ``value`` capped to the highest effort level ``model`` supports."""
         if value not in AgentEngine._EFFORT_RANK:
             return None
-        allowed = AgentEngine._MODEL_EFFORT_LEVELS.get(model or "")
-        if not allowed:
-            return value
-        if value in allowed:
+        allowed: tuple[str, ...] | None = None
+        if model:
+            m = model.lower()
+            for key, levels in AgentEngine._MODEL_EFFORT_LEVELS.items():
+                if key in m:
+                    allowed = levels
+                    break
+        if not allowed or value in allowed:
             return value
         requested_rank = AgentEngine._EFFORT_RANK.index(value)
         for level in reversed(AgentEngine._EFFORT_RANK[: requested_rank + 1]):
             if level in allowed:
+                logger.debug(
+                    "Capped effort %r to %r for model %r (model caps at %r)",
+                    value, level, model, allowed[-1],
+                )
                 return level
         return None
 

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -739,10 +739,9 @@ class AgentEngine:
             self.config.agent.thinking,
             model or self.config.agent.model,
         )
-        effort = (
-            self.config.agent.effort
-            if self.config.agent.effort in ("low", "medium", "high", "xhigh", "max")
-            else None
+        effort = self._effective_effort(
+            self.config.agent.effort,
+            model or self.config.agent.model,
         )
         betas = (
             ["context-1m-2025-08-07"] if self.config.agent.context_1m else []
@@ -953,6 +952,40 @@ class AgentEngine:
         except ValueError:
             logger.warning("Unknown thinking config '%s', using adaptive", value)
             return {"type": "adaptive"}
+
+    # Adaptive-thinking effort levels accepted per Claude model.
+    # Sonnet/Haiku tiers top out at "high"; only Opus advertises xhigh/max.
+    # Kept in sync with Anthropic model capabilities and the CLIProxyAPI
+    # registry (internal/registry/models/models.json).
+    _MODEL_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
+        "claude-opus-4-7": ("low", "medium", "high", "xhigh", "max"),
+        "claude-opus-4-6": ("low", "medium", "high", "max"),
+        "claude-sonnet-4-6": ("low", "medium", "high"),
+    }
+    _EFFORT_RANK: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
+
+    @staticmethod
+    def _effective_effort(value: str, model: str | None) -> str | None:
+        """Return the effort level to send to the SDK, capped to what ``model`` supports.
+
+        Global ``agent.effort`` (e.g. ``"max"``) is shared across the main agent
+        and auxiliary models (``cron_model``, memU recall/memorize). Tiers below
+        Opus cap at ``"high"``, so forwarding ``max`` unmodified triggers a 400
+        from the upstream (or from CLIProxyAPI's tier validation). This caps
+        to the highest level the target model advertises.
+        """
+        if value not in AgentEngine._EFFORT_RANK:
+            return None
+        allowed = AgentEngine._MODEL_EFFORT_LEVELS.get(model or "")
+        if not allowed:
+            return value
+        if value in allowed:
+            return value
+        requested_rank = AgentEngine._EFFORT_RANK.index(value)
+        for level in reversed(AgentEngine._EFFORT_RANK[: requested_rank + 1]):
+            if level in allowed:
+                return level
+        return None
 
     # ------------------------------------------------------------------ #
     #  SDK client lifecycle                                                #

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,43 @@
+"""Tests for nerve.agent.engine — pure helpers (no SDK state)."""
+
+import pytest
+
+from nerve.agent.engine import AgentEngine
+
+
+@pytest.mark.parametrize(
+    "value, model, expected",
+    [
+        # Opus 4.7 supports every level
+        ("max",    "claude-opus-4-7",           "max"),
+        ("xhigh",  "claude-opus-4-7",           "xhigh"),
+        ("high",   "claude-opus-4-7",           "high"),
+        # Dated alias resolves via substring match
+        ("max",    "claude-opus-4-7-20260416",  "max"),
+        # Opus 4.6: max OK, xhigh caps to high (not registered)
+        ("max",    "claude-opus-4-6",           "max"),
+        ("xhigh",  "claude-opus-4-6",           "high"),
+        # Sonnet 4.6 tops out at high
+        ("max",    "claude-sonnet-4-6",         "high"),
+        ("xhigh",  "claude-sonnet-4-6",         "high"),
+        ("high",   "claude-sonnet-4-6",         "high"),
+        ("medium", "claude-sonnet-4-6",         "medium"),
+        ("low",    "claude-sonnet-4-6",         "low"),
+        # Unknown models (including Haiku which uses budget_tokens, not levels)
+        # pass through unchanged — capping is a no-op for non-level-based thinking
+        ("max",    "claude-haiku-4-5-20251001", "max"),
+        ("max",    "some-future-model",         "max"),
+        ("max",    None,                        "max"),
+        ("max",    "",                          "max"),
+        # Invalid effort string → None (same as the pre-existing behaviour)
+        ("invalid", "claude-opus-4-7",          None),
+        ("",        "claude-sonnet-4-6",        None),
+    ],
+)
+def test_effective_effort(value, model, expected):
+    assert AgentEngine._effective_effort(value, model) == expected
+
+
+def test_effective_effort_model_default_none():
+    # Signature symmetry with _parse_thinking_config
+    assert AgentEngine._effective_effort("max") == "max"


### PR DESCRIPTION
## Problem

Global `agent.effort` (default `"max"`) shared across main agent + `cron_model` / `memory.recall_model` / `memory.memorize_model`. Auxiliary models default to `claude-sonnet-4-6
`. Sonnet no advertise `max`.

Forward `max` to Sonnet → 400. CLIProxyAPI error:

```
thinking: validation failed | provider=claude model=claude-sonnet-4-6
  error=level "max" not supported, valid levels: low, medium, high
```

(validator: `internal/thinking/validate.go:125`; source: `internal/registry/models/models.json`)

Every cron source job + every memU recall/memorize call on `proxy.enabled: true` → 400. Stall inbox-processor + background work.

Same shape on Opus 4.6 + `xhigh` (4.6 supports `max` not `xhigh`). Any config where `cron_model` / memU model tier below main `model`.

### Behavior

| `effort` | model | result |
|---|---|---|
| `max` | `claude-opus-4-7` | `max` |
| `max` | `claude-opus-4-6` | `max` |
| `max` | `claude-sonnet-4-6` | `high` **← fix** |
| `xhigh` | `claude-opus-4-7` | `xhigh` |
| `xhigh` | `claude-opus-4-6` | `high` |
| `xhigh` | `claude-sonnet-4-6` | `high` |
| `low`/`medium`/`high` | any | unchanged |
| any | unknown / `None` | unchanged (backward compatible) |
| invalid | any | `None` (pre-PR behavior) |

### Why table not proxy query

1. `GET /v1/models` at startup → couple to CLIProxyAPI, break direct-API users, need cache/refresh.
2. Retry-on-400 downgrade → complex, latency cost, error-path only.

Static table: simple, testable, explicit. Bump per new model. Few level-based Claude models today; bump = 1-line PR.

Entries track Anthropic capabilities + CLIProxyAPI `internal/registry/models/models.json`. Unknown models (Haiku, legacy Sonnet/Opus on budget-tokens) pass through. Fully backwa
rd compatible.

## Verification

Unit tests: 17 cases — opus 4.7, opus 4.6, sonnet 4.6, haiku, dated alias, unknown, `None`, empty, invalid. All pass.

Live proxy mode (`proxy.enabled: true`), before:
- `cron:inbox-processor` → 400 `level "max" not supported` every tick
- Telegram Bot admin reply → same 400 on memU recall/memorize

After:
- Opus 4.7 main agent: `effort: max` (verified via subprocess env / request inspection).
- Sonnet 4.6 auxiliary: `effort: high`. Proxy 200. Requests succeed.