### PR TITLE
web: rename Inbox nav label to Sources and surface Notifs higher

### DIFF
--- a/web/src/components/Layout/NavRail.tsx
+++ b/web/src/components/Layout/NavRail.tsx
@@ -9,14 +9,14 @@ import { ThemeToggle } from './ThemeToggle';
 
 const NAV_ITEMS = [
   { path: '/chat', icon: MessageSquare, label: 'Chat' },
+  { path: '/notifications', icon: Bell, label: 'Notifs' },
   { path: '/files', icon: FolderOpen, label: 'Files' },
   { path: '/tasks', icon: CheckSquare, label: 'Tasks' },
   { path: '/plans', icon: Lightbulb, label: 'Plans' },
   { path: '/skills', icon: Sparkles, label: 'Skills' },
   { path: '/mcp', icon: Plug, label: 'MCP' },
   { path: '/houseofagents', icon: Users, label: 'HoA', feature: 'hoa' as const },
-  { path: '/notifications', icon: Bell, label: 'Notifs' },
-  { path: '/sources', icon: Inbox, label: 'Inbox' },
+  { path: '/sources', icon: Inbox, label: 'Sources' },
   { path: '/cron', icon: Clock, label: 'Cron' },
   { path: '/memory', icon: Brain, label: 'Memory' },
   { path: '/diagnostics', icon: Activity, label: 'Diag' },


### PR DESCRIPTION
## Summary

- Rename the `/sources` nav rail label from "Inbox" to "Sources".
  The route shows raw sync-source feeds (Gmail, GitHub, Telegram)
  and the URL already matches. The "Inbox" label collided with the
  notifications inbox concept at `/notifications`, which made the
  rail harder to read at a glance.
- Move the Notifs item next to Chat so the actionable surface sits
  at the top of the rail.

## Test plan

- [x] `cd web && npm run build` clean (vite + tsc).
- [x] Verified manually that the badge logic on Notifs still works
      (the `isNotifs` check is keyed on `path === '/notifications'`,
      not the label or position).
- [ ] Visual check on the running daemon: rail shows "Notifs" next
      to Chat, "Sources" lower with the Inbox icon, no other
      changes.