### PR TITLE
Make Telegram TCP keepalive opts platform-aware

### DIFF
--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -50,12 +50,25 @@ WATCHDOG_HEARTBEAT_EVERY = 10
 # TCP keepalive: prevent NAT/firewall from silently dropping the
 # long-poll connection.  These values tell the OS to send a keepalive
 # probe after 60s idle, retry every 10s, give up after 3 failures.
-_TCP_KEEPALIVE_OPTS = (
-    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-    (socket.SOL_TCP, socket.TCP_KEEPIDLE, 60),
-    (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
-    (socket.SOL_TCP, socket.TCP_KEEPCNT, 3),
-)
+#
+# The fine-grained tuning constants (TCP_KEEPIDLE/INTVL/CNT) are Linux-only.
+# macOS exposes only TCP_KEEPALIVE (semantically equivalent to TCP_KEEPIDLE).
+# On Windows / unknown platforms we fall back to enabling SO_KEEPALIVE alone
+# and let the OS use its default keepalive timing.
+if sys.platform == "linux":
+    _TCP_KEEPALIVE_OPTS: tuple[tuple[int, int, int], ...] = (
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+        (socket.SOL_TCP, socket.TCP_KEEPIDLE, 60),
+        (socket.SOL_TCP, socket.TCP_KEEPINTVL, 10),
+        (socket.SOL_TCP, socket.TCP_KEEPCNT, 3),
+    )
+elif sys.platform == "darwin":
+    _TCP_KEEPALIVE_OPTS = (
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+        (socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 60),
+    )
+else:
+    _TCP_KEEPALIVE_OPTS = ((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),)
 
 
 def _md_to_tg_html(text: str) -> str:


### PR DESCRIPTION
## Problem

Running Nerve on macOS crashes at startup:

```
File "nerve/channels/telegram.py", line 55, in <module>
    (socket.SOL_TCP, socket.TCP_KEEPIDLE, 60),
                     ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'socket' has no attribute 'TCP_KEEPIDLE'. Did you mean: 'TCP_KEEPALIVE'?
```

`TCP_KEEPIDLE`, `TCP_KEEPINTVL`, and `TCP_KEEPCNT` are Linux-only socket constants. Because `_TCP_KEEPALIVE_OPTS` is built at module import time, the AttributeError takes down the import of `nerve.channels.telegram`, which in turn kills FastAPI's lifespan startup in `gateway/server.py` and prevents Nerve from starting at all.

## Fix

Build `_TCP_KEEPALIVE_OPTS` based on `sys.platform`:

- **Linux** — keep the existing four-tuple (idle 60s, interval 10s, count 3).
- **macOS (darwin)** — use `TCP_KEEPALIVE` (semantically equivalent to Linux's `TCP_KEEPIDLE`) with the same 60s idle threshold. macOS doesn't expose user-space tuning for retry interval / count.
- **Windows / unknown** — just enable `SO_KEEPALIVE` and let the OS use its default keepalive timing.

Behaviour on Linux is unchanged.

## Test plan

- [x] \`pytest tests/ -v\` — all 376 tests pass on Linux
- [x] Module imports successfully on Linux
- [ ] Verify import succeeds on macOS (reporter can confirm)

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*