### PR TITLE
feat(telegram): preview + file fallback for long responses

### DIFF
--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -19,6 +19,8 @@ import subprocess
 import sys
 import time
 import zipfile
+from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
@@ -42,6 +44,17 @@ logger = logging.getLogger(__name__)
 
 # Telegram message length limit
 MAX_MSG_LEN = 4096
+# Footer appended to the inline preview when full text is delivered as a file.
+PREVIEW_FOOTER = "\n\n... (truncated)"
+# Code points reserved at the end of the preview for the footer.
+PREVIEW_RESERVE = len(PREVIEW_FOOTER)
+# Minimum gap between preview and document send to clear Telegram's per-chat
+# 1 msg/sec floodwait. Slight cushion above 1.0s for clock skew and queueing.
+FLOODWAIT_GAP_S = 1.1
+# Pattern of characters allowed in attachment filename slug derived from session_id.
+_FILENAME_SAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+# Max length of the sanitized session_id slug used in the filename.
+_FILENAME_SID_MAX = 16
 # Minimum interval between message edits (seconds) to avoid rate limits
 EDIT_INTERVAL = 1.5
 # Watchdog: check every 30s, log heartbeat every ~5 min
@@ -509,33 +522,77 @@ class TelegramChannel(BaseChannel):
     # ------------------------------------------------------------------ #
 
     async def send(self, message: OutboundMessage) -> None:
-        """Send a message to a Telegram chat."""
+        """Send a message to a Telegram chat.
+
+        Short responses (≤ ``MAX_MSG_LEN``) ship as a single inline message.
+        Long responses ship as an inline preview (first ``MAX_MSG_LEN -
+        PREVIEW_RESERVE`` chars + ``PREVIEW_FOOTER`` truncation marker)
+        followed by a document attachment containing the full original text.
+        """
         if self._app is None:
             return
         chat_id = int(message.target)
         text = message.text
-        # Split long messages
-        for i in range(0, len(text), MAX_MSG_LEN):
-            chunk = text[i:i + MAX_MSG_LEN]
-            html_chunk = _md_to_tg_html(chunk)
-            try:
-                sent = await self._app.bot.send_message(
-                    chat_id=chat_id,
-                    text=html_chunk,
-                    parse_mode=ParseMode.HTML,
-                )
-            except Exception:
-                sent = await self._app.bot.send_message(
-                    chat_id=chat_id,
-                    text=chunk,
-                )
-            self._cache_message(sent.message_id, chat_id, chunk)
+        if not text:
+            return
 
-    def format_response(self, text: str) -> str:
-        """Truncate for Telegram if needed."""
-        if len(text) > MAX_MSG_LEN:
-            return text[:MAX_MSG_LEN - 20] + "\n\n... (truncated)"
-        return text
+        if len(text) <= MAX_MSG_LEN:
+            await self._send_single(chat_id, text)
+            return
+
+        preview_len = MAX_MSG_LEN - PREVIEW_RESERVE
+        preview = text[:preview_len].rstrip() + PREVIEW_FOOTER
+        await self._send_single(chat_id, preview)
+        await self._send_response_document(chat_id, message)
+
+    async def _send_single(self, chat_id: int, text: str) -> None:
+        """Send a single message with HTML formatting and plain-text fallback."""
+        html_text = _md_to_tg_html(text)
+        try:
+            sent = await self._app.bot.send_message(
+                chat_id=chat_id,
+                text=html_text,
+                parse_mode=ParseMode.HTML,
+            )
+        except Exception:
+            sent = await self._app.bot.send_message(
+                chat_id=chat_id,
+                text=text,
+            )
+        self._cache_message(sent.message_id, chat_id, text)
+
+    async def _send_response_document(
+        self, chat_id: int, message: OutboundMessage,
+    ) -> None:
+        """Attach the full response as a markdown document.
+
+        Waits ``FLOODWAIT_GAP_S`` before uploading to clear Telegram's per-chat
+        1 msg/sec floodwait — anything shorter risks throttling the document
+        send, which would silently leave the user with only the preview
+        because upload failures are swallowed below.
+        """
+        # Sanitize session_id: strip anything outside [A-Za-z0-9_-] and cap
+        # length so routing-path values with separators, control chars, or
+        # unusual length cannot break send_document request validation.
+        sid = _FILENAME_SAFE_RE.sub("", message.session_id or "")[:_FILENAME_SID_MAX] or "unknown"
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        filename = f"response-{sid}-{ts}.md"
+        bio = BytesIO(message.text.encode("utf-8"))
+        await asyncio.sleep(FLOODWAIT_GAP_S)
+        try:
+            await self._app.bot.send_document(
+                chat_id=chat_id,
+                document=bio,
+                filename=filename,
+            )
+        except Exception as e:
+            logger.warning(
+                "send: response document upload failed for chat=%s sid=%s len=%d: %s",
+                chat_id, sid, len(message.text), e,
+            )
+
+    # Length policy lives in ``send`` (preview + file fallback).
+    # ``format_response`` inherited from base (identity).
 
     # ------------------------------------------------------------------ #
     #  Streaming protocol                                                  #

--- a/tests/test_telegram_send.py
+++ b/tests/test_telegram_send.py
@@ -1,0 +1,241 @@
+"""Tests for TelegramChannel.send length policy.
+
+Covers the inline / preview-plus-document split for outbound responses:
+- Short text → single inline message, no document.
+- Boundary text (= MAX_MSG_LEN) → single inline message, no document.
+- Long text (> MAX_MSG_LEN) → inline preview + document attachment.
+- Filename construction (with and without session_id).
+- Document upload failure tolerated; preview still delivered.
+- format_response is identity (length policy lives in send()).
+"""
+
+from __future__ import annotations
+
+import re
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nerve.channels.base import OutboundMessage
+from nerve.channels.telegram import (
+    FLOODWAIT_GAP_S,
+    MAX_MSG_LEN,
+    PREVIEW_FOOTER,
+    TelegramChannel,
+)
+from nerve.config import NerveConfig
+
+
+@pytest.fixture(autouse=True)
+def _patch_floodwait_sleep(monkeypatch):
+    """Replace the floodwait gap sleep with a no-op so tests don't actually wait."""
+    import nerve.channels.telegram as tg_mod
+
+    async def _fast_sleep(_secs):  # noqa: D401
+        return None
+
+    monkeypatch.setattr(tg_mod.asyncio, "sleep", _fast_sleep)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_telegram_channel() -> TelegramChannel:
+    """Build a TelegramChannel with a mocked PTB Application."""
+    cfg = NerveConfig()
+    cfg.telegram.bot_token = "TEST:TOKEN"
+    cfg.telegram.allowed_users = [1]
+    ch = TelegramChannel(cfg, router=MagicMock())
+    mock_app = MagicMock()
+    mock_app.bot = MagicMock()
+    sent_msg = MagicMock()
+    sent_msg.message_id = 42
+    mock_app.bot.send_message = AsyncMock(return_value=sent_msg)
+    mock_app.bot.send_document = AsyncMock()
+    ch._app = mock_app
+    return ch
+
+
+def _outbound(text: str, target: str = "12345", session_id: str = "abc123de") -> OutboundMessage:
+    return OutboundMessage(target=target, text=text, session_id=session_id)
+
+
+# ---------------------------------------------------------------------------
+# Length policy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTelegramSendLengthPolicy:
+    async def test_send_short_text_single_message(self):
+        """Short text: 1 send_message call, 0 send_document calls."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("x" * 100))
+        ch._app.bot.send_message.assert_awaited_once()
+        ch._app.bot.send_document.assert_not_awaited()
+
+    async def test_send_at_boundary_4096(self):
+        """Boundary text (= MAX_MSG_LEN): inline only, no document."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("x" * MAX_MSG_LEN))
+        ch._app.bot.send_message.assert_awaited_once()
+        ch._app.bot.send_document.assert_not_awaited()
+
+    async def test_send_one_over_4097_preview_plus_file(self):
+        """1 char over boundary: preview + file attachment."""
+        ch = _make_telegram_channel()
+        text = "y" * (MAX_MSG_LEN + 1)
+        await ch.send(_outbound(text))
+
+        # Inline preview was sent
+        ch._app.bot.send_message.assert_awaited_once()
+        sent_text = ch._app.bot.send_message.await_args.kwargs["text"]
+        assert sent_text.endswith(PREVIEW_FOOTER)
+        assert len(sent_text) <= MAX_MSG_LEN
+
+        # Document was sent with the full original text
+        ch._app.bot.send_document.assert_awaited_once()
+        doc_arg = ch._app.bot.send_document.await_args.kwargs["document"]
+        assert isinstance(doc_arg, BytesIO)
+        assert doc_arg.getvalue() == text.encode("utf-8")
+        assert len(doc_arg.getvalue()) == MAX_MSG_LEN + 1
+
+    async def test_send_long_preview_holds_text_prefix(self):
+        """Preview body is a prefix of the original — content not lost on the wire."""
+        ch = _make_telegram_channel()
+        text = ("paragraph one. " * 600).strip()  # ~9000 chars, > MAX_MSG_LEN
+        await ch.send(_outbound(text))
+
+        sent_text = ch._app.bot.send_message.await_args.kwargs["text"]
+        assert sent_text.endswith(PREVIEW_FOOTER)
+        body = sent_text[: -len(PREVIEW_FOOTER)].rstrip()
+        assert text.startswith(body)
+
+
+# ---------------------------------------------------------------------------
+# Filename construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTelegramFilename:
+    async def test_filename_includes_session_id(self):
+        """Filename matches response-<session_id>-<YYYYmmdd-HHMMSS>.md."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("a" * (MAX_MSG_LEN + 100), session_id="abc123de"))
+        kwargs = ch._app.bot.send_document.await_args.kwargs
+        assert re.fullmatch(r"response-abc123de-\d{8}-\d{6}\.md", kwargs["filename"])
+
+    async def test_filename_falls_back_when_session_empty(self):
+        """Empty session_id → filename starts with response-unknown-."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("b" * (MAX_MSG_LEN + 100), session_id=""))
+        kwargs = ch._app.bot.send_document.await_args.kwargs
+        assert kwargs["filename"].startswith("response-unknown-")
+        assert kwargs["filename"].endswith(".md")
+
+    async def test_filename_sanitizes_unsafe_chars(self):
+        """Path separators / spaces / control chars in session_id are stripped."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound(
+            "e" * (MAX_MSG_LEN + 50), session_id="ab/cd\\ef gh\n12",
+        ))
+        kwargs = ch._app.bot.send_document.await_args.kwargs
+        # Result keeps only [A-Za-z0-9_-]; "abcdefgh12" survives.
+        assert re.fullmatch(
+            r"response-abcdefgh12-\d{8}-\d{6}\.md", kwargs["filename"],
+        )
+
+    async def test_filename_truncates_long_session_id(self):
+        """Very long session_id is capped at 16 chars in the slug."""
+        ch = _make_telegram_channel()
+        long_sid = "a" * 100
+        await ch.send(_outbound("f" * (MAX_MSG_LEN + 50), session_id=long_sid))
+        kwargs = ch._app.bot.send_document.await_args.kwargs
+        # Slug is exactly 16 'a's.
+        assert re.fullmatch(
+            r"response-a{16}-\d{8}-\d{6}\.md", kwargs["filename"],
+        )
+
+    async def test_filename_only_invalid_chars_falls_back(self):
+        """All-invalid session_id ('///\\\\') sanitizes to empty → 'unknown'."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("g" * (MAX_MSG_LEN + 50), session_id="///\\\\"))
+        kwargs = ch._app.bot.send_document.await_args.kwargs
+        assert kwargs["filename"].startswith("response-unknown-")
+
+
+# ---------------------------------------------------------------------------
+# Failure modes & format_response identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTelegramSendFailureModes:
+    async def test_document_failure_preserves_preview(self, caplog):
+        """If send_document raises, preview was already delivered; no exception escapes."""
+        import logging
+
+        ch = _make_telegram_channel()
+        ch._app.bot.send_document.side_effect = RuntimeError("network exploded")
+        text = "c" * (MAX_MSG_LEN + 50)
+
+        with caplog.at_level(logging.WARNING, logger="nerve.channels.telegram"):
+            await ch.send(_outbound(text))  # must not raise
+
+        # Preview was sent successfully
+        ch._app.bot.send_message.assert_awaited_once()
+        # Document attempt was made and failed
+        ch._app.bot.send_document.assert_awaited_once()
+        # Warning was logged
+        assert any(
+            "response document upload failed" in rec.message
+            for rec in caplog.records
+        )
+
+    async def test_preview_footer_is_truncated_marker_only(self):
+        """Preview ends with exactly PREVIEW_FOOTER ('\\n\\n... (truncated)'), nothing more."""
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("d" * (MAX_MSG_LEN + 200)))
+        sent_text = ch._app.bot.send_message.await_args.kwargs["text"]
+        assert sent_text.endswith("\n\n... (truncated)")
+        # No trailing content past the footer
+        assert sent_text.count("(truncated)") == 1
+
+
+@pytest.mark.asyncio
+class TestTelegramFloodwaitGap:
+    async def test_floodwait_gap_at_least_one_second(self):
+        """Gap between preview and document must clear Telegram's 1 msg/sec/chat limit."""
+        assert FLOODWAIT_GAP_S >= 1.0
+
+    async def test_floodwait_gap_is_awaited_between_sends(self, monkeypatch):
+        """send() awaits asyncio.sleep(FLOODWAIT_GAP_S) before send_document."""
+        import nerve.channels.telegram as tg_mod
+
+        observed: list[float] = []
+
+        async def _spy_sleep(secs):
+            observed.append(secs)
+
+        monkeypatch.setattr(tg_mod.asyncio, "sleep", _spy_sleep)
+
+        ch = _make_telegram_channel()
+        await ch.send(_outbound("h" * (MAX_MSG_LEN + 100)))
+
+        assert FLOODWAIT_GAP_S in observed
+
+
+def test_format_response_identity():
+    """format_response no longer truncates — length policy lives in send()."""
+    cfg = NerveConfig()
+    cfg.telegram.bot_token = "TEST:TOKEN"
+    cfg.telegram.allowed_users = [1]
+    ch = TelegramChannel(cfg, router=MagicMock())
+    long_text = "x" * 10000
+    assert ch.format_response(long_text) == long_text
+    assert ch.format_response("short") == "short"


### PR DESCRIPTION
## Summary

Replace silent `…(truncated)` of outbound text >4096 chars with **inline preview + `.md` document attachment**. Single squashed commit cherry-picked from neomnezia/nerve#7.

## Behavior

| Input length | Outbound delivery |
|---|---|
| ≤ 4096 chars | Single inline message (unchanged) |
| > 4096 chars | Inline preview ending in `\n\n... (truncated)` + `.md` attachment with full text |

## Why

Long-standing UX bug: agent responses over 4096 chars on Telegram had their tail silently dropped. Now the user sees what fits inline and gets the full text as a downloadable `.md` file.

## Implementation notes

- Length policy lives entirely in `TelegramChannel.send()`; `format_response` left as base-class identity.
- Filename: `response-{session_id}-{ts}.md`. `session_id` sanitized to `[A-Za-z0-9_-]`, capped at 16 chars; falls back to `response-unknown-{ts}.md` when empty (e.g. cron deliver path).
- 1.1 s gap between preview and document send to clear Telegram's per-chat 1 msg/sec floodwait ceiling.
- `send_document` failures are logged and swallowed — the inline preview already shipped, so a missing attachment is degraded UX, not a hard error.

## Known gap (deferred to follow-up PR)

`notifications/service.py:_send_telegram_html` calls `bot.send_message` directly and does **not** route through `TelegramChannel.send`, so the preview+document fallback does NOT fire for:
- `notify` MCP tool invocations with body >4096 chars
- `ask_user` MCP tool invocations with body >4096 chars
- Cron/source jobs that emit via `notify()`

Cron jobs that emit via the agent stream (`engine.run` → `StreamAdapter` → `channel.send`) ARE protected. Fix path: extract a shared `_send_long_with_fallback(bot, chat_id, text, *, session_id, reply_markup, silent)` helper used by both call sites.

## Files

- `nerve/channels/telegram.py` — refactor `send()`, add `_send_single` / `_send_response_document` (+79 / -22)
- `tests/test_telegram_send.py` — 14 tests covering both branches, filename construction, sanitization, failure modes, floodwait invariants (+241 new)

## Test Plan

- [x] `pytest tests/test_telegram_send.py` — 14/14 pass
- [x] `pytest tests/ -k telegram` — 20/20 pass
- [x] Smoke-tested live on a running instance: long agent response (>4096 chars) → preview + `.md` attachment fires through StreamAdapter → channel.send

🤖 Generated with [Claude Code](https://claude.com/claude-code)