### PR TITLE
fix(web): refresh todos panel from buffered events on reconnect

### DIFF
--- a/web/src/stores/handlers/sessionHandlers.ts
+++ b/web/src/stores/handlers/sessionHandlers.ts
@@ -1,6 +1,6 @@
 import type { WSMessage } from '../../api/websocket';
 import type { PanelTab } from '../../types/chat';
-import { applyStreamEvent, rebuildPanelTabsFromBuffer, deriveStatus } from '../helpers/bufferReplay';
+import { applyStreamEvent, rebuildPanelTabsFromBuffer, deriveStatus, extractTodosFromBuffer } from '../helpers/bufferReplay';
 import type { Get, Set } from './types';
 
 // ------------------------------------------------------------------ //
@@ -89,7 +89,13 @@ export function handleSessionStatus(
       }
     }
 
-    set({
+    // Restore todos panel from the freshest TodoWrite in the buffer. Without
+    // this, a client that reconnects mid-turn (page refresh, WS drop, tab
+    // backgrounded) sees a stale snapshot from persisted history because the
+    // buffered TodoWrite tool_use events fed only streamingBlocks.
+    const restoredTodos = extractTodosFromBuffer(bufferedEvents);
+
+    const update: Record<string, unknown> = {
       isStreaming: true,
       streamingBlocks: blocks,
       agentStatus: deriveStatus(blocks),
@@ -97,7 +103,11 @@ export function handleSessionStatus(
       activePanelId: restored.activePanelId,
       panelVisible: restored.panels.length > 0,
       pendingInteraction: restoredInteraction,
-    });
+    };
+    if (restoredTodos !== null) {
+      update.currentTodos = restoredTodos;
+    }
+    set(update);
   } else {
     set({ isStreaming: true, streamingBlocks: blocks, agentStatus: deriveStatus(blocks) });
   }

--- a/web/src/stores/helpers/bufferReplay.ts
+++ b/web/src/stores/helpers/bufferReplay.ts
@@ -184,3 +184,27 @@ export function extractTodosFromMessages(messages: ChatMessage[]): TodoItem[] {
   }
   return [];
 }
+
+/**
+ * Extract the latest TodoWrite todos from a list of buffered WS events.
+ * Used during live reconnect (session_status with buffered_events): the
+ * persisted message history may not yet include the in-flight turn, so the
+ * todos panel needs to read the freshest state from the buffer.
+ *
+ * Returns null when the buffer contains no top-level TodoWrite, so the caller
+ * can preserve whatever currentTodos was already set from persisted history.
+ * Unlike extractTodosFromMessages, this does NOT skip the all-completed case;
+ * the panel's own auto-hide handles that animation once the user sees it.
+ */
+export function extractTodosFromBuffer(events: WSMessage[]): TodoItem[] | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.type !== 'tool_use') continue;
+    if (event.tool !== 'TodoWrite') continue;
+    // Sub-agent (Task) child TodoWrite calls belong to the panel, not the main todos.
+    if ('parent_tool_use_id' in event && event.parent_tool_use_id) continue;
+    const todos = (event.input as { todos?: TodoItem[] } | undefined)?.todos;
+    if (Array.isArray(todos)) return todos as TodoItem[];
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes #68. The todos panel in the web UI froze on a stale snapshot when a client reconnected in the middle of an active turn (page refresh, WS drop, tab backgrounded long enough to drop). New `TodoWrite` calls kept landing in the WS buffer and on the persisted history, but the panel kept showing the count from the last `TodoWrite` that was persisted *before* the reconnect.

## Cause

`handleSessionStatus` rebuilds `streamingBlocks` from `msg.buffered_events` via `applyStreamEvent`, but never updates `currentTodos`. The only `currentTodos` writers were:

- live `handleToolUse` (only runs while WS is live, not during buffer replay), and
- `extractTodosFromMessages(hydrated)` in `switchSession` (only sees persisted DB messages).

Any `TodoWrite` that arrived in the buffer for an in-flight turn before the reconnect bypassed both writers.

## Fix

- Add `extractTodosFromBuffer(events)` next to `extractTodosFromMessages`. Walks the buffered events backward, returns the latest top-level `TodoWrite` input, or `null` if there isn't one. Filters out sub-agent (`parent_tool_use_id`) entries to match the live handler's behaviour.
- Call it from `handleSessionStatus` after rebuilding `blocks`. Update `currentTodos` only when the helper returns non-null; otherwise preserve whatever was already set from persisted history.

`extractTodosFromBuffer` does not skip the all-completed case (unlike `extractTodosFromMessages`), so the panel can show the final state and let its own 5s auto-hide animate.

## Test plan

- [x] `npx tsc --noEmit` clean in `web/`.
- [x] `npm run build` clean in `web/`.
- [ ] Manual: Start a session with many `TodoWrite` calls in one turn, refresh the browser mid-turn, confirm the panel reflects the latest todos rather than the persisted snapshot.

## Notes

No new unit tests; `web/src/` has no test framework configured. Happy to add one in a follow-up if a runner gets wired in.

`[no-changeset: allow]` (no changeset infra in this repo).
