### PR TITLE
prompts: prefix Nerve tool names with mcp__nerve__

### DIFF
--- a/nerve/agent/prompts.py
+++ b/nerve/agent/prompts.py
@@ -37,6 +37,11 @@ def set_skill_manager(manager: Any) -> None:
 def _format_tool_list() -> str:
     """Generate tool list for system prompt from the default registry.
 
+    Tool names are prefixed with ``mcp__nerve__`` because that's how the
+    Claude Agent SDK exposes them: the in-process MCP server is named
+    "nerve", and the CLI namespaces every MCP tool as ``mcp__<server>__<name>``.
+    Calling the bare ``spec.name`` fails with "No such tool available".
+
     HoA tools are excluded — they don't usefully appear in the prompt
     when houseofagents is disabled, and including them when enabled
     bloats the prompt with rarely-used surface. The model still
@@ -46,7 +51,7 @@ def _format_tool_list() -> str:
     for spec in _get_prompt_tool_registry().list(include_hoa=False):
         # Take the first sentence of the description as the summary
         desc = spec.description.split("\n")[0].rstrip(".")
-        lines.append(f"- `{spec.name}` — {desc}")
+        lines.append(f"- `mcp__nerve__{spec.name}` — {desc}")
     return "\n".join(lines)
 
 
@@ -72,7 +77,7 @@ def _format_skills_list(skill_summaries: list[dict] | None = None) -> str | None
     lines = [
         "# Available Skills",
         "",
-        "The following skills are available. Use `skill_get(name)` to load a skill's full instructions when relevant.",
+        "The following skills are available. Use `mcp__nerve__skill_get(name)` to load a skill's full instructions when relevant.",
         "",
     ]
     for s in skill_summaries:

--- a/nerve/templates/personal/AGENTS.md
+++ b/nerve/templates/personal/AGENTS.md
@@ -8,7 +8,10 @@ Nerve is the platform you're running on — a personal AI assistant framework bu
 
 ### Your Tools
 
-These tools are always available via MCP:
+These tools are always available via MCP. **Call them as `mcp__nerve__<name>`** (e.g. `mcp__nerve__skill_get`, `mcp__nerve__task_create`) — the short names below are for readability.
+
+**Two task systems:** `mcp__nerve__task_*` is Nerve's persistent cross-session task tracker (use this for follow-ups that should survive the session). `TaskCreate`/`TaskUpdate`/etc. are Claude Code's in-session ephemeral todos (TodoPanel scratch list).
+
 
 **Memory** — Your persistence layer. You wake up fresh each session; these tools are how you remember.
 - `memorize` — Save a fact to long-term semantic memory (memU)

--- a/nerve/templates/worker/AGENTS.md
+++ b/nerve/templates/worker/AGENTS.md
@@ -6,7 +6,10 @@ Nerve is the platform you're running on — a task-driven AI worker framework bu
 
 ### Your Tools
 
-These tools are always available via MCP:
+These tools are always available via MCP. **Call them as `mcp__nerve__<name>`** (e.g. `mcp__nerve__skill_get`, `mcp__nerve__task_create`) — the short names below are for readability.
+
+**Two task systems:** `mcp__nerve__task_*` is Nerve's persistent cross-session task tracker (use this for follow-ups that should survive the session). `TaskCreate`/`TaskUpdate`/etc. are Claude Code's in-session ephemeral todos (TodoPanel scratch list).
+
 
 **Memory** — Your persistence layer. You wake up fresh each session; these tools are how you remember.
 - `memorize` — Save a fact to long-term semantic memory (memU)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,51 @@
+"""Tests for nerve.agent.prompts — system-prompt assembly."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from nerve.agent import prompts
+from nerve.agent.prompts import (
+    _format_skills_list,
+    _format_tool_list,
+    build_system_prompt,
+)
+
+
+def test_format_tool_list_uses_mcp_prefix():
+    """Tools must be advertised with the ``mcp__nerve__`` prefix.
+
+    The Claude Agent SDK exposes Nerve's in-process MCP server tools as
+    ``mcp__nerve__<name>``. If the prompt names the bare ``spec.name``
+    instead, the agent calls the short form and the CLI returns
+    "No such tool available". Regression test for that.
+    """
+    out = _format_tool_list()
+    assert out, "tool list must not be empty"
+    for line in out.splitlines():
+        assert line.startswith("- `mcp__nerve__"), f"unprefixed tool in prompt: {line!r}"
+
+
+def test_format_skills_list_uses_mcp_prefix():
+    """The skills-section header must direct the agent at ``mcp__nerve__skill_get``."""
+    section = _format_skills_list(
+        skill_summaries=[{"id": "demo", "name": "demo", "description": "Test skill"}]
+    )
+    assert section is not None
+    assert "mcp__nerve__skill_get" in section
+    # And the bare form should NOT appear standalone — that's the bug we're fixing
+    assert "Use `skill_get(name)`" not in section
+
+
+def test_format_skills_list_returns_none_for_empty():
+    assert _format_skills_list(None) is None
+    assert _format_skills_list([]) is None
+
+
+def test_build_system_prompt_smoke(tmp_path: Path):
+    """Sanity check: full prompt builder includes the prefixed tool names."""
+    # Reset cached registry so previous tests don't influence this one
+    prompts._PROMPT_TOOL_REGISTRY = None
+
+    prompt = build_system_prompt(workspace=tmp_path, session_id="t1", source="web")
+    assert "# Session Context" in prompt
+    assert "mcp__nerve__" in prompt, "prompt must advertise tools with mcp__nerve__ prefix"


### PR DESCRIPTION
## Summary

The Claude Agent SDK exposes Nerve's in-process MCP server tools as `mcp__nerve__<name>`. The system prompt was advertising them by bare `spec.name`, so agents reading the prompt tried `skill_get` / `task_create` and got "No such tool available" until they ToolSearch'd for the prefixed form.

Discovered while investigating a ClickHouse escalation — the agent fumbled through `Skill(skill="clickhouse-incident")` → `skill_get(...)` → `ToolSearch("select:mcp__nerve__skill_get")` → `mcp__nerve__skill_get(...)` before successfully loading a skill. Should have been one call.

## Changes

- `_format_tool_list()` and the skills-section header now emit `mcp__nerve__<name>` instead of bare `spec.name`.
- Both AGENTS.md templates get a short note clarifying the prefix and the distinction between Nerve's persistent task tracker (`mcp__nerve__task_*`) and Claude Code's in-session todos (`TaskCreate`/`TaskUpdate`).
- New `tests/test_prompts.py` with a regression guard so the prefix can't silently regress.

## Test plan

- [x] `pytest tests/test_prompts.py -v` — 4/4 pass
- [x] `pytest tests/` — 731/731 pass
- [ ] After merge + restart, verify in a new session that `mcp__nerve__skill_get(name="...")` works on first call without a ToolSearch round-trip

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*