### PR TITLE
fix(plans): /revise route now dispatches plan_update prompt

### DIFF
--- a/nerve/agent/plan_service.py
+++ b/nerve/agent/plan_service.py
@@ -1,0 +1,156 @@
+"""Shared plan-revision dispatch logic.
+
+Both the HTTP route ``/api/plans/{plan_id}/revise`` and the MCP tool
+``plan_revise`` need to do the same thing: validate the plan, persist
+feedback, write a task note, and dispatch a revision prompt to the
+planner session. The prompt instructs the planner to call ``plan_update``
+(in-place revision), not ``plan_propose`` — the latter refuses when a
+pending plan already exists for the task, which is precisely the
+situation here.
+
+Keeping this in one place prevents the two surfaces from drifting
+apart again. The HTTP route translates the exceptions raised here into
+HTTP status codes; the MCP tool translates them into user-facing text.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nerve.agent.engine import AgentEngine
+    from nerve.db import Database
+
+logger = logging.getLogger(__name__)
+
+
+_FALLBACK_PLANNER_SESSION = "cron:task-planner"
+
+
+# The prompt template lives here so future tweaks (model selection,
+# wording, calling conventions) happen in exactly one place.
+_REVISION_PROMPT_TEMPLATE = (
+    'Revise plan {plan_id} for task "{task_title}" based on this feedback:\n\n'
+    "{feedback}\n\n"
+    "Explore the codebase again if needed, then call "
+    'plan_update(plan_id="{plan_id}", content="...", feedback="<short summary>") '
+    "with the revised plan."
+)
+
+
+class PlanNotFound(Exception):
+    """The plan_id does not exist."""
+
+
+class TaskNotFound(Exception):
+    """The plan exists but its task is missing."""
+
+
+class PlanNotPending(Exception):
+    """The plan exists but is not in 'pending' status — cannot be revised."""
+
+
+async def request_plan_revision(
+    db: "Database",
+    engine: "AgentEngine",
+    plan_id: str,
+    feedback: str,
+) -> dict:
+    """Persist revision feedback and dispatch a revision prompt to the planner.
+
+    Args:
+        db: Database instance (used for plan/task lookups + updates).
+        engine: AgentEngine instance (used to ensure session + dispatch run).
+        plan_id: The pending plan to revise.
+        feedback: Free-text feedback explaining what should change.
+
+    Returns:
+        ``{"plan_id", "task_id", "session_id", "status"}`` on success.
+
+    Raises:
+        PlanNotFound: No plan with that ID.
+        TaskNotFound: The plan's task no longer exists.
+        PlanNotPending: The plan is declined/superseded/implementing/etc.
+
+    Behavior contract:
+        - Stores ``feedback`` on the plan (status untouched — old plan
+          stays ``pending`` until the planner calls ``plan_update``).
+        - Writes a ``Revision requested for {plan_id}`` note to the task.
+        - Dispatches ``engine.run()`` on the original proposer session
+          (``plan.session_id``), falling back to ``cron:task-planner``
+          if the proposer is unknown/deleted.
+        - The planner is instructed to call
+          ``plan_update(plan_id=..., content=..., feedback=<summary>)``
+          so version history stays linked.
+    """
+    # Import here to avoid a circular import: tools.py imports plan_service
+    # indirectly via the engine wiring.
+    from nerve.agent.tools import task_update as task_update_tool
+
+    feedback = feedback.strip()
+    if not feedback:
+        # Treat empty feedback as a programmer error — both callers
+        # validate this upstream, but defend the helper anyway.
+        raise ValueError("Feedback is required for revision requests.")
+
+    plan = await db.get_plan(plan_id)
+    if not plan:
+        raise PlanNotFound(f"Plan not found: {plan_id}")
+
+    if plan["status"] != "pending":
+        raise PlanNotPending(
+            f"Plan is '{plan['status']}' — only pending plans can be revised."
+        )
+
+    task = await db.get_task(plan["task_id"])
+    if not task:
+        raise TaskNotFound(f"Task not found for plan {plan_id}: {plan['task_id']}")
+
+    # 1. Store feedback on the plan (status stays pending until planner
+    #    supersedes it via plan_update).
+    await db.update_plan(plan_id, feedback=feedback)
+
+    # 2. Write a task note so the revision request is visible in the
+    #    task's history.
+    feedback_summary = feedback[:80] + "..." if len(feedback) > 80 else feedback
+    await task_update_tool.handler({
+        "task_id": plan["task_id"],
+        "note": f"Revision requested for {plan_id}: {feedback_summary}",
+    })
+
+    # 3. Build the revision prompt from the shared template.
+    prompt = _REVISION_PROMPT_TEMPLATE.format(
+        plan_id=plan_id,
+        task_title=task["title"],
+        feedback=feedback,
+    )
+
+    # 4. Route the prompt back to the original proposer session.
+    #    Fall back to the cron planner if the plan was created without
+    #    a session attribution (older rows, manual inserts, etc.).
+    session_id = plan.get("session_id") or _FALLBACK_PLANNER_SESSION
+    session_title = (
+        f"Cron: {session_id.split(':')[-1]}"
+        if session_id.startswith("cron:")
+        else session_id
+    )
+    await engine.sessions.get_or_create(
+        session_id, title=session_title, source="cron",
+    )
+    asyncio.create_task(
+        engine.run(session_id=session_id, user_message=prompt, source="cron")
+    )
+
+    logger.info(
+        "Revision dispatched: plan=%s task=%s session=%s",
+        plan_id, plan["task_id"], session_id,
+    )
+
+    return {
+        "plan_id": plan_id,
+        "task_id": plan["task_id"],
+        "session_id": session_id,
+        "status": "revision_requested",
+    }

--- a/nerve/agent/tools.py
+++ b/nerve/agent/tools.py
@@ -1479,7 +1479,12 @@ async def plan_decline(args: dict) -> dict:
     },
 )
 async def plan_revise(args: dict) -> dict:
-    import asyncio
+    from nerve.agent.plan_service import (
+        PlanNotFound,
+        PlanNotPending,
+        TaskNotFound,
+        request_plan_revision,
+    )
 
     plan_id = args["plan_id"]
     feedback = (args.get("feedback", "") or "").strip()
@@ -1491,48 +1496,18 @@ async def plan_revise(args: dict) -> dict:
     if not feedback:
         return {"content": [{"type": "text", "text": "Feedback is required for revision requests."}]}
 
-    plan = await _db.get_plan(plan_id)
-    if not plan:
+    try:
+        result = await request_plan_revision(
+            db=_db, engine=_engine, plan_id=plan_id, feedback=feedback,
+        )
+    except PlanNotFound:
         return {"content": [{"type": "text", "text": f"Plan not found: {plan_id}"}]}
+    except TaskNotFound:
+        return {"content": [{"type": "text", "text": "Task not found for this plan."}]}
+    except PlanNotPending as exc:
+        return {"content": [{"type": "text", "text": str(exc)}]}
 
-    if plan["status"] != "pending":
-        return {"content": [{"type": "text", "text": f"Plan is '{plan['status']}' — only pending plans can be revised."}]}
-
-    task = await _db.get_task(plan["task_id"])
-    if not task:
-        return {"content": [{"type": "text", "text": f"Task not found: {plan['task_id']}"}]}
-
-    # Store feedback on the plan
-    await _db.update_plan(plan_id, feedback=feedback)
-
-    # Write task note
-    feedback_summary = feedback[:80] + "..." if len(feedback) > 80 else feedback
-    await task_update.handler({
-        "task_id": plan["task_id"],
-        "note": f"Revision requested for {plan_id}: {feedback_summary}",
-    })
-
-    # Send revision request to persistent planner session.
-    # Tell the planner to update the existing plan in-place via plan_update
-    # so the version history stays linked instead of producing an orphan via
-    # plan_propose.
-    feedback_prompt = (
-        f'Revise plan {plan_id} for task "{task["title"]}" based on this feedback:\n\n'
-        f"{feedback}\n\n"
-        f"Explore the codebase again if needed, then call "
-        f'plan_update(plan_id="{plan_id}", content="...", feedback="<short summary>") '
-        f"with the revised plan."
-    )
-
-    session_id = plan.get("session_id") or "cron:task-planner"
-    await _engine.sessions.get_or_create(
-        session_id, title=f"Cron: {session_id.split(':')[-1]}" if session_id.startswith("cron:") else session_id, source="cron",
-    )
-    asyncio.create_task(
-        _engine.run(session_id=session_id, user_message=feedback_prompt, source="cron")
-    )
-
-    return {"content": [{"type": "text", "text": f"Revision requested for {plan_id}. Feedback sent to planner session ({session_id})."}]}
+    return {"content": [{"type": "text", "text": f"Revision requested for {result['plan_id']}. Feedback sent to planner session ({result['session_id']})."}]}
 
 
 # --- Skill tools ---

--- a/nerve/gateway/routes/plans.py
+++ b/nerve/gateway/routes/plans.py
@@ -10,6 +10,12 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from nerve.agent.plan_service import (
+    PlanNotFound,
+    PlanNotPending,
+    TaskNotFound,
+    request_plan_revision,
+)
 from nerve.config import get_config
 from nerve.gateway.auth import require_auth
 from nerve.gateway.routes._deps import get_deps
@@ -89,43 +95,31 @@ async def update_plan(plan_id: str, req: PlanUpdateRequest, user: dict = Depends
 
 @router.post("/api/plans/{plan_id}/revise")
 async def revise_plan(plan_id: str, req: PlanReviseRequest, user: dict = Depends(require_auth)):
-    """Send revision feedback to the persistent planner session."""
+    """Send revision feedback to the persistent planner session.
+
+    Thin wrapper around ``request_plan_revision`` — the shared helper
+    handles validation, persistence, and dispatch. Errors are mapped to
+    HTTP status codes so the UI can surface meaningful messages instead
+    of silently dropping non-pending revision attempts.
+    """
+    if not req.feedback.strip():
+        raise HTTPException(status_code=400, detail="Feedback is required")
+
     deps = get_deps()
-    plan = await deps.db.get_plan(plan_id)
-    if not plan:
+    try:
+        result = await request_plan_revision(
+            db=deps.db,
+            engine=deps.engine,
+            plan_id=plan_id,
+            feedback=req.feedback,
+        )
+    except PlanNotFound:
         raise HTTPException(status_code=404, detail="Plan not found")
-    task = await deps.db.get_task(plan["task_id"])
-    if not task:
+    except TaskNotFound:
         raise HTTPException(status_code=404, detail="Task not found")
-
-    # Store feedback on the plan
-    await deps.db.update_plan(plan_id, feedback=req.feedback)
-
-    # Write task note
-    from nerve.agent.tools import task_update as task_update_tool
-    feedback_summary = req.feedback[:80] + "..." if len(req.feedback) > 80 else req.feedback
-    await task_update_tool.handler({
-        "task_id": plan["task_id"],
-        "note": f"Revision requested for {plan_id}: {feedback_summary}",
-    })
-
-    # Send revision request to the persistent planner session
-    feedback_prompt = (
-        f'Revise plan {plan_id} for task "{task["title"]}" based on this feedback:\n\n'
-        f"{req.feedback}\n\n"
-        f"Explore the codebase again if needed, then call "
-        f'plan_propose(task_id="{plan["task_id"]}", content="...") with the revised plan.'
-    )
-
-    session_id = plan.get("session_id") or "cron:task-planner"
-    # Ensure the session exists — route feedback to the original proposer
-    await deps.engine.sessions.get_or_create(
-        session_id, title=f"Cron: {session_id.split(':')[-1]}" if session_id.startswith("cron:") else session_id, source="cron",
-    )
-    asyncio.create_task(
-        deps.engine.run(session_id=session_id, user_message=feedback_prompt, source="cron")
-    )
-    return {"plan_id": plan_id, "status": "revision_requested"}
+    except PlanNotPending as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    return result
 
 
 @router.post("/api/plans/{plan_id}/approve")

--- a/tests/test_plan_revise.py
+++ b/tests/test_plan_revise.py
@@ -1,0 +1,386 @@
+"""Tests for the shared plan-revision helper (``nerve.agent.plan_service``).
+
+Covers both the MCP ``plan_revise`` tool and the HTTP
+``/api/plans/{plan_id}/revise`` route, since both surfaces delegate to
+the same helper. The bug that motivated this module: the HTTP route
+used to instruct the planner to call ``plan_propose`` — which now
+refuses when a pending plan already exists — silently no-op'ing every
+UI revise click. These tests pin the behaviour so the divergence can't
+come back.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from nerve.agent import tools as tools_mod
+from nerve.agent.plan_service import (
+    PlanNotFound,
+    PlanNotPending,
+    TaskNotFound,
+    request_plan_revision,
+)
+from nerve.db import Database
+
+
+class FakeSessionManager:
+    """Records get_or_create calls so tests can assert routing decisions."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def get_or_create(
+        self,
+        session_id: str,
+        title: str | None = None,
+        source: str = "web",
+        metadata: dict | None = None,
+    ) -> dict:
+        self.calls.append({
+            "session_id": session_id,
+            "title": title,
+            "source": source,
+        })
+        return {"id": session_id, "title": title or session_id, "source": source}
+
+
+class FakeEngine:
+    """Mimics AgentEngine.run + .sessions for revision dispatch tests."""
+
+    def __init__(self) -> None:
+        self.sessions = FakeSessionManager()
+        self.runs: list[dict[str, Any]] = []
+        # Event flipped after every run() call so tests can await
+        # dispatch deterministically instead of sleeping.
+        self.run_event = asyncio.Event()
+
+    async def run(
+        self,
+        session_id: str,
+        user_message: str,
+        source: str = "web",
+    ) -> None:
+        self.runs.append({
+            "session_id": session_id,
+            "user_message": user_message,
+            "source": source,
+        })
+        self.run_event.set()
+
+
+async def _setup(db: Database, tmp_path) -> tuple[FakeEngine, str]:
+    """Create a task on disk + DB and a pending plan, then wire tools."""
+    task_id = "t-revise"
+    file_path = "task.md"
+    task_md = tmp_path / file_path
+    task_md.write_text("# Demo task\n\nBody.\n", encoding="utf-8")
+
+    await db.upsert_task(
+        task_id=task_id, file_path=file_path, title="Demo task",
+        status="pending", content=task_md.read_text(),
+    )
+    await db.create_plan(
+        plan_id="plan-orig", task_id=task_id, content="v1 plan",
+        session_id="sess-proposer", version=1, plan_type="generic",
+    )
+
+    engine = FakeEngine()
+    tools_mod.init_tools(workspace=tmp_path, db=db, engine=engine)
+    return engine, task_id
+
+
+@pytest.mark.asyncio
+class TestRequestPlanRevision:
+    """The shared helper exposes a single behaviour contract — verify it."""
+
+    async def test_dispatches_plan_update_prompt(self, db: Database, tmp_path):
+        """The bug fix: planner is told to call plan_update, NOT plan_propose."""
+        engine, _ = await _setup(db, tmp_path)
+
+        result = await request_plan_revision(
+            db=db, engine=engine,
+            plan_id="plan-orig", feedback="be more specific about edge cases",
+        )
+
+        # Wait for the background dispatch task to actually call engine.run.
+        await asyncio.wait_for(engine.run_event.wait(), timeout=1.0)
+
+        assert result["plan_id"] == "plan-orig"
+        assert result["task_id"] == "t-revise"
+        assert result["status"] == "revision_requested"
+
+        assert len(engine.runs) == 1
+        prompt = engine.runs[0]["user_message"]
+        # Crucial: plan_update with the plan_id, NOT plan_propose with the task_id.
+        assert 'plan_update(plan_id="plan-orig"' in prompt
+        assert "plan_propose(" not in prompt
+        # Feedback is embedded verbatim.
+        assert "be more specific about edge cases" in prompt
+
+    async def test_stores_feedback_and_writes_task_note(self, db: Database, tmp_path):
+        engine, task_id = await _setup(db, tmp_path)
+
+        await request_plan_revision(
+            db=db, engine=engine,
+            plan_id="plan-orig", feedback="needs more tests",
+        )
+        await asyncio.wait_for(engine.run_event.wait(), timeout=1.0)
+
+        # Feedback persisted on the plan; plan stays pending until the
+        # planner supersedes it via plan_update.
+        plan = await db.get_plan("plan-orig")
+        assert plan["feedback"] == "needs more tests"
+        assert plan["status"] == "pending"
+
+        # Task markdown got a revision note appended.
+        task = await db.get_task(task_id)
+        task_md = tmp_path / task["file_path"]
+        body = task_md.read_text(encoding="utf-8")
+        assert "Revision requested for plan-orig" in body
+        assert "needs more tests" in body
+
+    async def test_routes_to_proposer_session(self, db: Database, tmp_path):
+        engine, _ = await _setup(db, tmp_path)
+
+        await request_plan_revision(
+            db=db, engine=engine,
+            plan_id="plan-orig", feedback="rev",
+        )
+        await asyncio.wait_for(engine.run_event.wait(), timeout=1.0)
+
+        # The plan recorded session_id="sess-proposer" at creation — dispatch
+        # must route the feedback there, not to the cron fallback.
+        assert engine.runs[0]["session_id"] == "sess-proposer"
+        assert engine.sessions.calls[0]["session_id"] == "sess-proposer"
+
+    async def test_falls_back_to_cron_planner_when_session_unknown(
+        self, db: Database, tmp_path,
+    ):
+        """Plans without a proposer session (older rows, manual inserts)
+        should route to the cron planner so revisions don't silently drop."""
+        await _setup(db, tmp_path)
+        # Null out session_id to simulate a legacy plan.
+        await db.update_plan("plan-orig", session_id=None)
+        engine = FakeEngine()
+        tools_mod.init_tools(workspace=tmp_path, db=db, engine=engine)
+
+        await request_plan_revision(
+            db=db, engine=engine,
+            plan_id="plan-orig", feedback="rev",
+        )
+        await asyncio.wait_for(engine.run_event.wait(), timeout=1.0)
+
+        assert engine.runs[0]["session_id"] == "cron:task-planner"
+        # The fallback session should be created with a friendly title.
+        assert engine.sessions.calls[0]["title"] == "Cron: task-planner"
+
+    async def test_refuses_non_pending_plan(self, db: Database, tmp_path):
+        engine, _ = await _setup(db, tmp_path)
+        await db.update_plan("plan-orig", status="declined")
+
+        with pytest.raises(PlanNotPending):
+            await request_plan_revision(
+                db=db, engine=engine,
+                plan_id="plan-orig", feedback="rev",
+            )
+        # Nothing should have been dispatched.
+        assert engine.runs == []
+
+    async def test_refuses_superseded_plan(self, db: Database, tmp_path):
+        """A plan already replaced by plan_update can't be revised again."""
+        engine, _ = await _setup(db, tmp_path)
+        await db.update_plan("plan-orig", status="superseded")
+
+        with pytest.raises(PlanNotPending):
+            await request_plan_revision(
+                db=db, engine=engine,
+                plan_id="plan-orig", feedback="rev",
+            )
+
+    async def test_raises_plan_not_found(self, db: Database, tmp_path):
+        engine, _ = await _setup(db, tmp_path)
+
+        with pytest.raises(PlanNotFound):
+            await request_plan_revision(
+                db=db, engine=engine,
+                plan_id="plan-does-not-exist", feedback="rev",
+            )
+        assert engine.runs == []
+
+    async def test_raises_task_not_found(self, db: Database, tmp_path):
+        """If the underlying task was deleted out from under the plan, surface it."""
+        engine, _ = await _setup(db, tmp_path)
+        # Delete the task row directly — simulates an orphaned plan.
+        await db.db.execute("DELETE FROM tasks WHERE id = ?", ("t-revise",))
+        await db.db.commit()
+
+        with pytest.raises(TaskNotFound):
+            await request_plan_revision(
+                db=db, engine=engine,
+                plan_id="plan-orig", feedback="rev",
+            )
+        assert engine.runs == []
+
+    async def test_empty_feedback_raises_value_error(self, db: Database, tmp_path):
+        engine, _ = await _setup(db, tmp_path)
+
+        with pytest.raises(ValueError):
+            await request_plan_revision(
+                db=db, engine=engine,
+                plan_id="plan-orig", feedback="   ",
+            )
+
+
+@pytest.mark.asyncio
+class TestPlanReviseTool:
+    """The MCP plan_revise tool is now a thin wrapper — verify the shape
+    contracts the agents depend on are still intact."""
+
+    async def test_tool_dispatches_plan_update_prompt(self, db: Database, tmp_path):
+        from nerve.agent.tools import plan_revise
+
+        engine, _ = await _setup(db, tmp_path)
+
+        result = await plan_revise.handler({
+            "plan_id": "plan-orig",
+            "feedback": "tighten the test plan",
+        })
+        await asyncio.wait_for(engine.run_event.wait(), timeout=1.0)
+
+        text = result["content"][0]["text"]
+        assert "Revision requested for plan-orig" in text
+        assert "sess-proposer" in text  # routed to original proposer
+        assert 'plan_update(plan_id="plan-orig"' in engine.runs[0]["user_message"]
+
+    async def test_tool_returns_text_on_missing_plan(self, db: Database, tmp_path):
+        from nerve.agent.tools import plan_revise
+
+        engine, _ = await _setup(db, tmp_path)
+
+        result = await plan_revise.handler({
+            "plan_id": "plan-missing",
+            "feedback": "rev",
+        })
+        text = result["content"][0]["text"]
+        assert "Plan not found" in text
+        assert engine.runs == []
+
+    async def test_tool_returns_text_on_non_pending(self, db: Database, tmp_path):
+        from nerve.agent.tools import plan_revise
+
+        engine, _ = await _setup(db, tmp_path)
+        await db.update_plan("plan-orig", status="declined")
+
+        result = await plan_revise.handler({
+            "plan_id": "plan-orig",
+            "feedback": "rev",
+        })
+        text = result["content"][0]["text"]
+        assert "declined" in text
+        assert "only pending" in text
+        assert engine.runs == []
+
+    async def test_tool_rejects_empty_feedback(self, db: Database, tmp_path):
+        from nerve.agent.tools import plan_revise
+
+        engine, _ = await _setup(db, tmp_path)
+
+        result = await plan_revise.handler({
+            "plan_id": "plan-orig",
+            "feedback": "   ",
+        })
+        text = result["content"][0]["text"]
+        assert "required" in text.lower()
+        assert engine.runs == []
+
+
+@pytest.mark.asyncio
+class TestHttpReviseRoute:
+    """End-to-end check that the FastAPI route maps helper exceptions
+    to the right status codes and dispatches the same plan_update prompt."""
+
+    @pytest_asyncio.fixture
+    async def app_setup(self, db: Database, tmp_path):
+        """Build a minimal FastAPI app wired to a fake engine + this DB.
+
+        We bypass auth (no jwt_secret) and use TestClient for sync HTTP.
+        """
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from nerve.config import NerveConfig
+        from nerve.gateway.routes._deps import init_deps
+        from nerve.gateway.routes.plans import router as plans_router
+
+        # Auth dependency reads get_config().auth.jwt_secret — set up a
+        # config with no secret so require_auth is a no-op.
+        import nerve.config as cfg_mod
+        cfg = NerveConfig()
+        cfg.workspace = tmp_path
+        cfg.auth.jwt_secret = ""
+        cfg_mod._config = cfg
+
+        engine, task_id = await _setup(db, tmp_path)
+        init_deps(engine=engine, db=db)  # type: ignore[arg-type]
+
+        app = FastAPI()
+        app.include_router(plans_router)
+        client = TestClient(app)
+
+        yield SimpleNamespace(client=client, engine=engine, db=db, task_id=task_id)
+
+        cfg_mod._config = None  # leave global state clean for other tests
+
+    async def test_revise_returns_409_for_declined_plan(self, app_setup):
+        await app_setup.db.update_plan("plan-orig", status="declined")
+
+        resp = app_setup.client.post(
+            "/api/plans/plan-orig/revise",
+            json={"feedback": "should fail with 409"},
+        )
+        assert resp.status_code == 409
+        assert "declined" in resp.json()["detail"]
+        assert app_setup.engine.runs == []
+
+    async def test_revise_returns_404_for_unknown_plan(self, app_setup):
+        resp = app_setup.client.post(
+            "/api/plans/plan-missing/revise",
+            json={"feedback": "rev"},
+        )
+        assert resp.status_code == 404
+        assert app_setup.engine.runs == []
+
+    async def test_revise_returns_400_for_empty_feedback(self, app_setup):
+        resp = app_setup.client.post(
+            "/api/plans/plan-orig/revise",
+            json={"feedback": "   "},
+        )
+        assert resp.status_code == 400
+        assert app_setup.engine.runs == []
+
+    async def test_revise_dispatches_plan_update_prompt(self, app_setup):
+        resp = app_setup.client.post(
+            "/api/plans/plan-orig/revise",
+            json={"feedback": "smoke test"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["plan_id"] == "plan-orig"
+        assert body["session_id"] == "sess-proposer"
+        assert body["status"] == "revision_requested"
+
+        # The dispatch happens via asyncio.create_task inside the helper
+        # — TestClient runs the request synchronously but the engine.run
+        # task still completes on the same event loop before TestClient
+        # tears it down. Wait for the event to be safe.
+        await asyncio.wait_for(app_setup.engine.run_event.wait(), timeout=1.0)
+
+        assert len(app_setup.engine.runs) == 1
+        prompt = app_setup.engine.runs[0]["user_message"]
+        assert 'plan_update(plan_id="plan-orig"' in prompt
+        assert "plan_propose(" not in prompt

--- a/web/src/pages/PlanDetailPage.tsx
+++ b/web/src/pages/PlanDetailPage.tsx
@@ -30,7 +30,18 @@ interface HoaStatus {
 export function PlanDetailPage() {
   const { planId } = useParams<{ planId: string }>();
   const navigate = useNavigate();
-  const { selectedPlan: plan, detailLoading, actionLoading, loadPlan, updatePlan, approvePlan, revisePlan, clearSelectedPlan } = usePlanStore();
+  const {
+    selectedPlan: plan,
+    detailLoading,
+    actionLoading,
+    actionError,
+    loadPlan,
+    updatePlan,
+    approvePlan,
+    revisePlan,
+    clearActionError,
+    clearSelectedPlan,
+  } = usePlanStore();
   const [feedback, setFeedback] = useState('');
   const [showFeedback, setShowFeedback] = useState(false);
   const [declineFeedback, setDeclineFeedback] = useState('');
@@ -88,9 +99,10 @@ export function PlanDetailPage() {
     setShowDeclineFeedback(false);
   };
 
-  const handleRevise = () => {
-    if (feedback.trim()) {
-      revisePlan(plan.id, feedback.trim());
+  const handleRevise = async () => {
+    if (!feedback.trim()) return;
+    const ok = await revisePlan(plan.id, feedback.trim());
+    if (ok) {
       setFeedback('');
       setShowFeedback(false);
     }
@@ -267,7 +279,10 @@ export function PlanDetailPage() {
                     <div className="flex-1 pl-3">
                       <textarea
                         value={feedback}
-                        onChange={e => setFeedback(e.target.value)}
+                        onChange={e => {
+                          setFeedback(e.target.value);
+                          if (actionError) clearActionError();
+                        }}
                         placeholder="Describe what to change..."
                         className="w-full p-3 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary placeholder:text-placeholder focus:outline-none focus:border-accent/50 resize-none"
                         rows={3}
@@ -275,6 +290,12 @@ export function PlanDetailPage() {
                       />
                     </div>
                   </div>
+                  {actionError && (
+                    <div className="flex gap-0">
+                      <div className="w-1 bg-red-500/40 rounded-full shrink-0" />
+                      <div className="pl-3 py-1 text-[12px] text-hue-red">{actionError}</div>
+                    </div>
+                  )}
                   <div className="flex justify-end">
                     <button
                       onClick={handleRevise}

--- a/web/src/stores/planStore.ts
+++ b/web/src/stores/planStore.ts
@@ -25,14 +25,35 @@ interface PlanState {
   loading: boolean;
   detailLoading: boolean;
   actionLoading: boolean;
+  actionError: string | null;
 
   loadPlans: () => Promise<void>;
   setFilter: (f: string) => void;
   loadPlan: (id: string) => Promise<void>;
   updatePlan: (id: string, status: string, feedback?: string) => Promise<void>;
   approvePlan: (id: string, options?: { runtime?: string; hoa_mode?: string; hoa_agents?: string[]; hoa_pipeline_id?: string }) => Promise<{ impl_session_id: string } | null>;
-  revisePlan: (id: string, feedback: string) => Promise<void>;
+  revisePlan: (id: string, feedback: string) => Promise<boolean>;
+  clearActionError: () => void;
   clearSelectedPlan: () => void;
+}
+
+// Extract a user-friendly message out of an Error thrown by api/client.
+// The client formats non-2xx responses as `${status}: ${body}` where the
+// body is FastAPI's JSON error object. Strip that wrapping so we can show
+// the `detail` string instead of raw JSON.
+function extractErrorMessage(err: unknown, fallback: string): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const match = raw.match(/^\d+:\s*(.*)$/s);
+  const body = match ? match[1] : raw;
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed === 'object' && typeof parsed.detail === 'string') {
+      return parsed.detail;
+    }
+  } catch {
+    // Not JSON — fall through and use the body as-is.
+  }
+  return body || fallback;
 }
 
 export const usePlanStore = create<PlanState>((set, get) => ({
@@ -42,6 +63,7 @@ export const usePlanStore = create<PlanState>((set, get) => ({
   loading: true,
   detailLoading: false,
   actionLoading: false,
+  actionError: null,
 
   loadPlans: async () => {
     try {
@@ -107,19 +129,23 @@ export const usePlanStore = create<PlanState>((set, get) => ({
   },
 
   revisePlan: async (id: string, feedback: string) => {
-    set({ actionLoading: true });
+    set({ actionLoading: true, actionError: null });
     try {
       await api.revisePlan(id, feedback);
       const sel = get().selectedPlan;
       if (sel && sel.id === id) {
         set({ selectedPlan: { ...sel, feedback } });
       }
+      return true;
     } catch (e) {
       console.error('Failed to request revision:', e);
+      set({ actionError: extractErrorMessage(e, 'Failed to request revision') });
+      return false;
     } finally {
       set({ actionLoading: false });
     }
   },
 
-  clearSelectedPlan: () => set({ selectedPlan: null }),
+  clearActionError: () => set({ actionError: null }),
+  clearSelectedPlan: () => set({ selectedPlan: null, actionError: null }),
 }));


### PR DESCRIPTION
## Summary

The web UI's **Revise** button silently no-op'd. The HTTP route `/api/plans/{plan_id}/revise` still instructed the planner to call `plan_propose`, which now refuses with *\"Task X already has a pending or implementing plan. Skip it.\"* whenever a pending plan exists for the task — i.e. every revise attempt. The request returned `200 {\"status\": \"revision_requested\"}`, so the failure was invisible.

Fix: dispatch the `plan_update` prompt (mirroring the MCP `plan_revise` tool) and extract a shared `request_plan_revision()` helper so the two surfaces can't drift apart again.

## Changes

- **New** `nerve/agent/plan_service.py` — single source of truth for revision dispatch. Exposes `request_plan_revision(db, engine, plan_id, feedback)` plus `PlanNotFound` / `TaskNotFound` / `PlanNotPending` exceptions. Prompt template is a module-level constant.
- **HTTP route** `nerve/gateway/routes/plans.py` — thin wrapper around the helper; maps exceptions to **400** (empty feedback), **404** (plan/task missing), **409** (non-pending). Previously every error path returned 200 with feedback silently stored on the plan.
- **MCP tool** `nerve/agent/tools.py::plan_revise` — same thin-wrapper treatment.
- **Frontend** — `planStore.revisePlan` now returns `Promise<boolean>`, sets `actionError` on failure, and parses FastAPI's `{detail: ...}` JSON envelope. `PlanDetailPage` renders the error inline next to the textarea; the form only collapses on success.

## Test plan

- [x] `tests/test_plan_revise.py` — 17 new tests covering the helper (prompt content, feedback persistence, session routing, fallback to `cron:task-planner`, all three exceptions, empty-feedback ValueError), the MCP tool wrapper, and the HTTP route via FastAPI `TestClient`.
- [x] Full suite green: 564 passed in 33s
- [x] `npm run build` clean
- [ ] Manual smoke test post-merge against one of the 85 pending plans:
  ```bash
  curl -X POST http://localhost:8900/api/plans/<some-pending-plan>/revise \
       -H \"Content-Type: application/json\" \
       -d '{\"feedback\":\"smoke test — be more specific about edge cases\"}'
  # Expect: original plan superseded + v2 pending within ~60s
  ```

## Out of scope

The dead supersede-loop in `_plan_propose_impl` (`tools.py:1131-1133`) is now unreachable from the revise path. Harmless dead code; separate cleanup PR.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*