### PR TITLE
feat(sources): inbox guardrails — per-source allow/deny filtering

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,10 @@ sync:
   github:
     enabled: true
     schedule: "*/15 * * * *"
+    # Guardrails — limit which repos reach the inbox (case-insensitive globs).
+    # allow_repos = allowlist (empty = all); deny_repos takes precedence.
+    allow_repos: []                # Example: ["ClickHouse/*", "myorg/myrepo"]
+    deny_repos: []
 
 # Memory (memU)
 memory:

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -13,6 +13,8 @@ PRODUCERS (sources):
       ↓
   Source.preprocess(records)          ← source-specific cleanup (e.g., strip email boilerplate)
       ↓
+  InboxFilter.partition(records)      ← guardrail: drop records that fail allow/deny rules
+      ↓
   Persist to source_messages table    ← inbox storage (with TTL)
       ↓
   SourceRunner._condense_long_content ← LLM condensation via Haiku (if condense: true)
@@ -33,8 +35,9 @@ CONSUMERS (agent tools):
 2. **Preprocess** — Two-stage content cleanup:
    - **Source-specific** (`source.preprocess()`) — Each source can override this for programmatic cleanup. Gmail strips boilerplate paragraphs (legal disclaimers, unsubscribe blocks, tracking URLs). Default: no-op
    - **LLM condensation** (`condense: true`) — Records still over 800 chars are sent to a fast model (Haiku) that extracts only essential information. Configurable per source, runs concurrently with a 30s timeout per record, falls back to original content on failure
-3. **Persist** — Records are saved to the `source_messages` table with a configurable TTL
-4. **Advance** — Source cursor is saved to SQLite after successful persistence
+3. **Guardrail** — An optional `InboxFilter` drops records that fail the source's allow/deny rules (see [Guardrails](#guardrails-inbox-filtering)). Dropped records are never persisted
+4. **Persist** — Records are saved to the `source_messages` table with a configurable TTL
+5. **Advance** — Source cursor is saved to SQLite after successful persistence
 
 ### Consumption (Consumer Side)
 
@@ -133,6 +136,8 @@ sync:
     schedule: "*/15 * * * *"
     batch_size: 30
     condense: true                # Haiku extraction for long notifications
+    allow_repos: []               # Guardrail allowlist — empty = all repos. Example: ["ClickHouse/*"]
+    deny_repos: []                # Guardrail denylist — always dropped (takes precedence)
 
   github_events:
     enabled: true
@@ -153,6 +158,72 @@ sync:
 | `condense` | bool | `false` | LLM-condense long records via `memory.fast_model` before storing |
 | `message_ttl_days` | int | `7` | How long to keep inbox messages |
 | `consumer_cursor_ttl_days` | int | `2` | Consumer cursors expire after N days of inactivity |
+
+## Guardrails (Inbox Filtering)
+
+Guardrails programmatically limit **which records ever reach the inbox**. Non-matching
+records are dropped at ingestion — they are never persisted to `source_messages`, so the
+agent can never see them and they never cost tokens. This shrinks the prompt-injection
+attack surface, which matters most in **worker mode** where the agent acts on inbox
+content without a human in the loop.
+
+Filtering happens at the choke point in `SourceRunner` (after `source.preprocess()`,
+before persist). The source cursor still advances normally, so dropped records are not
+re-fetched on the next run. The number of dropped records is reported in the run summary
+(visible in the **Runs** tab and `nerve sync` output).
+
+### How it works
+
+Guardrails are declarative allow/deny rules evaluated against `SourceRecord` fields — a
+`metadata` key, or the special `source` / `record_type` attributes. The engine lives in
+`nerve/sources/filters.py` (`FieldRule`, `InboxFilter`) and is source-agnostic.
+
+Per-rule semantics:
+- **deny wins** — a value matching any `deny` pattern is always dropped.
+- **allow is a gate** — if `allow` is non-empty, the value must match one of its patterns,
+  otherwise the record is dropped. An absent field fails closed (cannot satisfy `allow`).
+- an empty `allow` list means "allow anything not denied".
+
+A record is kept only if it passes **every** rule. Matching is case-insensitive and
+supports shell-style globs (`ClickHouse/*`). List-valued metadata (e.g. Gmail `labels`)
+matches if any element matches; non-string scalars (e.g. Telegram `chat_id`) are coerced
+to strings.
+
+### GitHub repo guardrail
+
+The GitHub notification source matches on `repo_name` (the repo `full_name`, e.g.
+`ClickHouse/nerve`):
+
+```yaml
+sync:
+  github:
+    allow_repos: ["ClickHouse/*", "myorg/myrepo"]   # Only these repos reach the inbox
+    deny_repos:  ["myorg/noisy-repo"]                # Always dropped, even if allowed above
+```
+
+With `allow_repos` empty (the default), all repos pass — behavior is unchanged.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `github.allow_repos` | list | `[]` | Allowlist of repo globs. Empty = all repos pass |
+| `github.deny_repos` | list | `[]` | Denylist of repo globs. Takes precedence over `allow_repos` |
+
+### Extending to other sources
+
+Adding a guardrail to another source is a config field plus one registry line. In
+`build_source_runners()`, build an `InboxFilter` from the relevant metadata key and pass
+it to the `SourceRunner`:
+
+```python
+from nerve.sources.filters import InboxFilter
+
+# e.g. filter Gmail by label, or Telegram by chat_id
+flt = InboxFilter.from_field("labels", allow=cfg.allow_labels, deny=cfg.deny_labels)
+runners.append(SourceRunner(..., inbox_filter=flt))
+```
+
+(Telegram already filters by folder/chat inside `fetch()` via `monitored_folders` /
+`exclude_chats`; those remain source-specific.)
 
 ## Agent Tools
 
@@ -384,7 +455,8 @@ export function MyRenderer({ content, metadata, summary }: Props) {
 |------|---------|
 | `nerve/sources/models.py` | `SourceRecord`, `FetchResult`, `IngestResult` dataclasses |
 | `nerve/sources/base.py` | `Source` abstract base class |
-| `nerve/sources/runner.py` | `SourceRunner` — pure ingestion pipeline (fetch → persist → condense → advance) |
+| `nerve/sources/runner.py` | `SourceRunner` — pure ingestion pipeline (fetch → preprocess → guardrail → persist → condense → advance) |
+| `nerve/sources/filters.py` | `InboxFilter` / `FieldRule` — declarative allow/deny guardrails applied before persist |
 | `nerve/sources/processor.py` | Legacy agent prompt building (unused by runner, may be used by tools) |
 | `nerve/sources/registry.py` | Config → `list[SourceRunner]` factory |
 | `nerve/sources/telegram.py` | Telegram adapter (Telethon) |

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -874,6 +874,7 @@ def sync(ctx: click.Context, source: str) -> None:
                 click.echo(
                     f" [{status}] "
                     f"{result.records_ingested} ingested"
+                    + (f", {result.records_dropped} dropped" if result.records_dropped else "")
                     + (f" — {result.error}" if result.error else "")
                 )
                 # Log to source_run_log

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -215,6 +215,12 @@ class GitHubSyncConfig:
     prompt_hint: str = ""
     model: str = ""
     condense: bool = False
+    # Inbox guardrails — limit which repos reach the inbox (matched on the
+    # notification's repo full_name, e.g. "ClickHouse/nerve"). Both support
+    # case-insensitive globs. allow_repos is an allowlist (empty = all repos
+    # pass); deny_repos is a denylist and takes precedence over allow_repos.
+    allow_repos: list[str] = field(default_factory=list)
+    deny_repos: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, d: dict) -> GitHubSyncConfig:
@@ -226,6 +232,8 @@ class GitHubSyncConfig:
             prompt_hint=d.get("prompt_hint", ""),
             model=d.get("model", ""),
             condense=d.get("condense", False),
+            allow_repos=d.get("allow_repos", []),
+            deny_repos=d.get("deny_repos", []),
         )
 
 

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -444,6 +444,8 @@ class CronService:
         try:
             result = await runner.run()
             summary = f"{result.records_ingested} ingested"
+            if result.records_dropped:
+                summary += f", {result.records_dropped} dropped by guardrail"
             if result.error:
                 summary += f", error: {result.error}"
 

--- a/nerve/sources/filters.py
+++ b/nerve/sources/filters.py
@@ -1,0 +1,150 @@
+"""Inbox guardrails — programmatic filtering of source records before they
+reach the agent's inbox.
+
+A guardrail is the choke point between a source's raw fetch output and the
+inbox (``source_messages``). It limits what an autonomous agent can ever
+see, shrinking the prompt-injection attack surface — especially important in
+worker mode, where the agent acts on inbox content without a human in the
+loop.
+
+Filters are declarative. Each :class:`FieldRule` matches one field of a
+:class:`~nerve.sources.models.SourceRecord` — a ``metadata`` key, or the
+special ``source`` / ``record_type`` attributes — against an *allow* list
+and a *deny* list.
+
+Per-rule semantics:
+
+* **deny wins** — if the value matches any deny pattern, the record is
+  dropped, regardless of the allow list.
+* **allow is a gate** — if the allow list is non-empty, the value MUST match
+  one of its patterns or the record is dropped. An absent field cannot
+  satisfy a non-empty allow list (fail-closed).
+* an empty allow list means "allow anything not denied".
+
+A record is kept only if it passes **every** rule (logical AND).
+
+Matching is case-insensitive and supports shell-style globs
+(``ClickHouse/*``). List-valued metadata (e.g. Gmail ``labels``) matches if
+*any* element matches. Non-string scalars (e.g. Telegram ``chat_id``) are
+coerced to ``str`` before matching.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import fnmatch
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nerve.sources.models import SourceRecord
+
+logger = logging.getLogger(__name__)
+
+
+def _norm(value: object) -> str:
+    """Normalize a value for case-insensitive matching."""
+    return str(value).strip().lower()
+
+
+def _matches_any(value: str, patterns: list[str]) -> bool:
+    """Case-insensitive shell-glob match of *value* against any pattern."""
+    norm_value = _norm(value)
+    return any(fnmatch.fnmatchcase(norm_value, _norm(p)) for p in patterns)
+
+
+@dataclass
+class FieldRule:
+    """Allow/deny matching on a single record field.
+
+    Args:
+        field: A :class:`SourceRecord` ``metadata`` key, or the special
+            attributes ``"source"`` / ``"record_type"``.
+        allow: If non-empty, the field value must match at least one pattern.
+        deny: If the field value matches any pattern, the record is dropped
+            (takes precedence over ``allow``).
+    """
+
+    field: str
+    allow: list[str] = dataclasses.field(default_factory=list)
+    deny: list[str] = dataclasses.field(default_factory=list)
+
+    @property
+    def active(self) -> bool:
+        """Whether this rule actually constrains anything."""
+        return bool(self.allow or self.deny)
+
+    def _values(self, record: SourceRecord) -> list[str]:
+        """Extract candidate string value(s) for this field from *record*."""
+        if self.field == "source":
+            raw: object = record.source
+        elif self.field == "record_type":
+            raw = record.record_type
+        else:
+            raw = (record.metadata or {}).get(self.field)
+
+        if raw is None:
+            return []
+        if isinstance(raw, (list, tuple, set)):
+            return [str(v) for v in raw if v is not None]
+        return [str(raw)]
+
+    def passes(self, record: SourceRecord) -> bool:
+        """Return True if *record* satisfies this rule (should be kept)."""
+        values = self._values(record)
+
+        # deny wins — drop on any deny match.
+        if self.deny and any(_matches_any(v, self.deny) for v in values):
+            return False
+
+        # allow gate — when set, require a match. An absent field fails closed.
+        if self.allow:
+            if not values:
+                return False
+            return any(_matches_any(v, self.allow) for v in values)
+
+        return True
+
+
+@dataclass
+class InboxFilter:
+    """A set of :class:`FieldRule` applied to source records (logical AND).
+
+    An inactive filter (no rules, or all rules empty) is a pass-through —
+    :meth:`partition` returns every record as kept with nothing dropped.
+    """
+
+    rules: list[FieldRule] = dataclasses.field(default_factory=list)
+
+    @property
+    def active(self) -> bool:
+        """Whether any rule actually constrains anything."""
+        return any(r.active for r in self.rules)
+
+    def passes(self, record: SourceRecord) -> bool:
+        """Return True if *record* passes all rules (should be kept)."""
+        return all(r.passes(record) for r in self.rules)
+
+    def partition(
+        self, records: list[SourceRecord],
+    ) -> tuple[list[SourceRecord], list[SourceRecord]]:
+        """Split *records* into ``(kept, dropped)``.
+
+        Order within each list is preserved. When the filter is inactive,
+        all records are kept and nothing is dropped (no per-record work).
+        """
+        if not self.active:
+            return list(records), []
+        kept: list[SourceRecord] = []
+        dropped: list[SourceRecord] = []
+        for r in records:
+            (kept if self.passes(r) else dropped).append(r)
+        return kept, dropped
+
+    @classmethod
+    def from_field(
+        cls, field: str, allow: list[str], deny: list[str],
+    ) -> InboxFilter:
+        """Build a single-rule filter for one field (the common case)."""
+        return cls(rules=[FieldRule(field=field, allow=allow or [], deny=deny or [])])

--- a/nerve/sources/models.py
+++ b/nerve/sources/models.py
@@ -34,6 +34,7 @@ class IngestResult:
     """Result of source ingestion (fetch + persist, no processing)."""
 
     records_ingested: int
+    records_dropped: int = 0        # Dropped by the inbox guardrail before persist
     error: str | None = None
 
 

--- a/nerve/sources/registry.py
+++ b/nerve/sources/registry.py
@@ -86,9 +86,15 @@ def build_source_runners(
     # GitHub (notifications)
     gh = config.sync.github
     if gh.enabled:
+        from nerve.sources.filters import InboxFilter
         from nerve.sources.github import GitHubSource
 
         source = GitHubSource()
+        # Guardrail: restrict which repos reach the inbox (matched on the
+        # "repo_name" metadata key set by GitHubSource).
+        gh_filter = InboxFilter.from_field(
+            "repo_name", allow=gh.allow_repos, deny=gh.deny_repos,
+        )
         runners.append(SourceRunner(
             source=source,
             db=db,
@@ -97,8 +103,15 @@ def build_source_runners(
             condense_model=condense_model,
             condense_client_factory=condense_factory,
             ttl_days=ttl_days,
+            inbox_filter=gh_filter,
         ))
-        logger.info("Registered source: github (batch=%d)", gh.batch_size)
+        if gh_filter.active:
+            logger.info(
+                "Registered source: github (batch=%d, guardrail: allow=%s deny=%s)",
+                gh.batch_size, gh.allow_repos or "*", gh.deny_repos or [],
+            )
+        else:
+            logger.info("Registered source: github (batch=%d)", gh.batch_size)
 
     # GitHub Events (user's own activity)
     gh_events = config.sync.github_events

--- a/nerve/sources/runner.py
+++ b/nerve/sources/runner.py
@@ -21,6 +21,7 @@ from nerve.sources.models import IngestResult, SourceRecord
 if TYPE_CHECKING:
     from nerve.db import Database
     from nerve.sources.base import Source
+    from nerve.sources.filters import InboxFilter
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +116,10 @@ class SourceRunner:
             Provided by NerveConfig.create_async_anthropic_client — handles provider
             detection, credentials, timeout, and proxy routing automatically.
         ttl_days: TTL for persisted source messages.
+        inbox_filter: Optional guardrail applied after preprocess and before
+            persist. Records that don't pass are dropped — never written to
+            the inbox, never seen by the agent. An inactive/None filter is a
+            no-op. See :mod:`nerve.sources.filters`.
     """
 
     def __init__(
@@ -128,6 +133,7 @@ class SourceRunner:
         condense_prompt: str = "",
         condense_client_factory: Callable[[], Any] | None = None,
         ttl_days: int = 7,
+        inbox_filter: InboxFilter | None = None,
     ):
         self.source = source
         self.db = db
@@ -138,6 +144,7 @@ class SourceRunner:
         self.condense_prompt = condense_prompt
         self._client_factory = condense_client_factory
         self.ttl_days = ttl_days
+        self.inbox_filter = inbox_filter
         self._lock = asyncio.Lock()
         self._condense_client: Any | None = None
         self.health = SourceHealth()
@@ -244,6 +251,22 @@ class SourceRunner:
         # 1. Source-specific cleanup (e.g., Gmail boilerplate stripping)
         records = await self.source.preprocess(result.records)
 
+        # 1b. Guardrail: drop records that don't pass the inbox filter. This is
+        # the choke point — dropped records are never persisted, so the agent
+        # can never see them (worker-mode safety). The cursor still advances
+        # below, so dropped records are not re-fetched.
+        dropped_count = 0
+        if self.inbox_filter is not None and self.inbox_filter.active:
+            kept, dropped = self.inbox_filter.partition(records)
+            dropped_count = len(dropped)
+            if dropped:
+                logger.info(
+                    "Source %s: guardrail dropped %d/%d records (e.g. %r)",
+                    self.source.source_name, dropped_count, len(records),
+                    dropped[0].summary,
+                )
+            records = kept
+
         # 2. Persist to inbox (post-preprocess, pre-condense — human-readable)
         await self._persist_to_inbox(records)
 
@@ -267,7 +290,7 @@ class SourceRunner:
                 self.source.source_name, len(records), result.next_cursor,
             )
 
-        return IngestResult(records_ingested=len(records))
+        return IngestResult(records_ingested=len(records), records_dropped=dropped_count)
 
     # ------------------------------------------------------------------
     # Inbox persistence

--- a/tests/test_session_context_tool.py
+++ b/tests/test_session_context_tool.py
@@ -41,12 +41,12 @@ async def test_bundles_recall_and_skills() -> None:
     bridge.available = True
     bridge.recall = AsyncMock(return_value=[
         {"id": "mem-1", "type": "knowledge", "summary": "Alice is in NYC"},
-        {"id": "mem-2", "type": "profile", "summary": "Prefers Russian-language responses"},
+        {"id": "mem-2", "type": "profile", "summary": "Prefers concise responses"},
     ])
 
     skill_manager = MagicMock()
     skill_manager.get_enabled_summaries = AsyncMock(return_value=[
-        {"id": "vox-clickhouse", "name": "vox-clickhouse", "description": "Query Vox CH"},
+        {"id": "db-query", "name": "db-query", "description": "Query the database"},
     ])
 
     db = MagicMock()
@@ -54,20 +54,20 @@ async def test_bundles_recall_and_skills() -> None:
 
     ctx = _ctx(memory_bridge=bridge, skill_manager=skill_manager, db=db)
     result = await session_context_handler(ctx, {
-        "topic": "fix the wallet endpoint",
+        "topic": "fix the auth endpoint",
         "memory_limit": 5,
     })
 
     text = result.content[0]["text"]
-    assert "fix the wallet endpoint" in text
+    assert "fix the auth endpoint" in text
     assert "Alice is in NYC" in text
-    assert "vox-clickhouse" in text
+    assert "db-query" in text
     assert "test-session-123" in text
     assert "codex" in text  # source from session record
 
     # Recall was biased by topic
     args, kwargs = bridge.recall.call_args
-    assert "fix the wallet endpoint" in args[0]
+    assert "fix the auth endpoint" in args[0]
     assert kwargs["limit"] == 5
 
 

--- a/tests/test_source_filters.py
+++ b/tests/test_source_filters.py
@@ -1,0 +1,196 @@
+"""Inbox guardrails — declarative allow/deny filtering of source records.
+
+Covers the pure matching logic of :class:`FieldRule` / :class:`InboxFilter`
+plus an end-to-end runner test proving dropped records never reach the inbox
+while the source cursor still advances.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nerve.sources.base import Source
+from nerve.sources.filters import FieldRule, InboxFilter
+from nerve.sources.models import FetchResult, SourceRecord
+from nerve.sources.runner import SourceRunner
+
+
+def _rec(repo: str = "owner/repo", **meta) -> SourceRecord:
+    """Build a GitHub-ish SourceRecord with repo_name metadata."""
+    metadata = {"repo_name": repo}
+    metadata.update(meta)
+    return SourceRecord(
+        id=f"id-{repo}-{len(meta)}",
+        source="github",
+        record_type="github_notification",
+        summary=f"[{repo}] something",
+        content="body",
+        timestamp="2026-01-01T00:00:00Z",
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FieldRule semantics
+# ---------------------------------------------------------------------------
+
+def test_empty_rule_is_inactive_and_passes_everything():
+    rule = FieldRule(field="repo_name")
+    assert rule.active is False
+    assert rule.passes(_rec("any/thing")) is True
+
+
+def test_allowlist_keeps_only_matching():
+    rule = FieldRule(field="repo_name", allow=["owner/repo"])
+    assert rule.passes(_rec("owner/repo")) is True
+    assert rule.passes(_rec("other/repo")) is False
+
+
+def test_denylist_drops_matching():
+    rule = FieldRule(field="repo_name", deny=["owner/secret"])
+    assert rule.passes(_rec("owner/secret")) is False
+    assert rule.passes(_rec("owner/public")) is True
+
+
+def test_deny_takes_precedence_over_allow():
+    rule = FieldRule(field="repo_name", allow=["owner/*"], deny=["owner/secret"])
+    assert rule.passes(_rec("owner/public")) is True
+    assert rule.passes(_rec("owner/secret")) is False
+
+
+def test_glob_matching_is_case_insensitive():
+    rule = FieldRule(field="repo_name", allow=["clickhouse/*"])
+    assert rule.passes(_rec("ClickHouse/nerve")) is True
+    assert rule.passes(_rec("ClickHouse/ClickHouse")) is True
+    assert rule.passes(_rec("other-org/other-repo")) is False
+
+
+def test_allowlist_with_absent_field_fails_closed():
+    # Record has no "repo_name" → cannot satisfy a non-empty allowlist.
+    rec = SourceRecord(
+        id="x", source="github", record_type="t",
+        summary="s", content="c", timestamp="t", metadata={},
+    )
+    assert FieldRule(field="repo_name", allow=["owner/repo"]).passes(rec) is False
+    # deny-only with an absent field keeps the record (nothing to deny).
+    assert FieldRule(field="repo_name", deny=["owner/repo"]).passes(rec) is True
+
+
+def test_list_valued_metadata_matches_any_element():
+    rule = FieldRule(field="labels", allow=["important"])
+    assert rule.passes(_rec(labels=["important", "inbox"])) is True
+    assert rule.passes(_rec(labels=["promotions"])) is False
+    # deny matches if ANY element matches
+    deny_rule = FieldRule(field="labels", deny=["spam"])
+    assert deny_rule.passes(_rec(labels=["inbox", "spam"])) is False
+
+
+def test_scalar_non_string_is_coerced():
+    # Telegram chat_id is an int; matching coerces to str.
+    rule = FieldRule(field="chat_id", deny=["12345"])
+    assert rule.passes(_rec(chat_id=12345)) is False
+    assert rule.passes(_rec(chat_id=999)) is True
+
+
+def test_special_source_and_record_type_fields():
+    src_rule = FieldRule(field="source", allow=["github"])
+    assert src_rule.passes(_rec()) is True
+    type_rule = FieldRule(field="record_type", deny=["github_notification"])
+    assert type_rule.passes(_rec()) is False
+
+
+# ---------------------------------------------------------------------------
+# InboxFilter aggregation
+# ---------------------------------------------------------------------------
+
+def test_inbox_filter_inactive_partition_is_passthrough():
+    flt = InboxFilter()
+    records = [_rec("a/b"), _rec("c/d")]
+    kept, dropped = flt.partition(records)
+    assert kept == records
+    assert dropped == []
+    assert flt.active is False
+
+
+def test_inbox_filter_partition_splits_and_preserves_order():
+    flt = InboxFilter.from_field("repo_name", allow=["keep/*"], deny=[])
+    records = [_rec("keep/one"), _rec("drop/one"), _rec("keep/two")]
+    kept, dropped = flt.partition(records)
+    assert [r.metadata["repo_name"] for r in kept] == ["keep/one", "keep/two"]
+    assert [r.metadata["repo_name"] for r in dropped] == ["drop/one"]
+
+
+def test_inbox_filter_requires_all_rules_to_pass():
+    flt = InboxFilter(rules=[
+        FieldRule(field="repo_name", allow=["owner/*"]),
+        FieldRule(field="labels", deny=["muted"]),
+    ])
+    assert flt.passes(_rec("owner/repo", labels=["inbox"])) is True
+    assert flt.passes(_rec("owner/repo", labels=["muted"])) is False
+    assert flt.passes(_rec("other/repo", labels=["inbox"])) is False
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — dropped records never hit the inbox
+# ---------------------------------------------------------------------------
+
+class _FakeSource(Source):
+    """A source that returns a fixed batch of records once."""
+
+    source_name = "github"
+
+    def __init__(self, records: list[SourceRecord], next_cursor: str = "c1"):
+        self._records = records
+        self._next_cursor = next_cursor
+
+    async def fetch(self, cursor, limit: int = 100) -> FetchResult:
+        return FetchResult(records=list(self._records), next_cursor=self._next_cursor)
+
+
+@pytest.mark.asyncio
+async def test_runner_drops_filtered_records_before_persist(db):
+    records = [_rec("ClickHouse/nerve"), _rec("evil/repo"), _rec("ClickHouse/ClickHouse")]
+    flt = InboxFilter.from_field("repo_name", allow=["clickhouse/*"], deny=[])
+    runner = SourceRunner(source=_FakeSource(records), db=db, inbox_filter=flt)
+
+    result = await runner.run()
+
+    assert result.records_ingested == 2
+    assert result.records_dropped == 1
+    assert result.error is None
+
+    # Inbox contains only the two allowed repos.
+    rows, _ = await db.list_source_messages(source="github", limit=100)
+    repos = {r["summary"] for r in rows}
+    assert repos == {"[ClickHouse/nerve] something", "[ClickHouse/ClickHouse] something"}
+
+    # Cursor advanced even though one record was dropped.
+    assert await db.get_sync_cursor("github") == "c1"
+
+
+@pytest.mark.asyncio
+async def test_runner_without_filter_ingests_all(db):
+    records = [_rec("a/b"), _rec("c/d")]
+    runner = SourceRunner(source=_FakeSource(records), db=db)
+
+    result = await runner.run()
+
+    assert result.records_ingested == 2
+    assert result.records_dropped == 0
+    rows, _ = await db.list_source_messages(source="github", limit=100)
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_runner_all_dropped_still_advances_cursor(db):
+    records = [_rec("evil/one"), _rec("evil/two")]
+    flt = InboxFilter.from_field("repo_name", allow=["trusted/*"], deny=[])
+    runner = SourceRunner(source=_FakeSource(records, next_cursor="c2"), db=db, inbox_filter=flt)
+
+    result = await runner.run()
+
+    assert result.records_ingested == 0
+    assert result.records_dropped == 2
+    rows, _ = await db.list_source_messages(source="github", limit=100)
+    assert rows == []
+    assert await db.get_sync_cursor("github") == "c2"


### PR DESCRIPTION
## Summary

Adds a **safety guardrail layer** that programmatically limits which records reach the agent's inbox. Non-matching records are **dropped at ingestion** — never persisted to `source_messages`, never seen by the agent, zero token cost. This shrinks the prompt-injection attack surface, which matters most in **worker mode** where the agent acts on inbox content without a human in the loop.

Enforced at the one choke point every source flows through — `SourceRunner._run_locked()`, after `source.preprocess()` and before persist. The source cursor still advances, so dropped records aren't re-fetched.

## Design

A source-agnostic engine (`FieldRule` / `InboxFilter` in `nerve/sources/filters.py`) plus per-source config fields. Declarative allow/deny rules over any `SourceRecord` field (a `metadata` key, or the special `source` / `record_type`):

- **deny wins** — a value matching any deny pattern is always dropped
- **allow is a gate** — if `allow` is non-empty, the value must match one of its patterns; an absent field fails closed
- empty `allow` = "allow anything not denied"

Case-insensitive, shell-glob support (`ClickHouse/*`), list-valued metadata (e.g. Gmail `labels`) matches if any element matches, non-string scalars (e.g. Telegram `chat_id`) coerced to strings.

## GitHub repo guardrail (the concrete wiring)

```yaml
sync:
  github:
    allow_repos: ["ClickHouse/*", "myorg/myrepo"]   # only these reach the inbox
    deny_repos:  ["myorg/noisy-repo"]                # always dropped (precedence)
```

Default (`[]`) = all repos pass → **behavior unchanged for existing setups**. Adding a guardrail to another source is one config field + one registry line (documented in `docs/sources.md`).

## Observability

Dropped counts appear in run summaries — the **Runs** tab (cron log output) and `nerve sync` CLI output (`N ingested, M dropped`).

## Changes

- `nerve/sources/filters.py` (new) — `FieldRule` + `InboxFilter` engine
- `nerve/sources/runner.py` — apply filter at the choke point; thread `records_dropped`
- `nerve/sources/registry.py` — build the GitHub filter from config
- `nerve/sources/models.py` — `IngestResult.records_dropped`
- `nerve/config.py` — `github.allow_repos` / `github.deny_repos`
- `nerve/cron/service.py`, `nerve/cli.py` — surface dropped counts
- `config.example.yaml`, `docs/sources.md` — config + Guardrails docs
- `tests/test_source_filters.py` (new) — 15 tests

## Test plan

- [x] `pytest tests/test_source_filters.py` — 15 pass (rule semantics, globs/case, fail-closed, list/scalar coercion, deny-precedence, 3 runner integration tests proving dropped records never persist while cursor advances)
- [x] Full suite: `pytest tests/` — 769 pass
- [ ] Restart Nerve and confirm an active `allow_repos` guardrail drops out-of-scope GitHub notifications (logs `guardrail dropped N/M`)

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*