### PR TITLE
feat: tidy up plan decline + sort/paginate tasks page

### DIFF
--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -1379,16 +1379,18 @@ async def plan_decline(args: dict) -> dict:
         fields["feedback"] = feedback
     await _db.update_plan(plan_id, **fields)
 
-    # Write task note
-    feedback_suffix = ""
+    # Mark the related task as done. Feedback is optional — if absent,
+    # leave a generic comment noting that the plan was closed without a reason.
     if feedback:
-        feedback_suffix = f" — {feedback[:80]}{'...' if len(feedback) > 80 else ''}"
-    await task_update.handler({
+        note = f"Plan {plan_id} declined — {feedback}"
+    else:
+        note = f"Related plan {plan_id} was closed without a specified reason"
+    await task_done.handler({
         "task_id": plan["task_id"],
-        "note": f"Plan declined: {plan_id}{feedback_suffix}",
+        "note": note,
     })
 
-    return {"content": [{"type": "text", "text": f"Plan {plan_id} declined.{(' Feedback: ' + feedback) if feedback else ''}"}]}
+    return {"content": [{"type": "text", "text": f"Plan {plan_id} declined and task moved to done.{(' Feedback: ' + feedback) if feedback else ''}"}]}
 
 
 @tool(

--- a/nerve/db/tasks.py
+++ b/nerve/db/tasks.py
@@ -48,7 +48,22 @@ class TaskStore:
             row = await cursor.fetchone()
             return dict(row) if row else None
 
-    async def list_tasks(self, status: str | None = None, tag: str | None = None, limit: int = 100) -> list[dict]:
+    # Supported sort keys → ORDER BY clause. Keep deterministic with a
+    # secondary key so equal timestamps don't flicker between pages.
+    _SORT_CLAUSES = {
+        "deadline": "deadline ASC NULLS LAST, created_at DESC, id DESC",
+        "updated_at": "updated_at DESC, id DESC",
+        "created_at": "created_at DESC, id DESC",
+    }
+
+    async def list_tasks(
+        self,
+        status: str | None = None,
+        tag: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        sort: str = "deadline",
+    ) -> list[dict]:
         conditions: list[str] = []
         params: list = []
 
@@ -66,12 +81,41 @@ class TaskStore:
             params.append(f"%,{tag.strip().lower()},%")
 
         where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
-        params.append(limit)
+        order_clause = self._SORT_CLAUSES.get(sort, self._SORT_CLAUSES["deadline"])
+        params.extend([limit, offset])
         async with self.db.execute(
-            f"SELECT * FROM tasks{where} ORDER BY deadline ASC NULLS LAST, created_at DESC LIMIT ?",
+            f"SELECT * FROM tasks{where} ORDER BY {order_clause} LIMIT ? OFFSET ?",
             tuple(params),
         ) as cursor:
             return [dict(row) async for row in cursor]
+
+    async def count_tasks(
+        self,
+        status: str | None = None,
+        tag: str | None = None,
+    ) -> int:
+        """Count tasks matching the given filters (without limit/offset)."""
+        conditions: list[str] = []
+        params: list = []
+
+        if status == "all":
+            pass
+        elif status:
+            conditions.append("status = ?")
+            params.append(status)
+        else:
+            conditions.append("status != 'done'")
+
+        if tag:
+            conditions.append("',' || tags || ',' LIKE ?")
+            params.append(f"%,{tag.strip().lower()},%")
+
+        where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+        async with self.db.execute(
+            f"SELECT COUNT(*) FROM tasks{where}", tuple(params),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row[0] if row else 0
 
     async def update_task_status(self, task_id: str, status: str) -> None:
         now = datetime.now(timezone.utc).isoformat()

--- a/nerve/gateway/routes/plans.py
+++ b/nerve/gateway/routes/plans.py
@@ -71,15 +71,17 @@ async def update_plan(plan_id: str, req: PlanUpdateRequest, user: dict = Depends
     if fields:
         await deps.db.update_plan(plan_id, **fields)
 
-    # Write task note on decline
+    # On decline: mark the related task as done with a note explaining the closure.
+    # The user-supplied feedback is optional — if absent, leave a generic comment.
     if req.status == "declined":
-        from nerve.agent.tools import task_update as task_update_tool
-        feedback_suffix = ""
+        from nerve.agent.tools import task_done as task_done_tool
         if req.feedback:
-            feedback_suffix = f" — {req.feedback[:80]}{'...' if len(req.feedback) > 80 else ''}"
-        await task_update_tool.handler({
+            note = f"Plan {plan_id} declined — {req.feedback}"
+        else:
+            note = f"Related plan {plan_id} was closed without a specified reason"
+        await task_done_tool.handler({
             "task_id": plan["task_id"],
-            "note": f"Plan declined: {plan_id}{feedback_suffix}",
+            "note": note,
         })
 
     return {"plan_id": plan_id, "updated": True}

--- a/nerve/gateway/routes/tasks.py
+++ b/nerve/gateway/routes/tasks.py
@@ -28,18 +28,39 @@ class TaskUpdateRequest(BaseModel):
     title: str = ""
 
 
+_ALLOWED_SORTS = {"deadline", "updated_at", "created_at"}
+
+
 @router.get("/api/tasks")
-async def list_tasks(status: str = "", user: dict = Depends(require_auth)):
+async def list_tasks(
+    status: str = "",
+    sort: str = "deadline",
+    limit: int = 50,
+    offset: int = 0,
+    user: dict = Depends(require_auth),
+):
     deps = get_deps()
-    tasks = await deps.db.list_tasks(status=status or None)
-    return {"tasks": tasks}
+    # Clamp inputs to sensible bounds; silently fall back on unknown sorts.
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+    if sort not in _ALLOWED_SORTS:
+        sort = "deadline"
+
+    status_filter = status or None
+    tasks = await deps.db.list_tasks(
+        status=status_filter, sort=sort, limit=limit, offset=offset,
+    )
+    total = await deps.db.count_tasks(status=status_filter)
+    return {"tasks": tasks, "total": total, "limit": limit, "offset": offset}
 
 
 @router.get("/api/tasks/search")
 async def search_tasks(q: str, status: str = "", user: dict = Depends(require_auth)):
     deps = get_deps()
-    tasks = await deps.db.search_tasks(query=q, status=status or None)
-    return {"tasks": tasks}
+    # Search is relevance-ranked (BM25); pagination would fight the ranking,
+    # so we return up to 100 hits and let the UI hide pagination when active.
+    tasks = await deps.db.search_tasks(query=q, status=status or None, limit=100)
+    return {"tasks": tasks, "total": len(tasks), "limit": len(tasks), "offset": 0}
 
 
 @router.post("/api/tasks")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -559,6 +559,41 @@ class TestTaskSearch:
         results = await db.list_tasks(tag="ci")
         assert len(results) == 2
 
+    async def test_list_tasks_sort_and_pagination(self, db: Database):
+        """list_tasks should respect sort + limit/offset, and count_tasks
+        should return the total ignoring pagination."""
+        import asyncio
+        # Insert three tasks; sleep briefly between each so updated_at
+        # is monotonically increasing.
+        await db.upsert_task(task_id="t-a", file_path="a.md", title="A", status="pending")
+        await asyncio.sleep(0.01)
+        await db.upsert_task(task_id="t-b", file_path="b.md", title="B", status="pending")
+        await asyncio.sleep(0.01)
+        await db.upsert_task(task_id="t-c", file_path="c.md", title="C", status="pending")
+
+        # Sort by updated_at DESC — newest first
+        results = await db.list_tasks(sort="updated_at")
+        assert [r["id"] for r in results] == ["t-c", "t-b", "t-a"]
+
+        # Sort by created_at DESC — same order in this case
+        results = await db.list_tasks(sort="created_at")
+        assert [r["id"] for r in results] == ["t-c", "t-b", "t-a"]
+
+        # Unknown sort falls back to default (deadline) without raising
+        results = await db.list_tasks(sort="bogus")
+        assert len(results) == 3
+
+        # Pagination: limit=2 returns first 2; offset=2 returns the third
+        page1 = await db.list_tasks(sort="updated_at", limit=2, offset=0)
+        page2 = await db.list_tasks(sort="updated_at", limit=2, offset=2)
+        assert [r["id"] for r in page1] == ["t-c", "t-b"]
+        assert [r["id"] for r in page2] == ["t-a"]
+
+        # count_tasks ignores pagination
+        assert await db.count_tasks() == 3
+        assert await db.count_tasks(status="pending") == 3
+        assert await db.count_tasks(status="done") == 0
+
 
 class TestTagParsing:
     """Test tag string parsing handles various agent input formats."""

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -91,12 +91,23 @@ export const api = {
     }),
 
   // Tasks
-  listTasks: (status?: string) =>
-    request<{ tasks: any[] }>(`/tasks${status ? `?status=${status}` : ''}`),
+  listTasks: (params?: { status?: string; sort?: string; limit?: number; offset?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.status) qs.set('status', params.status);
+    if (params?.sort) qs.set('sort', params.sort);
+    if (params?.limit !== undefined) qs.set('limit', String(params.limit));
+    if (params?.offset !== undefined) qs.set('offset', String(params.offset));
+    const q = qs.toString();
+    return request<{ tasks: any[]; total: number; limit: number; offset: number }>(
+      `/tasks${q ? '?' + q : ''}`,
+    );
+  },
   searchTasks: (query: string, status?: string) => {
     const qs = new URLSearchParams({ q: query });
     if (status) qs.set('status', status);
-    return request<{ tasks: any[] }>(`/tasks/search?${qs}`);
+    return request<{ tasks: any[]; total: number; limit: number; offset: number }>(
+      `/tasks/search?${qs}`,
+    );
   },
   getTask: (id: string) => request<any>(`/tasks/${id}`),
   createTask: (data: { title: string; content?: string; deadline?: string }) =>

--- a/web/src/components/Tasks/TaskCard.tsx
+++ b/web/src/components/Tasks/TaskCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
-import { Calendar, ExternalLink } from 'lucide-react';
+import { Calendar, Clock, ExternalLink } from 'lucide-react';
 import type { Task } from '../../stores/taskStore';
+import { formatTimeAgo } from '../../utils/dateGroups';
 
 const STATUS_STYLES: Record<string, string> = {
   pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
@@ -30,6 +31,14 @@ export function TaskCard({ task, onStatusChange }: {
             {task.deadline && (
               <span className="flex items-center gap-1 text-text-dim">
                 <Calendar size={11} /> {task.deadline}
+              </span>
+            )}
+            {task.updated_at && (
+              <span
+                className="flex items-center gap-1 text-text-faint"
+                title={`Updated ${task.updated_at}`}
+              >
+                <Clock size={11} /> {formatTimeAgo(task.updated_at)}
               </span>
             )}
             {task.source && (

--- a/web/src/components/Tasks/TaskList.tsx
+++ b/web/src/components/Tasks/TaskList.tsx
@@ -24,7 +24,7 @@ export function TaskList() {
 
   const loadTasks = async () => {
     try {
-      const { tasks } = await api.listTasks(filter || undefined);
+      const { tasks } = await api.listTasks({ status: filter || undefined });
       setTasks(tasks);
     } catch (e) {
       console.error('Failed to load tasks:', e);

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -33,6 +33,8 @@ export function PlanDetailPage() {
   const { selectedPlan: plan, detailLoading, actionLoading, loadPlan, updatePlan, approvePlan, revisePlan, clearSelectedPlan } = usePlanStore();
   const [feedback, setFeedback] = useState('');
   const [showFeedback, setShowFeedback] = useState(false);
+  const [declineFeedback, setDeclineFeedback] = useState('');
+  const [showDeclineFeedback, setShowDeclineFeedback] = useState(false);
 
   // houseofagents runtime selection state
   const [hoaStatus, setHoaStatus] = useState<HoaStatus | null>(null);
@@ -81,7 +83,9 @@ export function PlanDetailPage() {
   };
 
   const handleDecline = () => {
-    updatePlan(plan.id, 'declined');
+    updatePlan(plan.id, 'declined', declineFeedback.trim() || undefined);
+    setDeclineFeedback('');
+    setShowDeclineFeedback(false);
   };
 
   const handleRevise = () => {
@@ -215,7 +219,7 @@ export function PlanDetailPage() {
                   {useMultiAgent ? 'Approve (Multi-Agent)' : 'Approve & Implement'}
                 </button>
                 <button
-                  onClick={handleDecline}
+                  onClick={() => setShowDeclineFeedback(!showDeclineFeedback)}
                   disabled={actionLoading}
                   className="flex items-center gap-1.5 px-4 py-2 text-[13px] bg-red-600/80 hover:bg-red-500/80 disabled:opacity-50 text-white rounded-lg cursor-pointer"
                 >
@@ -228,6 +232,33 @@ export function PlanDetailPage() {
                   <MessageSquare size={14} /> Request Revision
                 </button>
               </div>
+
+              {showDeclineFeedback && (
+                <div className="space-y-2">
+                  <div className="flex gap-0">
+                    <div className="w-1 bg-red-500/40 rounded-full shrink-0" />
+                    <div className="flex-1 pl-3">
+                      <textarea
+                        value={declineFeedback}
+                        onChange={e => setDeclineFeedback(e.target.value)}
+                        placeholder="Optional: why is this plan being declined? (leave empty to close without a reason)"
+                        className="w-full p-3 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary placeholder:text-placeholder focus:outline-none focus:border-red-500/50 resize-none"
+                        rows={3}
+                        autoFocus
+                      />
+                    </div>
+                  </div>
+                  <div className="flex justify-end">
+                    <button
+                      onClick={handleDecline}
+                      disabled={actionLoading}
+                      className="px-4 py-2 text-[13px] bg-red-600/80 hover:bg-red-500/80 disabled:opacity-50 text-white rounded-lg cursor-pointer"
+                    >
+                      Confirm Decline
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {showFeedback && (
                 <div className="space-y-2">

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,20 +1,34 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Plus, Search, X } from 'lucide-react';
-import { useTaskStore } from '../stores/taskStore';
+import { ChevronLeft, ChevronRight, Plus, Search, X } from 'lucide-react';
+import { useTaskStore, TASKS_PAGE_SIZE, type TaskSort } from '../stores/taskStore';
 import { TaskFilters } from '../components/Tasks/TaskFilters';
 import { TaskCard } from '../components/Tasks/TaskCard';
 import { TaskCreateDialog } from '../components/Tasks/TaskCreateDialog';
 
+const SORT_OPTIONS: { value: TaskSort; label: string }[] = [
+  { value: 'deadline', label: 'Deadline' },
+  { value: 'updated_at', label: 'Last update' },
+  { value: 'created_at', label: 'Created' },
+];
+
 export function TasksPage() {
   const {
-    tasks, filter, searchQuery, loading, showCreateDialog,
-    loadTasks, setFilter, setSearch, updateStatus, createTask, setShowCreateDialog,
+    tasks, filter, searchQuery, sort, page, total, loading, showCreateDialog,
+    loadTasks, setFilter, setSearch, setSort, setPage,
+    updateStatus, createTask, setShowCreateDialog,
   } = useTaskStore();
 
   const [localQuery, setLocalQuery] = useState(searchQuery);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => { loadTasks(); }, []);
+
+  const isSearching = searchQuery.trim().length > 0;
+  const pageStart = total === 0 ? 0 : (page - 1) * TASKS_PAGE_SIZE + 1;
+  const pageEnd = Math.min(page * TASKS_PAGE_SIZE, total);
+  const totalPages = Math.max(1, Math.ceil(total / TASKS_PAGE_SIZE));
+  const hasPrev = page > 1;
+  const hasNext = page < totalPages;
 
   const handleSearchChange = useCallback((value: string) => {
     setLocalQuery(value);
@@ -59,12 +73,28 @@ export function TasksPage() {
             )}
           </div>
         </div>
-        <button
-          onClick={() => setShowCreateDialog(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer"
-        >
-          <Plus size={14} /> New Task
-        </button>
+        <div className="flex items-center gap-2">
+          {!isSearching && (
+            <label className="flex items-center gap-1.5 text-[12px] text-text-faint">
+              Sort by
+              <select
+                value={sort}
+                onChange={e => setSort(e.target.value as TaskSort)}
+                className="px-2 py-1.5 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary focus:outline-none focus:border-accent/50 cursor-pointer"
+              >
+                {SORT_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button
+            onClick={() => setShowCreateDialog(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer"
+          >
+            <Plus size={14} /> New Task
+          </button>
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto p-6">
@@ -79,6 +109,37 @@ export function TasksPage() {
             {tasks.map(task => (
               <TaskCard key={task.id} task={task} onStatusChange={updateStatus} />
             ))}
+
+            {!isSearching && total > 0 && (
+              <div className="flex items-center justify-between pt-4 text-[12px] text-text-faint">
+                <span>
+                  Showing {pageStart}–{pageEnd} of {total}
+                </span>
+                {totalPages > 1 && (
+                  <div className="flex items-center gap-1">
+                    <button
+                      onClick={() => setPage(page - 1)}
+                      disabled={!hasPrev}
+                      className="p-1.5 rounded-md text-text-dim hover:bg-surface-raised hover:text-text-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                      aria-label="Previous page"
+                    >
+                      <ChevronLeft size={14} />
+                    </button>
+                    <span className="px-2 text-text-dim">
+                      Page {page} of {totalPages}
+                    </span>
+                    <button
+                      onClick={() => setPage(page + 1)}
+                      disabled={!hasNext}
+                      className="p-1.5 rounded-md text-text-dim hover:bg-surface-raised hover:text-text-muted disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                      aria-label="Next page"
+                    >
+                      <ChevronRight size={14} />
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/web/src/stores/taskStore.ts
+++ b/web/src/stores/taskStore.ts
@@ -13,10 +13,17 @@ export interface Task {
   content?: string;
 }
 
+export type TaskSort = 'deadline' | 'updated_at' | 'created_at';
+
+export const TASKS_PAGE_SIZE = 50;
+
 interface TaskState {
   tasks: Task[];
   filter: string;
   searchQuery: string;
+  sort: TaskSort;
+  page: number;
+  total: number;
   loading: boolean;
   showCreateDialog: boolean;
 
@@ -28,6 +35,8 @@ interface TaskState {
   loadTasks: () => Promise<void>;
   setFilter: (f: string) => void;
   setSearch: (q: string) => void;
+  setSort: (s: TaskSort) => void;
+  setPage: (p: number) => void;
   updateStatus: (id: string, status: string) => Promise<void>;
   createTask: (title: string, content: string, deadline: string) => Promise<void>;
   setShowCreateDialog: (show: boolean) => void;
@@ -41,6 +50,9 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   tasks: [],
   filter: '',
   searchQuery: '',
+  sort: 'deadline',
+  page: 1,
+  total: 0,
   loading: true,
   showCreateDialog: false,
 
@@ -49,12 +61,18 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   saving: false,
 
   loadTasks: async () => {
+    set({ loading: true });
     try {
-      const { filter, searchQuery } = get();
-      const { tasks } = searchQuery
+      const { filter, searchQuery, sort, page } = get();
+      const result = searchQuery
         ? await api.searchTasks(searchQuery, filter || undefined)
-        : await api.listTasks(filter || undefined);
-      set({ tasks, loading: false });
+        : await api.listTasks({
+            status: filter || undefined,
+            sort,
+            limit: TASKS_PAGE_SIZE,
+            offset: (page - 1) * TASKS_PAGE_SIZE,
+          });
+      set({ tasks: result.tasks, total: result.total ?? result.tasks.length, loading: false });
     } catch (e) {
       console.error('Failed to load tasks:', e);
       set({ loading: false });
@@ -62,12 +80,22 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   },
 
   setFilter: (f: string) => {
-    set({ filter: f });
+    set({ filter: f, page: 1 });
     get().loadTasks();
   },
 
   setSearch: (q: string) => {
-    set({ searchQuery: q });
+    set({ searchQuery: q, page: 1 });
+    get().loadTasks();
+  },
+
+  setSort: (s: TaskSort) => {
+    set({ sort: s, page: 1 });
+    get().loadTasks();
+  },
+
+  setPage: (p: number) => {
+    set({ page: Math.max(1, p) });
     get().loadTasks();
   },
 
@@ -83,7 +111,7 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   createTask: async (title: string, content: string, deadline: string) => {
     await api.createTask({ title, content, deadline });
-    set({ showCreateDialog: false });
+    set({ showCreateDialog: false, page: 1 });
     get().loadTasks();
   },
 

--- a/web/src/utils/dateGroups.ts
+++ b/web/src/utils/dateGroups.ts
@@ -40,6 +40,25 @@ export function getDateGroup(updatedAt: string): string {
 }
 
 /**
+ * Compact relative-time formatter for inline labels: "2m ago", "3h ago", "5d ago".
+ * Falls back to a short date for anything older than ~30 days.
+ */
+export function formatTimeAgo(input: string): string {
+  if (!input) return '';
+  const date = new Date(input.includes('T') ? input : input.replace(' ', 'T') + 'Z');
+  const diffMs = Date.now() - date.getTime();
+  if (diffMs < 0) return 'just now';
+  const minutes = Math.floor(diffMs / 60000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
  * Group items by date label. Preserves the order items arrive in
  * (most-recent-first from the API), so groups appear top-to-bottom
  * from newest to oldest without needing a hardcoded order list.


### PR DESCRIPTION
Two small UX improvements landing on one branch.

## 1. Plan decline moves task to done

Declining a plan now moves the related task to the `done/` directory with a note. Previously the task was left in `pending` status while the plan transitioned to `declined` — leaving an orphan task that had to be closed manually.

- **UI:** the Decline button expands an optional feedback textarea mirroring the existing Revise flow. A *Confirm Decline* button submits the action; the feedback is optional.
- **Backend:** both `PATCH /api/plans/{id}` and the `plan_decline` MCP tool route through `task_done` so file movement and DB status stay consistent across surfaces.
- **Note text:**
  - With feedback → `Plan {id} declined — {feedback}`
  - Without feedback → `Related plan {id} was closed without a specified reason`

## 2. Tasks page sort + pagination

- Three sort orders: **Deadline** (default), **Last update**, **Created**.
- 50-per-page pagination with prev/next controls and a `Showing X–Y of N` indicator.
- Sort/page reset to defaults when the filter/search/status changes.
- `list_tasks` gains `sort` and `offset` kwargs; new `count_tasks` helper returns the total ignoring pagination.
- A stable secondary key (`id DESC`) is appended to every ORDER BY so equal timestamps don't shuffle between pages.
- Each task card now shows a compact `updated 2h ago` label — makes the Last update sort visually meaningful.
- Search is **not paginated** — it returns the top 100 BM25-ranked hits and the pagination row is hidden, since slicing relevance results across pages fights the ranking.

## Verification

- `pytest tests/ -v` → **542 passed** (added one test covering sort orders, pagination slicing, and `count_tasks`).
- `npm run build` clean.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*