### PR TITLE
Configurable task statuses (CRUD + MCP validation)

### DIFF
--- a/nerve/agent/tools/handlers/tasks.py
+++ b/nerve/agent/tools/handlers/tasks.py
@@ -24,11 +24,51 @@ from nerve.agent.tools.schemas import (
     TASK_LIST_SCHEMA,
     TASK_READ_SCHEMA,
     TASK_SEARCH_SCHEMA,
+    TASK_STATUS_CREATE_SCHEMA,
+    TASK_STATUS_LIST_SCHEMA,
     TASK_UPDATE_SCHEMA,
     TASK_WRITE_SCHEMA,
 )
+from nerve.db.task_statuses import (
+    DEFAULT_STATUS,
+    STATUS_NAME_RE,
+    TERMINAL_STATUS,
+    normalize_color,
+    random_status_color,
+)
 
 logger = logging.getLogger(__name__)
+
+
+async def _format_status_reminder(ctx: ToolContext, header: str) -> str:
+    """Build a reminder listing every configured status + its description."""
+    statuses = await ctx.db.list_task_statuses() if ctx.db else []
+    lines = [header, "", "Available statuses:"]
+    for s in statuses:
+        desc = (s.get("description") or "").strip() or "(no description)"
+        lines.append(f"  - {s['name']}: {desc}")
+    lines.append("")
+    lines.append(
+        "Pick one of the statuses above. Only create a new status "
+        "(task_status_create) when configuring Nerve or when explicitly "
+        "asked to add one — not for routine task management."
+    )
+    return "\n".join(lines)
+
+
+async def _validate_status(ctx: ToolContext, status: str) -> str | None:
+    """Return a reminder message if ``status`` is not configured, else None.
+
+    With no DB available (tests/ad-hoc) validation is skipped.
+    """
+    if not ctx.db:
+        return None
+    names = await ctx.db.task_status_names()
+    if status in names:
+        return None
+    return await _format_status_reminder(
+        ctx, f"Invalid task status: '{status}'.",
+    )
 
 
 # Process-wide read-before-write guard. Tracks task IDs that have been
@@ -137,6 +177,12 @@ async def task_create_handler(ctx: ToolContext, args: dict) -> ToolResult:
     raw_tags = args.get("tags", "")
     tags = parse_tags_string(raw_tags)
     confirm = args.get("confirm_duplicate", False)
+    status = (args.get("status", "") or "").strip().lower() or DEFAULT_STATUS
+
+    # Reject unknown statuses up front with the list of valid options.
+    err = await _validate_status(ctx, status)
+    if err:
+        return ToolResult.text(err)
 
     # Duplicate check (skip if explicitly confirmed)
     if not confirm:
@@ -172,7 +218,7 @@ async def task_create_handler(ctx: ToolContext, args: dict) -> ToolResult:
             task_id=task_id,
             file_path=rel_path,
             title=title,
-            status="pending",
+            status=status,
             source=source,
             source_url=source_url or None,
             deadline=deadline or None,
@@ -181,7 +227,13 @@ async def task_create_handler(ctx: ToolContext, args: dict) -> ToolResult:
         )
 
     _tasks_read.add(task_id)
-    return ToolResult.text(f"Task created: {task_id}\nFile: {file_path}")
+
+    # Creating directly in the terminal status: route through task_done so
+    # the file is moved into done/ and stays consistent with the done-flow.
+    if status == TERMINAL_STATUS and ctx.db:
+        await task_done_handler(ctx, {"task_id": task_id, "note": ""})
+
+    return ToolResult.text(f"Task created: {task_id} (status: {status})\nFile: {file_path}")
 
 
 async def task_list_handler(ctx: ToolContext, args: dict) -> ToolResult:
@@ -218,14 +270,20 @@ async def task_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
     from nerve.tasks.models import parse_tags_string, tags_to_string
 
     task_id = args["task_id"]
-    status = args.get("status", "")
+    status = (args.get("status", "") or "").strip().lower()
     note = args.get("note", "")
     deadline = args.get("deadline", "")
     raw_tags = (args.get("tags", "") or "").strip()
     new_title = (args.get("title", "") or "").strip()
 
+    # Reject unknown statuses with the list of valid options.
+    if status:
+        err = await _validate_status(ctx, status)
+        if err:
+            return ToolResult.text(err)
+
     # Route done transitions through task_done to ensure file move + FTS sync
-    if status == "done":
+    if status == TERMINAL_STATUS:
         return await task_done_handler(ctx, {"task_id": task_id, "note": note})
 
     if ctx.db:
@@ -409,6 +467,50 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
     return ToolResult.text(f"Task {task_id} marked as done.")
 
 
+async def task_status_list_handler(ctx: ToolContext, args: dict) -> ToolResult:
+    if not ctx.db:
+        return ToolResult.text("Database not available.")
+    statuses = await ctx.db.list_task_statuses()
+    if not statuses:
+        return ToolResult.text("No task statuses configured.")
+    lines = ["Configured task statuses:"]
+    for s in statuses:
+        desc = (s.get("description") or "").strip() or "(no description)"
+        flag = " [protected]" if s.get("is_system") else ""
+        lines.append(f"  - {s['name']} ({s['color']}){flag}: {desc}")
+    return ToolResult.text("\n".join(lines))
+
+
+async def task_status_create_handler(ctx: ToolContext, args: dict) -> ToolResult:
+    if not ctx.db:
+        return ToolResult.text("Database not available.")
+
+    name = (args.get("name", "") or "").strip().lower()
+    if not name:
+        return ToolResult.text("A status 'name' is required.")
+    if not STATUS_NAME_RE.match(name):
+        return ToolResult.text(
+            f"Invalid status name '{name}'. Use lowercase letters, digits, "
+            "and underscores, starting with a letter or digit (e.g. 'in_review')."
+        )
+
+    existing = await ctx.db.get_task_status_def(name)
+    if existing:
+        return ToolResult.text(f"Status '{name}' already exists.")
+
+    label = (args.get("label", "") or "").strip() or name.replace("_", " ").title()
+    color = normalize_color((args.get("color", "") or "").strip() or random_status_color())
+    description = (args.get("description", "") or "").strip()
+
+    created = await ctx.db.create_task_status(
+        name=name, label=label, color=color, description=description,
+    )
+    return ToolResult.text(
+        f"Created task status '{created['name']}' "
+        f"(label: {created['label']}, color: {created['color']})."
+    )
+
+
 # Spec exports for registry registration.
 TASK_SEARCH_SPEC = ToolSpec(
     name="task_search",
@@ -462,6 +564,27 @@ TASK_DONE_SPEC = ToolSpec(
     handler=task_done_handler,
 )
 
+TASK_STATUS_LIST_SPEC = ToolSpec(
+    name="task_status_list",
+    description="List the configured task statuses with their colors and descriptions. Use this to discover valid status values for task_create/task_update.",
+    input_schema=TASK_STATUS_LIST_SCHEMA,
+    handler=task_status_list_handler,
+)
+
+TASK_STATUS_CREATE_SPEC = ToolSpec(
+    name="task_status_create",
+    description=(
+        "Create a new configurable task status. "
+        "⚠️ Use this ONLY when configuring Nerve (e.g. initial setup) or when "
+        "the user explicitly asks you to add a status. Do NOT invent new "
+        "statuses during routine task management — use an existing status "
+        "from task_status_list instead. Color defaults to a random color when "
+        "omitted; description is optional."
+    ),
+    input_schema=TASK_STATUS_CREATE_SCHEMA,
+    handler=task_status_create_handler,
+)
+
 
 TASK_SPECS = [
     TASK_SEARCH_SPEC,
@@ -471,4 +594,6 @@ TASK_SPECS = [
     TASK_READ_SPEC,
     TASK_WRITE_SPEC,
     TASK_DONE_SPEC,
+    TASK_STATUS_LIST_SPEC,
+    TASK_STATUS_CREATE_SPEC,
 ]

--- a/nerve/agent/tools/schemas.py
+++ b/nerve/agent/tools/schemas.py
@@ -57,6 +57,11 @@ TASK_CREATE_SCHEMA = {
             "description": "Deadline in YYYY-MM-DD format",
             "default": "",
         },
+        "status": {
+            "type": "string",
+            "description": "Initial status. Must be one of the configured task statuses (see task_status_list). Defaults to 'pending' when omitted.",
+            "default": "",
+        },
         "tags": {
             "type": "string",
             "description": "Comma-separated tags (e.g. 'urgent,backend,bug')",
@@ -76,7 +81,7 @@ TASK_LIST_SCHEMA = {
     "properties": {
         "status": {
             "type": "string",
-            "description": "Filter: 'pending', 'in_progress', 'done', 'deferred', 'open' (all non-done), or 'all' (everything). Default (empty) = all non-done.",
+            "description": "Filter by a configured status name (see task_status_list), 'open'/'' for all non-done, or 'all' for everything. Default (empty) = all non-done.",
             "default": "",
         },
         "tag": {
@@ -99,7 +104,7 @@ TASK_UPDATE_SCHEMA = {
         "task_id": {"type": "string", "description": "Task ID"},
         "status": {
             "type": "string",
-            "description": "New status: pending, in_progress, done, deferred",
+            "description": "New status. Must be one of the configured task statuses (see task_status_list). Invalid values are rejected with the list of valid options.",
             "default": "",
         },
         "note": {
@@ -157,6 +162,38 @@ TASK_DONE_SCHEMA = {
         },
     },
     "required": ["task_id"],
+}
+
+TASK_STATUS_LIST_SCHEMA = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+TASK_STATUS_CREATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Status identifier — lowercase letters, digits, and underscores (e.g. 'blocked', 'in_review').",
+        },
+        "label": {
+            "type": "string",
+            "description": "Human-readable label shown in the UI (e.g. 'In Review'). Defaults to a title-cased version of name.",
+            "default": "",
+        },
+        "color": {
+            "type": "string",
+            "description": "Hex color like '#3b82f6'. A random color is chosen if omitted.",
+            "default": "",
+        },
+        "description": {
+            "type": "string",
+            "description": "Optional explanation of what this status means.",
+            "default": "",
+        },
+    },
+    "required": ["name"],
 }
 
 # ----- Memory tools -----

--- a/nerve/db/base.py
+++ b/nerve/db/base.py
@@ -26,6 +26,7 @@ from nerve.db.plans import PlanStore
 from nerve.db.sessions import SessionStore
 from nerve.db.skills import SkillStore
 from nerve.db.sources import SourceStore
+from nerve.db.task_statuses import TaskStatusStore
 from nerve.db.tasks import TaskStore
 from nerve.db.usage import UsageStore
 
@@ -40,6 +41,7 @@ class Database(
     SessionStore,
     MessageStore,
     TaskStore,
+    TaskStatusStore,
     PlanStore,
     NotificationStore,
     SourceStore,

--- a/nerve/db/migrations/v030_task_statuses.py
+++ b/nerve/db/migrations/v030_task_statuses.py
@@ -1,0 +1,62 @@
+"""V30: Configurable task statuses.
+
+Adds a ``task_statuses`` table holding the set of statuses a task may
+take, each with a display label, color (hex), optional description, a
+``sort_order`` for stable ordering, and an ``is_system`` flag.
+
+Two statuses carry special semantics and are seeded as ``is_system=1``
+(protected — cannot be deleted):
+
+- ``pending``  — the default status assigned to new tasks.
+- ``done``     — the terminal status; ``task_done`` moves the task file
+                 into ``done/`` and these tasks are hidden from the
+                 default ("active") list.
+
+The other two previously-hardcoded statuses (``in_progress``,
+``deferred``) are seeded as ordinary, deletable statuses.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+# name, label, color, description, is_system, sort_order
+_SEED = [
+    ("pending", "Pending", "#eab308",
+     "Not started yet — the default status for new tasks.", 1, 0),
+    ("in_progress", "In Progress", "#3b82f6",
+     "Actively being worked on.", 0, 1),
+    ("done", "Done", "#10b981",
+     "Completed. The task file is moved to the done/ folder.", 1, 2),
+    ("deferred", "Deferred", "#6b7280",
+     "Postponed — not active right now but not dropped.", 0, 3),
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS task_statuses (
+            name        TEXT PRIMARY KEY,
+            label       TEXT NOT NULL,
+            color       TEXT NOT NULL DEFAULT '#6b7280',
+            description TEXT NOT NULL DEFAULT '',
+            is_system   INTEGER NOT NULL DEFAULT 0,
+            sort_order  INTEGER NOT NULL DEFAULT 0,
+            created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    for name, label, color, description, is_system, sort_order in _SEED:
+        await db.execute(
+            """INSERT OR IGNORE INTO task_statuses
+                   (name, label, color, description, is_system, sort_order)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (name, label, color, description, is_system, sort_order),
+        )
+    logger.info("v030: created task_statuses table and seeded default statuses")

--- a/nerve/db/task_statuses.py
+++ b/nerve/db/task_statuses.py
@@ -1,0 +1,153 @@
+"""Task status definition data access.
+
+This manages the *configurable set* of statuses a task may hold — the
+rows of the ``task_statuses`` table — which is distinct from a task's
+*current* status value (stored on ``tasks.status`` and managed by
+:class:`nerve.db.tasks.TaskStore`).
+"""
+
+from __future__ import annotations
+
+import random
+import re
+from datetime import datetime, timezone
+
+# Status names are slug-like so they're safe to store on tasks.status and
+# render without escaping: lowercase alphanumerics + underscores, starting
+# with an alphanumeric.
+STATUS_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
+# Statuses with special semantics — protected from deletion (see migration
+# v030 for the rationale). Kept here so handlers/routes share one source.
+DEFAULT_STATUS = "pending"   # initial status assigned to new tasks
+TERMINAL_STATUS = "done"     # task_done moves file to done/, hidden by default
+
+# Curated palette for "random by default" colors — pleasant, distinct hues
+# that read well on both light and dark themes.
+_COLOR_PALETTE = [
+    "#ef4444", "#f97316", "#f59e0b", "#eab308", "#84cc16", "#22c55e",
+    "#10b981", "#14b8a6", "#06b6d4", "#3b82f6", "#6366f1", "#8b5cf6",
+    "#a855f7", "#d946ef", "#ec4899", "#f43f5e",
+]
+
+_HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+def random_status_color() -> str:
+    """Return a random color from the curated palette."""
+    return random.choice(_COLOR_PALETTE)
+
+
+def normalize_color(color: str | None) -> str:
+    """Normalize a color to ``#rrggbb`` form, or pick a random one.
+
+    Accepts ``#rgb``/``#rrggbb`` (with or without leading ``#``). Falls
+    back to a random palette color when the input is empty or invalid so
+    the UI always has a renderable hex value.
+    """
+    if not color:
+        return random_status_color()
+    c = color.strip()
+    if not c.startswith("#"):
+        c = "#" + c
+    # Expand shorthand #rgb -> #rrggbb
+    if re.fullmatch(r"#[0-9a-fA-F]{3}", c):
+        c = "#" + "".join(ch * 2 for ch in c[1:])
+    if not _HEX_RE.match(c):
+        return random_status_color()
+    return c.lower()
+
+
+class TaskStatusStore:
+    """Mixin providing CRUD for the configurable ``task_statuses`` table."""
+
+    async def list_task_statuses(self) -> list[dict]:
+        """Return all status definitions ordered by sort_order then name."""
+        async with self.db.execute(
+            "SELECT * FROM task_statuses ORDER BY sort_order ASC, name ASC"
+        ) as cursor:
+            return [dict(row) async for row in cursor]
+
+    async def get_task_status_def(self, name: str) -> dict | None:
+        async with self.db.execute(
+            "SELECT * FROM task_statuses WHERE name = ?", (name,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            return dict(row) if row else None
+
+    async def task_status_names(self) -> list[str]:
+        """Return the set of valid status names (ordered)."""
+        async with self.db.execute(
+            "SELECT name FROM task_statuses ORDER BY sort_order ASC, name ASC"
+        ) as cursor:
+            return [row[0] async for row in cursor]
+
+    async def create_task_status(
+        self,
+        name: str,
+        label: str,
+        color: str | None = None,
+        description: str = "",
+        is_system: int = 0,
+    ) -> dict:
+        """Insert a new status definition. Caller validates name uniqueness."""
+        now = datetime.now(timezone.utc).isoformat()
+        async with self.db.execute(
+            "SELECT COALESCE(MAX(sort_order), -1) FROM task_statuses"
+        ) as cur:
+            next_order = (await cur.fetchone())[0] + 1
+        async with self._atomic():
+            await self.db.execute(
+                """INSERT INTO task_statuses
+                       (name, label, color, description, is_system, sort_order, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (name, label, normalize_color(color), description,
+                 1 if is_system else 0, next_order, now),
+            )
+        return await self.get_task_status_def(name)  # type: ignore[return-value]
+
+    async def update_task_status_def(
+        self,
+        name: str,
+        *,
+        label: str | None = None,
+        color: str | None = None,
+        description: str | None = None,
+        sort_order: int | None = None,
+    ) -> None:
+        """Patch mutable fields of a status definition (never the name)."""
+        sets: list[str] = []
+        params: list = []
+        if label is not None:
+            sets.append("label = ?")
+            params.append(label)
+        if color is not None:
+            sets.append("color = ?")
+            params.append(normalize_color(color))
+        if description is not None:
+            sets.append("description = ?")
+            params.append(description)
+        if sort_order is not None:
+            sets.append("sort_order = ?")
+            params.append(sort_order)
+        if not sets:
+            return
+        params.append(name)
+        await self.db.execute(
+            f"UPDATE task_statuses SET {', '.join(sets)} WHERE name = ?",
+            tuple(params),
+        )
+        await self.db.commit()
+
+    async def delete_task_status_def(self, name: str) -> None:
+        """Delete a status definition. Caller enforces protection rules."""
+        await self.db.execute("DELETE FROM task_statuses WHERE name = ?", (name,))
+        await self.db.commit()
+
+    async def count_tasks_with_status(self, name: str) -> int:
+        """Count tasks currently set to the given status."""
+        async with self.db.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = ?", (name,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row[0] if row else 0

--- a/nerve/gateway/routes/tasks.py
+++ b/nerve/gateway/routes/tasks.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from nerve.config import get_config
+from nerve.db.task_statuses import STATUS_NAME_RE, normalize_color
 from nerve.gateway.auth import require_auth
 from nerve.gateway.routes._deps import (
     build_route_tool_context,
@@ -30,6 +31,20 @@ class TaskUpdateRequest(BaseModel):
     deadline: str = ""
     content: str = ""
     title: str = ""
+
+
+class TaskStatusCreateRequest(BaseModel):
+    name: str
+    label: str = ""
+    color: str = ""
+    description: str = ""
+
+
+class TaskStatusUpdateRequest(BaseModel):
+    label: str | None = None
+    color: str | None = None
+    description: str | None = None
+    sort_order: int | None = None
 
 
 _ALLOWED_SORTS = {"deadline", "updated_at", "created_at"}
@@ -147,3 +162,77 @@ async def update_task(task_id: str, req: TaskUpdateRequest, user: dict = Depends
         )
 
     return {"task_id": task_id, "updated": True}
+
+
+# ── Configurable task statuses ───────────────────────────────────────────
+
+
+@router.get("/api/task-statuses")
+async def list_task_statuses(user: dict = Depends(require_auth)):
+    deps = get_deps()
+    return {"statuses": await deps.db.list_task_statuses()}
+
+
+@router.post("/api/task-statuses")
+async def create_task_status(
+    req: TaskStatusCreateRequest, user: dict = Depends(require_auth),
+):
+    deps = get_deps()
+    name = (req.name or "").strip().lower()
+    if not STATUS_NAME_RE.match(name):
+        raise HTTPException(
+            status_code=422,
+            detail="Status name must be lowercase letters, digits, and "
+                   "underscores, starting with a letter or digit.",
+        )
+    if await deps.db.get_task_status_def(name):
+        raise HTTPException(status_code=409, detail=f"Status '{name}' already exists")
+
+    label = (req.label or "").strip() or name.replace("_", " ").title()
+    color = normalize_color((req.color or "").strip())
+    created = await deps.db.create_task_status(
+        name=name, label=label, color=color,
+        description=(req.description or "").strip(),
+    )
+    return created
+
+
+@router.patch("/api/task-statuses/{name}")
+async def update_task_status(
+    name: str, req: TaskStatusUpdateRequest, user: dict = Depends(require_auth),
+):
+    deps = get_deps()
+    existing = await deps.db.get_task_status_def(name)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Status not found")
+
+    await deps.db.update_task_status_def(
+        name,
+        label=req.label.strip() if req.label is not None else None,
+        color=req.color if req.color is not None else None,
+        description=req.description if req.description is not None else None,
+        sort_order=req.sort_order,
+    )
+    return await deps.db.get_task_status_def(name)
+
+
+@router.delete("/api/task-statuses/{name}")
+async def delete_task_status(name: str, user: dict = Depends(require_auth)):
+    deps = get_deps()
+    existing = await deps.db.get_task_status_def(name)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Status not found")
+    if existing.get("is_system"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"'{name}' is a protected status and cannot be deleted",
+        )
+    in_use = await deps.db.count_tasks_with_status(name)
+    if in_use > 0:
+        raise HTTPException(
+            status_code=409,
+            detail=f"{in_use} task(s) use the '{name}' status. "
+                   "Reassign them before deleting it.",
+        )
+    await deps.db.delete_task_status_def(name)
+    return {"name": name, "deleted": True}

--- a/tests/test_task_statuses.py
+++ b/tests/test_task_statuses.py
@@ -1,0 +1,168 @@
+"""Tests for configurable task statuses: the TaskStatusStore and the
+status validation / management tool handlers."""
+
+from __future__ import annotations
+
+import pytest
+
+from nerve.agent.tools.registry import ToolContext
+from nerve.agent.tools.handlers.tasks import (
+    task_create_handler,
+    task_status_create_handler,
+    task_status_list_handler,
+    task_update_handler,
+)
+from nerve.db import Database
+from nerve.db.task_statuses import normalize_color
+
+
+def _text(result) -> str:
+    return result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+class TestTaskStatusStore:
+    async def test_seed_defaults(self, db: Database):
+        statuses = await db.list_task_statuses()
+        names = [s["name"] for s in statuses]
+        assert names == ["pending", "in_progress", "done", "deferred"]
+        by_name = {s["name"]: s for s in statuses}
+        # pending + done are protected; the others are not.
+        assert by_name["pending"]["is_system"] == 1
+        assert by_name["done"]["is_system"] == 1
+        assert by_name["in_progress"]["is_system"] == 0
+        assert by_name["deferred"]["is_system"] == 0
+        # Colors are stored as hex.
+        assert by_name["pending"]["color"].startswith("#")
+
+    async def test_create_appends_with_next_sort_order(self, db: Database):
+        created = await db.create_task_status(
+            name="blocked", label="Blocked", color="#ff0000",
+            description="Waiting on something external.",
+        )
+        assert created["name"] == "blocked"
+        assert created["sort_order"] == 4  # after the 4 seeded (0..3)
+        assert "blocked" in await db.task_status_names()
+
+    async def test_create_normalizes_color(self, db: Database):
+        created = await db.create_task_status(name="x", label="X", color="abc")
+        assert created["color"] == "#aabbcc"  # shorthand expanded + #-prefixed
+
+    async def test_update_def(self, db: Database):
+        await db.update_task_status_def(
+            "in_progress", label="Doing", color="#123456", description="new desc",
+        )
+        s = await db.get_task_status_def("in_progress")
+        assert s["label"] == "Doing"
+        assert s["color"] == "#123456"
+        assert s["description"] == "new desc"
+
+    async def test_count_and_delete(self, db: Database):
+        await db.create_task_status(name="review", label="Review")
+        await db.upsert_task(
+            task_id="t1", file_path="t1.md", title="T1", status="review",
+        )
+        assert await db.count_tasks_with_status("review") == 1
+        await db.delete_task_status_def("review")
+        assert "review" not in await db.task_status_names()
+
+
+class TestColorNormalization:
+    def test_shorthand_and_prefix(self):
+        assert normalize_color("#abc") == "#aabbcc"
+        assert normalize_color("abcdef") == "#abcdef"
+        assert normalize_color("#ABCDEF") == "#abcdef"
+
+    def test_invalid_falls_back_to_palette(self):
+        c = normalize_color("not-a-color")
+        assert c.startswith("#") and len(c) == 7
+
+    def test_empty_returns_random(self):
+        c = normalize_color("")
+        assert c.startswith("#") and len(c) == 7
+
+
+@pytest.mark.asyncio
+class TestStatusToolHandlers:
+    def _ctx(self, db, tmp_path) -> ToolContext:
+        return ToolContext(session_id="test", db=db, workspace=tmp_path)
+
+    async def test_create_rejects_invalid_status(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        result = await task_create_handler(
+            ctx, {"title": "Demo", "content": "x", "status": "bogus"},
+        )
+        text = _text(result)
+        assert "Invalid task status: 'bogus'" in text
+        # Reminder lists valid statuses with descriptions.
+        assert "pending:" in text
+        assert "in_progress:" in text
+        # No task should have been created.
+        assert await db.list_tasks(status="all") == []
+
+    async def test_create_defaults_to_pending(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        result = await task_create_handler(ctx, {"title": "Demo task", "content": "x"})
+        assert "status: pending" in _text(result)
+        tasks = await db.list_tasks(status="all")
+        assert len(tasks) == 1 and tasks[0]["status"] == "pending"
+
+    async def test_create_accepts_valid_custom_status(self, db: Database, tmp_path):
+        await db.create_task_status(name="blocked", label="Blocked")
+        ctx = self._ctx(db, tmp_path)
+        result = await task_create_handler(
+            ctx, {"title": "Blocked task", "content": "x", "status": "blocked"},
+        )
+        assert "status: blocked" in _text(result)
+        tasks = await db.list_tasks(status="blocked")
+        assert len(tasks) == 1
+
+    async def test_create_terminal_status_moves_to_done(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        await task_create_handler(
+            ctx, {"title": "Already done", "content": "x", "status": "done"},
+        )
+        tasks = await db.list_tasks(status="done")
+        assert len(tasks) == 1
+        # Routed through task_done → file lives under done/.
+        assert "/done/" in tasks[0]["file_path"] or tasks[0]["file_path"].startswith("done/") \
+            or "done" in tasks[0]["file_path"]
+
+    async def test_update_rejects_invalid_status(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        await task_create_handler(ctx, {"title": "Some task", "content": "x"})
+        task_id = (await db.list_tasks(status="all"))[0]["id"]
+        result = await task_update_handler(ctx, {"task_id": task_id, "status": "nope"})
+        assert "Invalid task status: 'nope'" in _text(result)
+        # Status unchanged.
+        assert (await db.get_task(task_id))["status"] == "pending"
+
+    async def test_update_accepts_valid_status(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        await task_create_handler(ctx, {"title": "Another task", "content": "x"})
+        task_id = (await db.list_tasks(status="all"))[0]["id"]
+        await task_update_handler(ctx, {"task_id": task_id, "status": "in_progress"})
+        assert (await db.get_task(task_id))["status"] == "in_progress"
+
+    async def test_status_create_handler(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        result = await task_status_create_handler(
+            ctx, {"name": "in_review", "description": "Awaiting review"},
+        )
+        assert "Created task status 'in_review'" in _text(result)
+        assert "in_review" in await db.task_status_names()
+
+    async def test_status_create_rejects_duplicate(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        result = await task_status_create_handler(ctx, {"name": "pending"})
+        assert "already exists" in _text(result)
+
+    async def test_status_create_rejects_invalid_name(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        result = await task_status_create_handler(ctx, {"name": "In Review!"})
+        assert "Invalid status name" in _text(result)
+
+    async def test_status_list_handler(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        text = _text(await task_status_list_handler(ctx, {}))
+        assert "pending" in text and "[protected]" in text

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,15 @@
 const API_BASE = '/api';
 
+export interface TaskStatusDef {
+  name: string;
+  label: string;
+  color: string;
+  description: string;
+  is_system: number;
+  sort_order: number;
+  created_at?: string;
+}
+
 let authToken: string | null = localStorage.getItem('nerve_token');
 
 export function setToken(token: string) {
@@ -114,6 +124,16 @@ export const api = {
     request<any>('/tasks', { method: 'POST', body: JSON.stringify(data) }),
   updateTask: (id: string, data: { status?: string; note?: string; content?: string }) =>
     request<any>(`/tasks/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+
+  // Task statuses (configurable)
+  listTaskStatuses: () =>
+    request<{ statuses: TaskStatusDef[] }>('/task-statuses'),
+  createTaskStatus: (data: { name: string; label?: string; color?: string; description?: string }) =>
+    request<TaskStatusDef>('/task-statuses', { method: 'POST', body: JSON.stringify(data) }),
+  updateTaskStatus: (name: string, data: { label?: string; color?: string; description?: string; sort_order?: number }) =>
+    request<TaskStatusDef>(`/task-statuses/${encodeURIComponent(name)}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  deleteTaskStatus: (name: string) =>
+    request<{ name: string; deleted: boolean }>(`/task-statuses/${encodeURIComponent(name)}`, { method: 'DELETE' }),
 
   // Memory
   listMemoryFiles: () => request<{ files: any[] }>('/memory/files'),

--- a/web/src/components/Tasks/StatusControls.tsx
+++ b/web/src/components/Tasks/StatusControls.tsx
@@ -1,0 +1,41 @@
+import { useTaskStatusStore, statusBadgeStyle } from '../../stores/taskStatusStore';
+
+/** Colored pill showing a task's status label (falls back to the raw name). */
+export function StatusBadge({ status, className = '' }: {
+  status: string;
+  className?: string;
+}) {
+  const meta = useTaskStatusStore((s) => s.statuses.find((x) => x.name === status));
+  return (
+    <span
+      className={`px-2 py-0.5 rounded-full border ${className}`}
+      style={statusBadgeStyle(meta?.color)}
+    >
+      {meta?.label || status}
+    </span>
+  );
+}
+
+/** Dropdown of configured statuses, driven by the task-status store. */
+export function StatusSelect({ value, onChange, className = '' }: {
+  value: string;
+  onChange: (status: string) => void;
+  className?: string;
+}) {
+  const statuses = useTaskStatusStore((s) => s.statuses);
+  // Keep the current value selectable even if it's somehow not in the
+  // configured set (defensive — deletion is blocked while a status is in use).
+  const hasValue = statuses.some((s) => s.name === value);
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={className}
+    >
+      {!hasValue && value && <option value={value}>{value}</option>}
+      {statuses.map((s) => (
+        <option key={s.name} value={s.name}>{s.label}</option>
+      ))}
+    </select>
+  );
+}

--- a/web/src/components/Tasks/TaskCard.tsx
+++ b/web/src/components/Tasks/TaskCard.tsx
@@ -2,13 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { Calendar, Clock, ExternalLink } from 'lucide-react';
 import type { Task } from '../../stores/taskStore';
 import { formatTimeAgo } from '../../utils/dateGroups';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
-  in_progress: 'bg-blue-400/10 text-hue-blue border-blue-400/20',
-  done: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
-  deferred: 'bg-border-subtle/50 text-text-muted border-border-subtle',
-};
+import { StatusBadge, StatusSelect } from './StatusControls';
 
 export function TaskCard({ task, onStatusChange }: {
   task: Task;
@@ -25,9 +19,7 @@ export function TaskCard({ task, onStatusChange }: {
         <div className="min-w-0 flex-1">
           <h3 className="font-medium text-[15px] text-text mb-1">{task.title}</h3>
           <div className="flex items-center gap-3 text-[12px]">
-            <span className={`px-2 py-0.5 rounded-full border ${STATUS_STYLES[task.status] || STATUS_STYLES.deferred}`}>
-              {task.status}
-            </span>
+            <StatusBadge status={task.status} />
             {task.deadline && (
               <span className="flex items-center gap-1 text-text-dim">
                 <Calendar size={11} /> {task.deadline}
@@ -57,16 +49,11 @@ export function TaskCard({ task, onStatusChange }: {
               <ExternalLink size={14} />
             </a>
           )}
-          <select
+          <StatusSelect
             value={task.status}
-            onChange={(e) => onStatusChange(task.id, e.target.value)}
+            onChange={(status) => onStatusChange(task.id, status)}
             className="text-[12px] px-2 py-1 bg-surface-raised border border-border rounded text-text-muted outline-none cursor-pointer"
-          >
-            <option value="pending">Pending</option>
-            <option value="in_progress">In Progress</option>
-            <option value="done">Done</option>
-            <option value="deferred">Deferred</option>
-          </select>
+          />
         </div>
       </div>
     </div>

--- a/web/src/components/Tasks/TaskFilters.tsx
+++ b/web/src/components/Tasks/TaskFilters.tsx
@@ -1,20 +1,20 @@
-const FILTERS = [
-  { value: '', label: 'Active' },
-  { value: 'pending', label: 'Pending' },
-  { value: 'in_progress', label: 'In Progress' },
-  { value: 'done', label: 'Done' },
-  { value: 'deferred', label: 'Deferred' },
-];
+import { useTaskStatusStore } from '../../stores/taskStatusStore';
 
 export function TaskFilters({ active, onChange }: {
   active: string;
   onChange: (filter: string) => void;
 }) {
+  const statuses = useTaskStatusStore((s) => s.statuses);
+  const filters = [
+    { value: '', label: 'Active' },
+    ...statuses.map((s) => ({ value: s.name, label: s.label })),
+  ];
+
   return (
     <div className="flex gap-1">
-      {FILTERS.map(f => (
+      {filters.map(f => (
         <button
-          key={f.value}
+          key={f.value || 'active'}
           onClick={() => onChange(f.value)}
           className={`px-3 py-1.5 text-[13px] rounded-md cursor-pointer transition-colors
             ${active === f.value

--- a/web/src/components/Tasks/TaskList.tsx
+++ b/web/src/components/Tasks/TaskList.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { api } from '../../api/client';
+import { useTaskStatusStore } from '../../stores/taskStatusStore';
+import { StatusBadge, StatusSelect } from './StatusControls';
 
 interface Task {
   id: string;
@@ -10,17 +12,12 @@ interface Task {
   created_at: string;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  pending: 'text-hue-yellow',
-  in_progress: 'text-hue-blue',
-  done: 'text-hue-green',
-  deferred: 'text-text-muted',
-};
-
 export function TaskList() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [filter, setFilter] = useState('');
   const [loading, setLoading] = useState(true);
+  const statuses = useTaskStatusStore((s) => s.statuses);
+  const loadStatuses = useTaskStatusStore((s) => s.load);
 
   const loadTasks = async () => {
     try {
@@ -33,6 +30,7 @@ export function TaskList() {
     }
   };
 
+  useEffect(() => { loadStatuses(); }, []);
   useEffect(() => { loadTasks(); }, [filter]);
 
   const handleStatusChange = async (id: string, newStatus: string) => {
@@ -50,10 +48,9 @@ export function TaskList() {
           className="text-sm px-2 py-1 bg-surface-raised border border-border-subtle rounded text-text outline-none"
         >
           <option value="">Active</option>
-          <option value="pending">Pending</option>
-          <option value="in_progress">In Progress</option>
-          <option value="done">Done</option>
-          <option value="deferred">Deferred</option>
+          {statuses.map((s) => (
+            <option key={s.name} value={s.name}>{s.label}</option>
+          ))}
         </select>
       </div>
 
@@ -71,22 +68,17 @@ export function TaskList() {
               <div className="flex items-start justify-between">
                 <div>
                   <div className="font-medium">{task.title}</div>
-                  <div className="text-xs text-text-dim mt-1">
-                    <span className={STATUS_COLORS[task.status] || ''}>{task.status}</span>
-                    {task.deadline && <span className="ml-2">Due: {task.deadline}</span>}
-                    {task.source && <span className="ml-2">from {task.source}</span>}
+                  <div className="text-xs text-text-dim mt-1 flex items-center gap-2">
+                    <StatusBadge status={task.status} />
+                    {task.deadline && <span>Due: {task.deadline}</span>}
+                    {task.source && <span>from {task.source}</span>}
                   </div>
                 </div>
-                <select
+                <StatusSelect
                   value={task.status}
-                  onChange={(e) => handleStatusChange(task.id, e.target.value)}
+                  onChange={(status) => handleStatusChange(task.id, status)}
                   className="text-xs px-1.5 py-0.5 bg-surface-raised border border-border-subtle rounded text-text-muted outline-none"
-                >
-                  <option value="pending">Pending</option>
-                  <option value="in_progress">In Progress</option>
-                  <option value="done">Done</option>
-                  <option value="deferred">Deferred</option>
-                </select>
+                />
               </div>
             </div>
           ))}

--- a/web/src/components/Tasks/TaskStatusManager.tsx
+++ b/web/src/components/Tasks/TaskStatusManager.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from 'react';
+import { X, Plus, Trash2, Pencil, Check, Lock } from 'lucide-react';
+import {
+  useTaskStatusStore,
+  statusBadgeStyle,
+  type TaskStatusDef,
+} from '../../stores/taskStatusStore';
+
+const PALETTE = [
+  '#ef4444', '#f97316', '#f59e0b', '#eab308', '#84cc16', '#22c55e',
+  '#10b981', '#14b8a6', '#06b6d4', '#3b82f6', '#6366f1', '#8b5cf6',
+  '#a855f7', '#d946ef', '#ec4899', '#f43f5e',
+];
+
+const randomColor = () => PALETTE[Math.floor(Math.random() * PALETTE.length)];
+const NAME_RE = /^[a-z0-9][a-z0-9_]*$/;
+
+/** Pull the server's `detail` out of a thrown request Error ("409: {json}"). */
+function parseErr(e: unknown): string {
+  const msg = String((e as Error)?.message ?? e);
+  const m = msg.match(/^\d+:\s*([\s\S]*)$/);
+  if (m) {
+    try {
+      const j = JSON.parse(m[1]);
+      if (j?.detail) return j.detail;
+    } catch { /* not JSON */ }
+    return m[1];
+  }
+  return msg;
+}
+
+export function TaskStatusManager({ onClose }: { onClose: () => void }) {
+  const { statuses, load, create, update, remove } = useTaskStatusStore();
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  // Inline edit state (existing rows)
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editLabel, setEditLabel] = useState('');
+  const [editDesc, setEditDesc] = useState('');
+
+  // Add form
+  const [showAdd, setShowAdd] = useState(false);
+  const [name, setName] = useState('');
+  const [label, setLabel] = useState('');
+  const [color, setColor] = useState(randomColor());
+  const [description, setDescription] = useState('');
+
+  useEffect(() => { load(true); }, []);
+
+  const beginEdit = (s: TaskStatusDef) => {
+    setEditing(s.name);
+    setEditLabel(s.label);
+    setEditDesc(s.description);
+    setError('');
+  };
+
+  const saveEdit = async (s: TaskStatusDef) => {
+    setBusy(true); setError('');
+    try {
+      await update(s.name, { label: editLabel.trim() || s.name, description: editDesc.trim() });
+      setEditing(null);
+    } catch (e) { setError(parseErr(e)); }
+    finally { setBusy(false); }
+  };
+
+  const changeColor = async (s: TaskStatusDef, c: string) => {
+    setError('');
+    try { await update(s.name, { color: c }); }
+    catch (e) { setError(parseErr(e)); }
+  };
+
+  const handleDelete = async (s: TaskStatusDef) => {
+    setError('');
+    try { await remove(s.name); }
+    catch (e) { setError(parseErr(e)); }
+  };
+
+  const resetAdd = () => {
+    setName(''); setLabel(''); setColor(randomColor());
+    setDescription(''); setShowAdd(false); setError('');
+  };
+
+  const handleCreate = async () => {
+    const n = name.trim().toLowerCase();
+    if (!NAME_RE.test(n)) {
+      setError('Name must be lowercase letters, digits, and underscores (e.g. in_review).');
+      return;
+    }
+    setBusy(true); setError('');
+    try {
+      await create({
+        name: n,
+        label: label.trim() || undefined,
+        color,
+        description: description.trim() || undefined,
+      });
+      resetAdd();
+    } catch (e) { setError(parseErr(e)); }
+    finally { setBusy(false); }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={onClose}>
+      <div
+        className="bg-surface-raised border border-border-subtle rounded-xl w-[560px] max-w-[92vw] max-h-[85vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+          <h2 className="text-[15px] font-semibold">Task Statuses</h2>
+          <button onClick={onClose} className="text-text-faint hover:text-text-muted cursor-pointer p-1">
+            <X size={18} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mx-5 mt-3 px-3 py-2 text-[12px] text-hue-red bg-red-400/10 border border-red-400/20 rounded-lg">
+            {error}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto p-5 space-y-2">
+          {statuses.map(s => (
+            <div key={s.name} className="border border-border-subtle rounded-lg p-3">
+              <div className="flex items-center gap-3">
+                {/* Color swatch — click to recolor */}
+                <label
+                  className="relative w-6 h-6 rounded-full border border-border shrink-0 cursor-pointer"
+                  style={{ backgroundColor: s.color }}
+                  title="Change color"
+                >
+                  <input
+                    type="color"
+                    value={s.color}
+                    onChange={e => changeColor(s, e.target.value)}
+                    className="absolute inset-0 opacity-0 cursor-pointer"
+                  />
+                </label>
+
+                <div className="min-w-0 flex-1">
+                  {editing === s.name ? (
+                    <input
+                      value={editLabel}
+                      onChange={e => setEditLabel(e.target.value)}
+                      className="w-full px-2 py-1 text-[13px] bg-surface border border-border-subtle rounded text-text outline-none focus:border-accent/50"
+                      placeholder="Label"
+                    />
+                  ) : (
+                    <div className="flex items-center gap-2">
+                      <span style={statusBadgeStyle(s.color)} className="px-2 py-0.5 rounded-full border text-[12px]">
+                        {s.label}
+                      </span>
+                      <code className="text-[11px] text-text-faint">{s.name}</code>
+                      {!!s.is_system && (
+                        <span className="flex items-center gap-1 text-[10px] text-text-faint" title="Protected — cannot be deleted">
+                          <Lock size={10} /> protected
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  {editing !== s.name && s.description && (
+                    <div className="text-[12px] text-text-dim mt-1">{s.description}</div>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-1 shrink-0">
+                  {editing === s.name ? (
+                    <>
+                      <button
+                        onClick={() => saveEdit(s)}
+                        disabled={busy}
+                        className="p-1.5 text-hue-green hover:bg-surface-hover rounded cursor-pointer disabled:opacity-50"
+                        title="Save"
+                      >
+                        <Check size={14} />
+                      </button>
+                      <button
+                        onClick={() => setEditing(null)}
+                        className="p-1.5 text-text-faint hover:bg-surface-hover rounded cursor-pointer"
+                        title="Cancel"
+                      >
+                        <X size={14} />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        onClick={() => beginEdit(s)}
+                        className="p-1.5 text-text-faint hover:text-text-muted hover:bg-surface-hover rounded cursor-pointer"
+                        title="Edit label & description"
+                      >
+                        <Pencil size={14} />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(s)}
+                        disabled={!!s.is_system}
+                        className="p-1.5 text-text-faint hover:text-hue-red hover:bg-surface-hover rounded cursor-pointer disabled:opacity-30 disabled:cursor-not-allowed"
+                        title={s.is_system ? 'Protected status' : 'Delete'}
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {editing === s.name && (
+                <textarea
+                  value={editDesc}
+                  onChange={e => setEditDesc(e.target.value)}
+                  rows={2}
+                  placeholder="Description (optional)"
+                  className="mt-2 w-full px-2 py-1 text-[12px] bg-surface border border-border-subtle rounded text-text outline-none focus:border-accent/50 resize-none"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="border-t border-border p-4">
+          {showAdd ? (
+            <div className="space-y-3">
+              <div className="flex gap-2">
+                <label
+                  className="relative w-9 h-9 rounded-lg border border-border shrink-0 cursor-pointer"
+                  style={{ backgroundColor: color }}
+                  title="Pick a color"
+                >
+                  <input
+                    type="color"
+                    value={color}
+                    onChange={e => setColor(e.target.value)}
+                    className="absolute inset-0 opacity-0 cursor-pointer"
+                  />
+                </label>
+                <input
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="name (e.g. in_review)"
+                  autoFocus
+                  className="flex-1 px-3 py-2 bg-surface border border-border-subtle rounded-lg text-[13px] text-text outline-none focus:border-accent/50"
+                />
+                <input
+                  value={label}
+                  onChange={e => setLabel(e.target.value)}
+                  placeholder="Label (optional)"
+                  className="flex-1 px-3 py-2 bg-surface border border-border-subtle rounded-lg text-[13px] text-text outline-none focus:border-accent/50"
+                />
+              </div>
+              <textarea
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                rows={2}
+                placeholder="Description (optional)"
+                className="w-full px-3 py-2 bg-surface border border-border-subtle rounded-lg text-[13px] text-text outline-none focus:border-accent/50 resize-none"
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={resetAdd}
+                  className="px-3 py-1.5 text-[13px] text-text-muted hover:text-text cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleCreate}
+                  disabled={busy || !name.trim()}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer disabled:opacity-50"
+                >
+                  <Plus size={14} /> Add status
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => { setColor(randomColor()); setShowAdd(true); }}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] text-accent hover:bg-accent/10 rounded-lg cursor-pointer"
+            >
+              <Plus size={14} /> New status
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/TaskDetailPage.tsx
+++ b/web/src/pages/TaskDetailPage.tsx
@@ -2,14 +2,9 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Edit3, Eye, Save, Calendar, ExternalLink } from 'lucide-react';
 import { useTaskStore } from '../stores/taskStore';
+import { useTaskStatusStore } from '../stores/taskStatusStore';
+import { StatusBadge, StatusSelect } from '../components/Tasks/StatusControls';
 import { MarkdownContent } from '../components/Chat/MarkdownContent';
-
-const STATUS_STYLES: Record<string, string> = {
-  pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
-  in_progress: 'bg-blue-400/10 text-hue-blue border-blue-400/20',
-  done: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
-  deferred: 'bg-border-subtle/50 text-text-muted border-border-subtle',
-};
 
 export function TaskDetailPage() {
   const { taskId } = useParams<{ taskId: string }>();
@@ -18,6 +13,7 @@ export function TaskDetailPage() {
     selectedTask, detailLoading, saving,
     loadTask, saveTaskContent, updateStatus, clearSelectedTask,
   } = useTaskStore();
+  const loadStatuses = useTaskStatusStore((s) => s.load);
 
   const [mode, setMode] = useState<'edit' | 'preview'>('preview');
   const [localContent, setLocalContent] = useState('');
@@ -26,6 +22,7 @@ export function TaskDetailPage() {
 
   useEffect(() => {
     if (taskId) loadTask(taskId);
+    loadStatuses();
     return () => clearSelectedTask();
   }, [taskId]);
 
@@ -128,19 +125,12 @@ export function TaskDetailPage() {
 
         {/* Meta row */}
         <div className="flex items-center gap-3 ml-9 text-[12px]">
-          <span className={`px-2 py-0.5 rounded-full border ${STATUS_STYLES[selectedTask.status] || STATUS_STYLES.deferred}`}>
-            {selectedTask.status}
-          </span>
-          <select
+          <StatusBadge status={selectedTask.status} />
+          <StatusSelect
             value={selectedTask.status}
-            onChange={(e) => updateStatus(selectedTask.id, e.target.value)}
+            onChange={(status) => updateStatus(selectedTask.id, status)}
             className="text-[12px] px-2 py-1 bg-surface-raised border border-border rounded text-text-muted outline-none cursor-pointer"
-          >
-            <option value="pending">Pending</option>
-            <option value="in_progress">In Progress</option>
-            <option value="done">Done</option>
-            <option value="deferred">Deferred</option>
-          </select>
+          />
           {selectedTask.deadline && (
             <span className="flex items-center gap-1 text-text-dim">
               <Calendar size={11} /> {selectedTask.deadline}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { ChevronLeft, ChevronRight, Plus, Search, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Plus, Search, SlidersHorizontal, X } from 'lucide-react';
 import { useTaskStore, TASKS_PAGE_SIZE, type TaskSort } from '../stores/taskStore';
+import { useTaskStatusStore } from '../stores/taskStatusStore';
 import { TaskFilters } from '../components/Tasks/TaskFilters';
 import { TaskCard } from '../components/Tasks/TaskCard';
 import { TaskCreateDialog } from '../components/Tasks/TaskCreateDialog';
+import { TaskStatusManager } from '../components/Tasks/TaskStatusManager';
 
 const SORT_OPTIONS: { value: TaskSort; label: string }[] = [
   { value: 'deadline', label: 'Deadline' },
@@ -18,10 +20,13 @@ export function TasksPage() {
     updateStatus, createTask, setShowCreateDialog,
   } = useTaskStore();
 
+  const loadStatuses = useTaskStatusStore((s) => s.load);
+
   const [localQuery, setLocalQuery] = useState(searchQuery);
+  const [showStatusManager, setShowStatusManager] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => { loadTasks(); }, []);
+  useEffect(() => { loadTasks(); loadStatuses(); }, []);
 
   const isSearching = searchQuery.trim().length > 0;
   const pageStart = total === 0 ? 0 : (page - 1) * TASKS_PAGE_SIZE + 1;
@@ -89,6 +94,13 @@ export function TasksPage() {
             </label>
           )}
           <button
+            onClick={() => setShowStatusManager(true)}
+            title="Manage statuses"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] text-text-secondary bg-surface-raised border border-border-subtle hover:border-border rounded-lg cursor-pointer"
+          >
+            <SlidersHorizontal size={14} /> Statuses
+          </button>
+          <button
             onClick={() => setShowCreateDialog(true)}
             className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer"
           >
@@ -149,6 +161,10 @@ export function TasksPage() {
           onClose={() => setShowCreateDialog(false)}
           onCreate={createTask}
         />
+      )}
+
+      {showStatusManager && (
+        <TaskStatusManager onClose={() => setShowStatusManager(false)} />
       )}
     </div>
   );

--- a/web/src/stores/taskStatusStore.ts
+++ b/web/src/stores/taskStatusStore.ts
@@ -1,0 +1,70 @@
+import type { CSSProperties } from 'react';
+import { create } from 'zustand';
+import { api, type TaskStatusDef } from '../api/client';
+
+export type { TaskStatusDef };
+
+interface TaskStatusState {
+  statuses: TaskStatusDef[];
+  loaded: boolean;
+  loading: boolean;
+
+  load: (force?: boolean) => Promise<void>;
+  create: (data: { name: string; label?: string; color?: string; description?: string }) => Promise<void>;
+  update: (name: string, data: { label?: string; color?: string; description?: string; sort_order?: number }) => Promise<void>;
+  remove: (name: string) => Promise<void>;
+  byName: (name: string) => TaskStatusDef | undefined;
+}
+
+export const useTaskStatusStore = create<TaskStatusState>((set, get) => ({
+  statuses: [],
+  loaded: false,
+  loading: false,
+
+  load: async (force = false) => {
+    if (get().loading) return;
+    if (get().loaded && !force) return;
+    set({ loading: true });
+    try {
+      const { statuses } = await api.listTaskStatuses();
+      set({ statuses, loaded: true, loading: false });
+    } catch (e) {
+      console.error('Failed to load task statuses:', e);
+      set({ loading: false });
+    }
+  },
+
+  create: async (data) => {
+    await api.createTaskStatus(data);
+    await get().load(true);
+  },
+
+  update: async (name, data) => {
+    await api.updateTaskStatus(name, data);
+    await get().load(true);
+  },
+
+  // Throws on failure (e.g. 409 in-use, 400 protected) so callers can surface
+  // the server's message.
+  remove: async (name) => {
+    await api.deleteTaskStatus(name);
+    await get().load(true);
+  },
+
+  byName: (name) => get().statuses.find((s) => s.name === name),
+}));
+
+const FALLBACK_COLOR = '#6b7280';
+
+/**
+ * Inline style for a status badge from an arbitrary hex color. Alpha
+ * suffixes keep user-chosen colors legible on both light and dark themes.
+ */
+export function statusBadgeStyle(color: string | undefined): CSSProperties {
+  const c = color || FALLBACK_COLOR;
+  return {
+    color: c,
+    backgroundColor: `${c}1a`, // ~10% opacity
+    borderColor: `${c}33`,     // ~20% opacity
+  };
+}


### PR DESCRIPTION
## Summary

Task statuses are no longer hardcoded. They live in a new DB-backed,
user-configurable set (migration `v030` + `task_statuses` table). Each
status has a label, hex color, optional description, and sort order.

- **Protected statuses:** `pending` (the new-task default) and `done`
  (terminal — `task_done` moves the file to `done/`, hidden from the
  default list) are recolor/relabel/redescribe-only and cannot be
  deleted. `in_progress`, `deferred`, and any custom statuses are fully
  editable/deletable.
- **Delete safety:** deleting a status is blocked while any task still
  uses it (409 with the count); protected statuses return 400.
- **MCP validation:** `task_create` / `task_update` validate the status
  against the configured set and, on a miss, return a reminder listing
  every valid status with its description. `task_create` gained an
  optional, validated `status` arg.
- **New MCP tools:** `task_status_list` and `task_status_create`. The
  create tool is documented as **config-only** — the agent is instructed
  not to invent statuses during routine task management.
- **REST:** CRUD under `/api/task-statuses`.
- **Frontend:** a task-status store drives dynamic colors/labels across
  the card, list, filters, and detail views, plus a "Statuses" manager
  modal on the Tasks page (create / recolor / relabel / describe /
  delete, random color by default).

## Test plan

- [x] `pytest tests/` — 791 pass (18 new in `tests/test_task_statuses.py`)
- [x] Frontend builds clean (`tsc -b && vite build`)
- [x] Live: migration applied (schema 30), four statuses seeded
- [x] Live MCP: invalid-status reminder + `task_status_create` duplicate guard
- [x] Live REST: create/list/delete round-trip; protected-delete blocked (400); clean cleanup
- [ ] Visual: Tasks → "Statuses" modal (manual)

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*