### PR TITLE
docs: add upgrading section to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ nerve start -f
 ```
 </details>
 
+### Upgrading
+
+```bash
+nerve upgrade
+nerve restart
+```
+
+Runs `git pull`, reinstalls Python deps, and rebuilds the web UI in one shot. Use `--no-pull`, `--no-deps`, or `--no-frontend` to skip steps. For Docker deployments, rebuild the image instead: `git pull && docker compose build && docker compose up -d`.
+
 **No API key?** Use your Claude subscription instead
 
 ## Two Modes


### PR DESCRIPTION
## Summary

Adds a small **Upgrading** subsection inside Quick Start covering the `nerve upgrade` command (git pull + deps + frontend rebuild) plus the rebuild flow for Docker deployments.

## Changes

- `README.md`: new `### Upgrading` block under Quick Start with the one-liner, the skip-step flags, and the correct Docker workflow (`git pull && docker compose build && docker compose up -d` — the generated `docker-compose.yml` uses `build: .`, not a registry image).

## Test plan

- [x] Rendered locally — section sits between manual-install `<details>` block and the "No API key?" line, matching surrounding style.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*