### PR TITLE
install.sh: bump Node minimum to v20.19 to match Vite 7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,8 @@ NERVE_BRANCH="${NERVE_BRANCH:-main}"
 INSTALL_DIR="${NERVE_INSTALL_DIR:-$HOME/nerve}"
 MIN_PYTHON_MINOR=12
 PREFERRED_PYTHON_MINOR=13
-MIN_NODE_MAJOR=18
+# Vite 7 (see web/package.json) requires Node 20.19+ or 22.12+.
+MIN_NODE_VERSION="20.19.0"
 AUTO_YES="${NERVE_YES:-0}"
 IS_UPGRADE=0
 
@@ -268,19 +269,19 @@ ensure_python() {
 ensure_node() {
     if command_exists node; then
         local ver
-        ver="$(node --version | tr -d 'v' | cut -d. -f1)"
-        if [ "$ver" -ge "$MIN_NODE_MAJOR" ] 2>/dev/null; then
-            success "Node.js $(node --version)"
+        ver="$(node --version | tr -d 'v')"
+        if version_ge "$ver" "$MIN_NODE_VERSION"; then
+            success "Node.js v$ver"
             return
         fi
-        warn "Node.js $(node --version) is too old (need v${MIN_NODE_MAJOR}+)"
+        warn "Node.js v$ver is too old (need v${MIN_NODE_VERSION}+ or v22.12+)"
     fi
 
-    info "Node.js ${MIN_NODE_MAJOR}+ is not installed"
+    info "Node.js v${MIN_NODE_VERSION}+ is not installed"
 
     if [ "$HAS_SUDO" = "0" ] && [ "$OS" = "linux" ]; then
         error "Node.js is required but sudo is not available."
-        error "Install Node.js ${MIN_NODE_MAJOR}+ manually and re-run."
+        error "Install Node.js v${MIN_NODE_VERSION}+ manually and re-run."
         exit 1
     fi
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `install.sh` Node.js version check to require v20.19+ (or v22.12+) so installs do not fail at the `vite build` step.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

`install.sh` gated Node at major `>= 18`, but `web/package.json` pins Vite `^7.3.2`, which requires Node `20.19+` or `22.12+`. Users with Node 18 passed the installer's check and then hit a hard failure inside `vite build`:

> You are using Node.js 18.19.1. Vite requires Node.js version 20.19+ or 22.12+. Please upgrade your Node.js version.

Switch to the full version string `MIN_NODE_VERSION="20.19.0"` and reuse the existing `version_ge` helper (already used for Python) so the installer prompts to upgrade Node *before* the build stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)