### PR TITLE
fix(channels): deliver send_file via Telegram and harden cross-channel dispatch

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -240,9 +240,17 @@ class AgentEngine:
         self._skill_manager: SkillManager | None = None
         self._memorize_lock = asyncio.Lock()
         self._session_locks: dict[str, asyncio.Lock] = {}
+        # Per-session active channel — set on run() entry, cleared on exit.
+        # Read by session-scoped tools (send_file) to avoid dispatching via
+        # stale router context from a prior inbound channel.
+        self._active_channel: dict[str, str] = {}
         self._router = None  # ChannelRouter — lazy-initialized via .router property
         self._mcp_servers_cache = list(config.mcp_servers)  # hot-reloadable
         self._claude_code_plugins: list[dict[str, str]] = []  # plugin dirs
+
+    def get_active_channel(self, session_id: str) -> str | None:
+        """Return the channel name currently driving ``session_id`` (or None)."""
+        return self._active_channel.get(session_id)
 
     async def initialize(self) -> None:
         """Initialize the agent engine — set up tools and main session."""
@@ -1302,6 +1310,8 @@ class AgentEngine:
                 # mark_running below.
                 self.sessions.pop_stop_request(session_id)
                 self.sessions.mark_running(session_id)
+                if channel is not None:
+                    self._active_channel[session_id] = channel
                 # Notify all connected clients that this session started running
                 await broadcaster.broadcast("__global__", {
                     "type": "session_running",
@@ -1316,6 +1326,7 @@ class AgentEngine:
                     )
                 finally:
                     self.sessions.mark_not_running(session_id)
+                    self._active_channel.pop(session_id, None)
                     broadcaster.stop_buffering(session_id)
                     # Notify all connected clients that this session stopped
                     await broadcaster.broadcast("__global__", {

--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -1742,6 +1742,55 @@ async def _send_sticker_impl(args: dict, session_id: str) -> dict:
         return {"content": [{"type": "text", "text": f"Failed to send sticker: {e}"}]}
 
 
+async def _send_file_impl(args: dict, session_id: str) -> dict:
+    """Core implementation for the send_file tool.
+
+    Delivers the file via the channel router (Telegram → send_document, etc.).
+    Falls back to a web-panel message when the bound channel cannot deliver
+    files natively. The web frontend renders the persisted tool_call block
+    as a SendFileBlock card regardless of native delivery.
+    """
+    file_path = args.get("file_path", "")
+    if not file_path:
+        return {"content": [{"type": "text", "text": "Error: file_path is required."}]}
+
+    resolved = Path(file_path).resolve()
+    if not resolved.is_file():
+        return {"content": [{"type": "text", "text": f"Error: file not found: {file_path}"}]}
+
+    # Security: workspace containment via is_relative_to (path-aware) —
+    # a string prefix check would let sibling-prefix paths slip past
+    # (e.g. workspace /srv/ws would accept /srv/ws-evil/secret.txt).
+    if _workspace:
+        try:
+            resolved.relative_to(_workspace.resolve())
+        except ValueError:
+            return {"content": [{"type": "text", "text": "Error: file must be within the workspace."}]}
+
+    filename = resolved.name
+    file_size = resolved.stat().st_size
+
+    delivered = False
+    if _engine is not None:
+        try:
+            # Pass active channel — router uses it to refuse stale-context dispatch.
+            active_channel = _engine.get_active_channel(session_id)
+            delivered = await _engine.router.send_file(
+                session_id, str(resolved), channel=active_channel,
+            )
+        except Exception as e:
+            logger.error("send_file dispatch failed: %s", e)
+            delivered = False
+
+    if delivered:
+        return {"content": [{"type": "text", "text": f"Sent file: {filename} ({file_size:,} bytes)"}]}
+
+    return {"content": [{"type": "text", "text": (
+        f"File ready: {filename} ({file_size:,} bytes). "
+        "Native delivery not available on this channel — open the web panel to download."
+    )}]}
+
+
 _nerve_asgi_app = None  # Cached mini FastAPI app for in-process API calls
 
 
@@ -2188,29 +2237,12 @@ def create_session_mcp_server(session_id: str):
     @tool(
         "send_file",
         "Send a file to the user as a downloadable attachment in the chat. "
-        "The file will appear inline as a download card. Use this when the user asks "
-        "you to share, export, or send them a file.",
+        "On Telegram the file is delivered as a document; on the web panel it appears as an inline "
+        "download card. Use this when the user asks you to share, export, or send them a file.",
         _SEND_FILE_SCHEMA,
     )
     async def session_send_file(args: dict) -> dict:
-        file_path = args.get("file_path", "")
-        if not file_path:
-            return {"content": [{"type": "text", "text": "Error: file_path is required."}]}
-
-        resolved = Path(file_path).resolve()
-        if not resolved.exists() or not resolved.is_file():
-            return {"content": [{"type": "text", "text": f"Error: file not found: {file_path}"}]}
-
-        # Security: must be within workspace
-        if _workspace and not str(resolved).startswith(str(_workspace.resolve())):
-            return {"content": [{"type": "text", "text": "Error: file must be within the workspace."}]}
-
-        filename = resolved.name
-        file_size = resolved.stat().st_size
-
-        # The tool_call block persists in DB — frontend renders it
-        # as an inline download card via SendFileBlock.
-        return {"content": [{"type": "text", "text": f"Sent file: {filename} ({file_size:,} bytes)"}]}
+        return await _send_file_impl(args, session_id)
 
     # Shared tools (don't need session context) + session-scoped tools
     shared_tools = [t for t in ALL_TOOLS if t.name not in ("notify", "ask_user", "react", "send_sticker", "plan_propose")]

--- a/nerve/channels/base.py
+++ b/nerve/channels/base.py
@@ -28,6 +28,7 @@ class ChannelCapability(Flag):
     INTERACTIVE = auto()        # Can route interactive tool responses back (AskUserQuestion, etc.)
     TYPING_INDICATOR = auto()   # Can show "typing…" status
     REACTIONS = auto()          # Can set emoji reactions on messages
+    SEND_FILES = auto()         # Can deliver files / documents as attachments
 
 
 @dataclass(frozen=True)
@@ -182,3 +183,17 @@ class BaseChannel(abc.ABC):
         For Telegram, this could render as inline keyboard buttons.
         For Web, this is a JSON event over WebSocket.
         """
+
+    # ------------------------------------------------------------------ #
+    #  Optional: file delivery                                              #
+    #  Only called if channel declares ChannelCapability.SEND_FILES.        #
+    # ------------------------------------------------------------------ #
+
+    async def send_file(self, target: str, file_path: str) -> bool:
+        """Deliver a file to a target as a downloadable attachment.
+
+        Returns True on successful delivery, False if the channel
+        cannot deliver the file (size limits, missing transport, etc.).
+        Only called if channel declares SEND_FILES capability.
+        """
+        return False

--- a/nerve/channels/router.py
+++ b/nerve/channels/router.py
@@ -322,6 +322,42 @@ class ChannelRouter:
         return True
 
     # ------------------------------------------------------------------ #
+    #  File delivery                                                        #
+    # ------------------------------------------------------------------ #
+
+    async def send_file(
+        self,
+        session_id: str,
+        file_path: str,
+        channel: str | None = None,
+    ) -> bool:
+        """Deliver a file via the channel passed by the caller.
+
+        Refuses delivery if ``channel`` is None — falling back to
+        ``_message_context`` would leak files from cron/planner runs
+        to whatever chat last touched the session (e.g. a stale
+        Telegram inbound from hours earlier).
+
+        ``_message_context`` is consulted only to look up the target
+        identifier when its cached channel matches the requested
+        ``channel``; otherwise the target is empty. Channels needing
+        a real target (Telegram) fail safely inside their own
+        ``send_file``; broadcast channels (web) succeed regardless.
+
+        Returns True on successful delivery, False otherwise.
+        """
+        if channel is None:
+            return False
+
+        chan_obj = self._channels.get(channel)
+        if not chan_obj or ChannelCapability.SEND_FILES not in chan_obj.capabilities:
+            return False
+
+        ctx = self._message_context.get(session_id)
+        target = ctx["target"] if ctx and ctx.get("channel_name") == channel else ""
+        return await chan_obj.send_file(target, file_path)
+
+    # ------------------------------------------------------------------ #
     #  Interactive tool response routing                                    #
     # ------------------------------------------------------------------ #
 

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import time
 import zipfile
+from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
 from telegram import Update
@@ -246,6 +247,7 @@ class TelegramChannel(BaseChannel):
             | ChannelCapability.MARKDOWN
             | ChannelCapability.TYPING_INDICATOR
             | ChannelCapability.REACTIONS
+            | ChannelCapability.SEND_FILES
         )
         if self.config.telegram.stream_mode == "partial":
             caps |= ChannelCapability.STREAMING
@@ -610,6 +612,32 @@ class TelegramChannel(BaseChannel):
             chat_id=int(target),
             sticker=sticker,
         )
+
+    # ------------------------------------------------------------------ #
+    #  Files: deliver a workspace file as a Telegram document             #
+    # ------------------------------------------------------------------ #
+
+    async def send_file(self, target: str, file_path: str) -> bool:
+        """Deliver a file to a Telegram chat as a document attachment.
+
+        Size limits are enforced by the Telegram API itself (50 MiB on
+        api.telegram.org, up to 2 GiB on self-hosted Bot API servers).
+        """
+        if self._app is None:
+            return False
+        path = Path(file_path)
+        if not path.is_file():
+            return False
+        try:
+            await self._app.bot.send_document(
+                chat_id=int(target),
+                document=path,
+                filename=path.name,
+            )
+            return True
+        except Exception as e:
+            logger.warning("send_file: send_document failed for %s: %s", target, e)
+            return False
 
     # ------------------------------------------------------------------ #
     #  Message cache (for reaction context)                                #

--- a/nerve/channels/web.py
+++ b/nerve/channels/web.py
@@ -36,6 +36,7 @@ class WebChannel(BaseChannel):
             | ChannelCapability.STREAMING
             | ChannelCapability.MARKDOWN
             | ChannelCapability.INTERACTIVE
+            | ChannelCapability.SEND_FILES
         )
 
     @property
@@ -82,3 +83,13 @@ class WebChannel(BaseChannel):
             session_id, interaction_type, interaction_id,
             tool_name, tool_input,
         )
+
+    async def send_file(self, target: str, file_path: str) -> bool:
+        """Web file delivery is handled by the persisted tool_call block.
+
+        The frontend renders a SendFileBlock card from the stored
+        ``send_file`` tool call (input + result). Returning True signals
+        that no fallback message is needed — the file is reachable via
+        the inline download card in the web UI.
+        """
+        return True

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -1,0 +1,564 @@
+"""Tests for the send_file dispatch path.
+
+Covers:
+- ChannelRouter.send_file fan-out: missing context, missing capability,
+  successful dispatch, and explicit-channel routing (cross-channel
+  leakage prevention).
+- TelegramChannel.send_file: missing file, oversized file, success path.
+- _send_file_impl in agent.tools: workspace scope, engine-unavailable
+  fallback, native-delivered success message, fallback message when
+  the channel cannot deliver, active-channel propagation.
+- AgentEngine.get_active_channel: accessor reflects internal state.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nerve.channels.base import BaseChannel, ChannelCapability
+from nerve.channels.router import ChannelRouter
+from nerve.channels.telegram import TelegramChannel
+from nerve.config import NerveConfig
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _StubChannel(BaseChannel):
+    """Minimal channel stub with configurable capabilities + send_file return."""
+
+    def __init__(
+        self,
+        name: str = "stub",
+        caps: ChannelCapability = ChannelCapability.SEND_TEXT,
+        send_file_returns: bool = True,
+    ):
+        self._name = name
+        self._caps = caps
+        self._send_file_returns = send_file_returns
+        self.send_file_calls: list[tuple[str, str]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def capabilities(self) -> ChannelCapability:
+        return self._caps
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def send(self, message) -> None:
+        pass
+
+    async def send_file(self, target: str, file_path: str) -> bool:  # type: ignore[override]
+        self.send_file_calls.append((target, file_path))
+        return self._send_file_returns
+
+
+# ---------------------------------------------------------------------------
+# ChannelRouter.send_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestRouterSendFile:
+    async def test_no_channel_arg_returns_false_no_context(self):
+        """No active channel + no message context → False."""
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        assert await router.send_file("missing-session", "/tmp/x") is False
+
+    async def test_no_channel_arg_refuses_even_with_context(self, tmp_path):
+        """Channel=None refuses delivery even when ``_message_context``
+        has a valid entry. This is the cross-channel leakage guard for
+        cron/planner sessions that don't pass a channel through
+        ``engine.run()`` — Codex P1 review on commit 28454ab.
+        """
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        ch = _StubChannel(
+            name="telegram",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+        )
+        router._channels["telegram"] = ch
+        # Stale context pointing at a Telegram chat.
+        router._message_context["sess-1"] = {
+            "channel_name": "telegram",
+            "target": "999",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        # Without an explicit ``channel`` arg the router MUST NOT
+        # dispatch via the cached context — otherwise cron/planner runs
+        # would leak files to that Telegram chat.
+        assert await router.send_file("sess-1", str(f)) is False
+        assert ch.send_file_calls == []
+
+    async def test_channel_without_capability_returns_false(self, tmp_path):
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        ch = _StubChannel(name="stub", caps=ChannelCapability.SEND_TEXT)
+        router._channels["stub"] = ch
+        router._message_context["sess-1"] = {
+            "channel_name": "stub",
+            "target": "12345",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        assert await router.send_file("sess-1", str(f), channel="stub") is False
+        assert ch.send_file_calls == []
+
+    async def test_dispatches_when_capability_present(self, tmp_path):
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        ch = _StubChannel(
+            name="stub",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+            send_file_returns=True,
+        )
+        router._channels["stub"] = ch
+        router._message_context["sess-1"] = {
+            "channel_name": "stub",
+            "target": "12345",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        assert await router.send_file("sess-1", str(f), channel="stub") is True
+        assert ch.send_file_calls == [("12345", str(f))]
+
+    async def test_propagates_channel_failure(self, tmp_path):
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        ch = _StubChannel(
+            name="stub",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+            send_file_returns=False,
+        )
+        router._channels["stub"] = ch
+        router._message_context["sess-1"] = {
+            "channel_name": "stub",
+            "target": "12345",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        assert await router.send_file("sess-1", str(f), channel="stub") is False
+        assert ch.send_file_calls == [("12345", str(f))]
+
+    # ---- Cross-channel safety (explicit ``channel`` arg) ------------- #
+
+    async def test_explicit_channel_overrides_stale_context(self, tmp_path):
+        """Stale Telegram ctx must NOT leak to Telegram when caller asks for web.
+
+        Reproduces the cross-channel leakage path: a session previously
+        received a Telegram message (so router._message_context points
+        at a Telegram chat), and is now being driven by a web prompt.
+        send_file with channel="web" must dispatch to the web channel,
+        never to the Telegram chat.
+        """
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        telegram_stub = _StubChannel(
+            name="telegram",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+        )
+        web_stub = _StubChannel(
+            name="web",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+        )
+        router._channels["telegram"] = telegram_stub
+        router._channels["web"] = web_stub
+        # Stale context from a prior Telegram inbound message.
+        router._message_context["sess-1"] = {
+            "channel_name": "telegram",
+            "target": "999",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+
+        ok = await router.send_file("sess-1", str(f), channel="web")
+        assert ok is True
+        # Telegram MUST NOT have been called — that would leak the file.
+        assert telegram_stub.send_file_calls == []
+        # Web received the dispatch (target irrelevant for web).
+        assert len(web_stub.send_file_calls) == 1
+        assert web_stub.send_file_calls[0][1] == str(f)
+
+    async def test_explicit_channel_uses_cached_target_when_match(self, tmp_path):
+        """When channel arg matches cached ctx, reuse the cached target."""
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        telegram_stub = _StubChannel(
+            name="telegram",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+        )
+        router._channels["telegram"] = telegram_stub
+        router._message_context["sess-1"] = {
+            "channel_name": "telegram",
+            "target": "12345",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+
+        ok = await router.send_file("sess-1", str(f), channel="telegram")
+        assert ok is True
+        assert telegram_stub.send_file_calls == [("12345", str(f))]
+
+    async def test_explicit_channel_empty_target_when_no_match(self, tmp_path):
+        """No matching context → empty target. Channels needing a real
+        target (Telegram) should fail safely; broadcast channels (web)
+        succeed regardless.
+        """
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        # Channel that records target — verify it's empty.
+        telegram_stub = _StubChannel(
+            name="telegram",
+            caps=ChannelCapability.SEND_TEXT | ChannelCapability.SEND_FILES,
+            send_file_returns=False,  # Real Telegram would fail on int("")
+        )
+        router._channels["telegram"] = telegram_stub
+        # Context points at a different channel.
+        router._message_context["sess-1"] = {
+            "channel_name": "web",
+            "target": "client-abc",
+            "message_id": 1,
+        }
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+
+        ok = await router.send_file("sess-1", str(f), channel="telegram")
+        assert ok is False
+        # Called with empty target — no leak of cached "client-abc".
+        assert telegram_stub.send_file_calls == [("", str(f))]
+
+    async def test_explicit_channel_unknown_returns_false(self, tmp_path):
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        assert await router.send_file(
+            "sess-1", str(f), channel="nonexistent",
+        ) is False
+
+    async def test_explicit_channel_without_capability_returns_false(self, tmp_path):
+        engine = MagicMock()
+        router = ChannelRouter(engine)
+        ch = _StubChannel(name="text-only", caps=ChannelCapability.SEND_TEXT)
+        router._channels["text-only"] = ch
+        f = tmp_path / "a.txt"
+        f.write_text("hi")
+        assert await router.send_file(
+            "sess-1", str(f), channel="text-only",
+        ) is False
+        assert ch.send_file_calls == []
+
+
+# ---------------------------------------------------------------------------
+# TelegramChannel.send_file
+# ---------------------------------------------------------------------------
+
+
+def _make_telegram_channel() -> TelegramChannel:
+    """Build a TelegramChannel with a minimal config and a mocked _app."""
+    cfg = NerveConfig()
+    cfg.telegram.bot_token = "TEST:TOKEN"
+    cfg.telegram.allowed_users = [1]
+    ch = TelegramChannel(cfg, router=MagicMock())
+    # Bypass real PTB Application — only need send_document to exist.
+    mock_app = MagicMock()
+    mock_app.bot = MagicMock()
+    mock_app.bot.send_document = AsyncMock()
+    ch._app = mock_app
+    return ch
+
+
+@pytest.mark.asyncio
+class TestTelegramSendFile:
+    async def test_missing_file_returns_false(self, tmp_path):
+        ch = _make_telegram_channel()
+        bogus = tmp_path / "does-not-exist.txt"
+        assert await ch.send_file("12345", str(bogus)) is False
+        ch._app.bot.send_document.assert_not_awaited()
+
+    async def test_directory_returns_false(self, tmp_path):
+        ch = _make_telegram_channel()
+        assert await ch.send_file("12345", str(tmp_path)) is False
+        ch._app.bot.send_document.assert_not_awaited()
+
+    async def test_success_path_calls_send_document(self, tmp_path):
+        ch = _make_telegram_channel()
+        f = tmp_path / "note.md"
+        f.write_text("hello")
+        ok = await ch.send_file("12345", str(f))
+        assert ok is True
+        ch._app.bot.send_document.assert_awaited_once()
+        kwargs = ch._app.bot.send_document.await_args.kwargs
+        assert kwargs["chat_id"] == 12345
+        assert kwargs["filename"] == "note.md"
+
+    async def test_send_document_failure_returns_false(self, tmp_path):
+        ch = _make_telegram_channel()
+        ch._app.bot.send_document.side_effect = RuntimeError("boom")
+        f = tmp_path / "note.md"
+        f.write_text("hello")
+        assert await ch.send_file("12345", str(f)) is False
+
+    async def test_no_app_returns_false(self, tmp_path):
+        ch = _make_telegram_channel()
+        ch._app = None
+        f = tmp_path / "note.md"
+        f.write_text("hi")
+        assert await ch.send_file("12345", str(f)) is False
+
+    async def test_capability_includes_send_files(self):
+        ch = _make_telegram_channel()
+        assert ChannelCapability.SEND_FILES in ch.capabilities
+
+
+# ---------------------------------------------------------------------------
+# tools._send_file_impl
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSendFileImpl:
+    async def test_missing_path_returns_error(self):
+        from nerve.agent import tools
+
+        result = await tools._send_file_impl({}, "sess")
+        assert "file_path is required" in result["content"][0]["text"]
+
+    async def test_file_not_found_returns_error(self, tmp_path):
+        from nerve.agent import tools
+
+        bogus = tmp_path / "missing"
+        result = await tools._send_file_impl({"file_path": str(bogus)}, "sess")
+        assert "not found" in result["content"][0]["text"]
+
+    async def test_outside_workspace_blocked(self, tmp_path):
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("nope")
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", MagicMock()):
+            result = await tools._send_file_impl(
+                {"file_path": str(outside)}, "sess"
+            )
+        assert "must be within the workspace" in result["content"][0]["text"]
+
+    async def test_sibling_prefix_bypass_blocked(self, tmp_path):
+        """Sibling directory whose path *string-prefixes* the workspace
+        must NOT pass the workspace guard. Without ``is_relative_to``-
+        style containment, ``/tmp/ws-evil/secret.txt`` would slip past
+        ``startswith("/tmp/ws")`` — Codex P1 review on PR #1 / e773296.
+        """
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        # Sibling directory whose name shares the workspace prefix.
+        sibling = tmp_path / "ws-evil"
+        sibling.mkdir()
+        evil = sibling / "secret.txt"
+        evil.write_text("would be exfiltrated")
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", MagicMock()):
+            result = await tools._send_file_impl(
+                {"file_path": str(evil)}, "sess"
+            )
+        assert "must be within the workspace" in result["content"][0]["text"]
+
+    async def test_engine_unavailable_falls_back(self, tmp_path):
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        f = workspace / "a.txt"
+        f.write_text("hi")
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", None):
+            result = await tools._send_file_impl(
+                {"file_path": str(f)}, "sess"
+            )
+        text = result["content"][0]["text"]
+        assert "File ready: a.txt" in text
+        assert "open the web panel" in text
+
+    async def test_native_delivery_success_message(self, tmp_path):
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        f = workspace / "a.txt"
+        f.write_text("hi")
+
+        engine = MagicMock()
+        engine.get_active_channel = MagicMock(return_value="telegram")
+        engine.router = MagicMock()
+        engine.router.send_file = AsyncMock(return_value=True)
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", engine):
+            result = await tools._send_file_impl(
+                {"file_path": str(f)}, "sess-1"
+            )
+
+        engine.router.send_file.assert_awaited_once_with(
+            "sess-1", str(f.resolve()), channel="telegram",
+        )
+        text = result["content"][0]["text"]
+        assert text.startswith("Sent file: a.txt")
+
+    async def test_dispatch_failure_returns_fallback(self, tmp_path):
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        f = workspace / "a.txt"
+        f.write_text("hi")
+
+        engine = MagicMock()
+        engine.get_active_channel = MagicMock(return_value="telegram")
+        engine.router = MagicMock()
+        engine.router.send_file = AsyncMock(return_value=False)
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", engine):
+            result = await tools._send_file_impl(
+                {"file_path": str(f)}, "sess-1"
+            )
+        text = result["content"][0]["text"]
+        assert "File ready: a.txt" in text
+        assert "open the web panel" in text
+
+    async def test_dispatch_exception_is_caught(self, tmp_path):
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        f = workspace / "a.txt"
+        f.write_text("hi")
+
+        engine = MagicMock()
+        engine.get_active_channel = MagicMock(return_value="web")
+        engine.router = MagicMock()
+        engine.router.send_file = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", engine):
+            result = await tools._send_file_impl(
+                {"file_path": str(f)}, "sess-1"
+            )
+        text = result["content"][0]["text"]
+        assert "File ready: a.txt" in text
+        assert "open the web panel" in text
+
+    async def test_active_channel_passed_through_to_router(self, tmp_path):
+        """_send_file_impl must read engine.get_active_channel and pass it
+        as the ``channel`` kwarg to router.send_file. This is what
+        prevents cross-channel leakage when ``_message_context`` is
+        stale.
+        """
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        f = workspace / "a.txt"
+        f.write_text("hi")
+
+        engine = MagicMock()
+        engine.get_active_channel = MagicMock(return_value="web")
+        engine.router = MagicMock()
+        engine.router.send_file = AsyncMock(return_value=True)
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", engine):
+            await tools._send_file_impl(
+                {"file_path": str(f)}, "sess-1"
+            )
+
+        engine.get_active_channel.assert_called_once_with("sess-1")
+        engine.router.send_file.assert_awaited_once_with(
+            "sess-1", str(f.resolve()), channel="web",
+        )
+
+    async def test_no_active_channel_passes_none(self, tmp_path):
+        """When no channel is active (e.g. cron sessions before any
+        inbound message), send_file falls back to the legacy lookup —
+        but channel=None is still explicitly passed.
+        """
+        from nerve.agent import tools
+
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        f = workspace / "a.txt"
+        f.write_text("hi")
+
+        engine = MagicMock()
+        engine.get_active_channel = MagicMock(return_value=None)
+        engine.router = MagicMock()
+        engine.router.send_file = AsyncMock(return_value=False)
+
+        with patch.object(tools, "_workspace", workspace), \
+             patch.object(tools, "_engine", engine):
+            await tools._send_file_impl(
+                {"file_path": str(f)}, "sess-1"
+            )
+
+        engine.router.send_file.assert_awaited_once_with(
+            "sess-1", str(f.resolve()), channel=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AgentEngine.get_active_channel
+# ---------------------------------------------------------------------------
+
+
+class TestEngineActiveChannel:
+    """Smoke tests for the per-session active-channel accessor.
+
+    The accessor is read by ``_send_file_impl`` to prevent stale
+    ``_message_context`` entries from misrouting files. We verify the
+    bookkeeping shape directly — driving a full engine.run() requires a
+    heavy fixture and is covered by integration smoke tests.
+    """
+
+    def test_get_returns_none_when_unset(self):
+        from nerve.agent.engine import AgentEngine
+
+        # Build a bare instance without running __init__ (no DB required).
+        engine = AgentEngine.__new__(AgentEngine)
+        engine._active_channel = {}
+        assert engine.get_active_channel("sess-1") is None
+
+    def test_get_returns_set_value(self):
+        from nerve.agent.engine import AgentEngine
+
+        engine = AgentEngine.__new__(AgentEngine)
+        engine._active_channel = {"sess-1": "telegram"}
+        assert engine.get_active_channel("sess-1") == "telegram"
+        assert engine.get_active_channel("sess-other") is None


### PR DESCRIPTION
## Summary

`mcp__nerve__send_file` was leaving phantom `[mcp__nerve__send_file]` headers in Telegram and only persisting a DB record for the web frontend — files never reached the chat. This PR makes the tool actually deliver via the bound channel and closes three P1 cross-channel leakage paths.

### What changed

- New `SEND_FILES` channel capability + `BaseChannel.send_file` interface.
- Telegram `send_document` impl with path/exists checks. No client-side size cap — the Telegram API enforces per-deployment limits (50 MiB on `api.telegram.org`, 2 GiB on self-hosted Bot API), and the surrounding try/except already handles the rejection.
- Web `send_file` no-ops since `SendFileBlock` already handles UI delivery.

### Cross-channel hardening

- `AgentEngine` tracks active channel per session (`_active_channel` set in `run()`, cleared on exit) and exposes `get_active_channel(session_id)`.
- `ChannelRouter.send_file(session_id, file_path, channel=...)` requires an explicit channel. Cached `_message_context` target is reused only when its channel matches the requested one — never to **pick** the destination channel. `channel=None` returns False unconditionally, so cron/planner/notifications/web routes that don't thread a channel through `engine.run()` can no longer leak files to a stale Telegram chat from a prior inbound message.
- `_send_file_impl` reads `engine.get_active_channel` and forwards.
- Path-aware workspace containment check (`Path.relative_to` / `ValueError`) replaces the bypassable `str.startswith` guard — closes a sibling-prefix exfiltration vector exposed by real Telegram delivery (e.g. workspace `/srv/ws` previously accepted `/srv/ws-evil/secret.txt`).

### Files

- `nerve/channels/base.py` — `Capability.SEND_FILES`, `BaseChannel.send_file` abstract.
- `nerve/channels/telegram.py` — `send_file` via `bot.send_document`, capability advertised.
- `nerve/channels/web.py` — no-op (UI already covered).
- `nerve/channels/router.py` — explicit-channel dispatch, cached-context match guard.
- `nerve/agent/engine.py` — `_active_channel` map, `get_active_channel()`, run()/exit lifecycle.
- `nerve/agent/tools.py` — `_send_file_impl` resolves channel via engine, path containment check.
- `tests/test_send_file.py` — 28 new tests (router dispatch, Telegram channel, tool impl, engine accessor, leakage + sibling-prefix bypass scenarios).

## Test plan

- [x] `pytest tests/test_send_file.py -v` → 28/28 pass
- [x] Full suite: 394 passed, 2 skipped
- [x] Smoke-tested end-to-end on Telegram: agent-invoked `send_file` on a workspace file delivers the document to the chat
- [x] Secret/PII scan on diff — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)