### PR TITLE
feat(wakeups): fire ScheduleWakeup through a Nerve-owned harness

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from claude_agent_sdk import (
@@ -833,8 +833,9 @@ class AgentEngine:
             ["context-1m-2025-08-07"] if self.config.agent.context_1m else []
         )
 
-        # Build PreToolUse hook for file snapshot capture
-        hooks = self._build_snapshot_hooks(session_id)
+        # Build PreToolUse (file snapshots, image validation) +
+        # PostToolUse (ScheduleWakeup capture) hooks.
+        hooks = self._build_hooks(session_id)
 
         def _cli_stderr(line: str) -> None:
             stripped = line.rstrip()
@@ -884,22 +885,13 @@ class AgentEngine:
             # External MCP server tools are discovered at connection time,
             # so we can't enumerate them upfront.
             #
-            # ``ScheduleWakeup`` is left enabled. Behaviour in Nerve:
-            #   • The CLI's internal scheduler "fires" the wakeup at the
-            #     scheduled time and enqueues the stored prompt as a
-            #     synthetic user message inside the SDK subprocess.
-            #   • Nerve has no background reader between turns — the queued
-            #     wakeup just sits in the SDK buffer.
-            #   • On the next user message, Nerve calls ``client.query()``
-            #     and the buffered wakeup is flushed BEFORE the user's
-            #     input, so the model sees the self-scheduled prompt first.
-            #   • If the user never sends another message before the idle
-            #     timeout reaps the client, the wakeup is lost (durable
-            #     wakeups would survive in ~/.claude/scheduled_tasks.json,
-            #     but the model rarely sets ``durable: true``).
-            # Net: it's a deferred-prompt, not an autonomous timer. The UI
-            # renders the call (see ``ScheduleWakeupBlock``) so the user
-            # knows what the model scheduled.
+            # Remove the CLI's cron tools — Nerve has its own cron system,
+            # so exposing CronCreate/CronList/CronDelete is redundant and
+            # confusing. ``ScheduleWakeup`` stays available and is handled by
+            # Nerve's wakeup harness (capture hook + cron-service sweep); the
+            # CLI's own autonomous firing is suppressed via the
+            # CLAUDE_CODE_DISABLE_CRON env var set in ``_build_env``.
+            disallowed_tools=["CronCreate", "CronList", "CronDelete"],
             env=self._build_env(),
             cwd=str(self.config.workspace),
             mcp_servers=self._build_mcp_servers(session_id),
@@ -953,6 +945,14 @@ class AgentEngine:
     def _build_env(self) -> dict[str, str]:
         """Build environment variables for the SDK subprocess."""
         env: dict[str, str] = {}
+        # Disable the CLI's built-in cron/wakeup scheduler. It fires
+        # autonomously inside the subprocess, but Nerve only reads the SDK
+        # stream during an active run() — so a fired turn lands in an unread
+        # buffer and then desyncs the next real turn. Nerve owns wakeup
+        # timing instead: a PostToolUse hook records each ScheduleWakeup and
+        # the cron service fires it via run(..., source="wakeup"). The tool
+        # itself stays available (this flag only gates the firing hook).
+        env["CLAUDE_CODE_DISABLE_CRON"] = "1"
         if self.config.provider.is_bedrock:
             env["CLAUDE_CODE_USE_BEDROCK"] = "1"
             if self.config.provider.aws_region:
@@ -1013,8 +1013,15 @@ class AgentEngine:
             )
         return servers
 
-    def _build_snapshot_hooks(self, session_id: str) -> dict:
-        """Build PreToolUse hooks for file snapshots and image validation."""
+    def _build_hooks(self, session_id: str) -> dict:
+        """Build SDK hooks for this session.
+
+        PreToolUse: file snapshots (Edit/Write/NotebookEdit) and image
+        validation (Read). PostToolUse: ScheduleWakeup capture, which
+        records the requested wakeup so the cron-service sweep can fire it
+        through ``engine.run(..., source="wakeup")`` (the CLI's own
+        autonomous firing is suppressed — see ``_build_env``).
+        """
         from nerve.agent.interactive import _read_file_safe
 
         captured_files: set[str] = set()
@@ -1070,6 +1077,24 @@ class AgentEngine:
 
             return {"hookSpecificOutput": {"hookEventName": "PreToolUse"}}
 
+        async def _capture_wakeup_hook(hook_input, tool_use_id, context):
+            """PostToolUse hook: record a ScheduleWakeup so Nerve can fire it.
+
+            The CLI's own scheduler is disabled (CLAUDE_CODE_DISABLE_CRON),
+            so the tool just records the request and returns. We persist it
+            here and the cron-service sweep re-injects the prompt at the
+            scheduled time via ``engine.run(..., source="wakeup")``.
+            """
+            try:
+                await self._record_wakeup(
+                    self.db, session_id, hook_input.get("tool_input", {}) or {},
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to record wakeup for session %s: %s", session_id, e,
+                )
+            return {"hookSpecificOutput": {"hookEventName": "PostToolUse"}}
+
         return {
             "PreToolUse": [
                 HookMatcher(
@@ -1081,7 +1106,61 @@ class AgentEngine:
                     hooks=[_validate_image_hook],
                 ),
             ],
+            "PostToolUse": [
+                HookMatcher(
+                    matcher="ScheduleWakeup",
+                    hooks=[_capture_wakeup_hook],
+                ),
+            ],
         }
+
+    # Min/max delay the CLI's ScheduleWakeup enforces (clamped to [60, 3600]).
+    _WAKEUP_MIN_DELAY = 60
+    _WAKEUP_MAX_DELAY = 3600
+
+    @classmethod
+    def _wakeup_fire_at(cls, delay_seconds: Any) -> str:
+        """Compute a UTC ISO fire time from a ScheduleWakeup ``delaySeconds``.
+
+        Mirrors the CLI's clamping: non-finite or out-of-range values are
+        coerced into ``[60, 3600]`` seconds from now.
+        """
+        try:
+            delay = float(delay_seconds)
+        except (TypeError, ValueError):
+            delay = float(cls._WAKEUP_MIN_DELAY)
+        if delay != delay:  # NaN
+            delay = float(cls._WAKEUP_MIN_DELAY)
+        elif delay == float("inf"):
+            delay = float(cls._WAKEUP_MAX_DELAY)
+        elif delay == float("-inf"):
+            delay = float(cls._WAKEUP_MIN_DELAY)
+        delay = max(cls._WAKEUP_MIN_DELAY, min(cls._WAKEUP_MAX_DELAY, round(delay)))
+        fire_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
+        return fire_at.isoformat()
+
+    @classmethod
+    async def _record_wakeup(
+        cls, db: Any, session_id: str, tool_input: dict,
+    ) -> int | None:
+        """Persist a ScheduleWakeup request from its tool input.
+
+        Returns the new wakeup id, or ``None`` when there's no prompt to
+        re-inject (in which case nothing is scheduled).
+        """
+        prompt = str(tool_input.get("prompt", "")).strip()
+        if not prompt:
+            return None
+        reason = str(tool_input.get("reason", "") or "")
+        fire_at = cls._wakeup_fire_at(tool_input.get("delaySeconds"))
+        wakeup_id = await db.add_wakeup(
+            session_id, prompt=prompt, fire_at=fire_at, reason=reason,
+        )
+        logger.info(
+            "Recorded wakeup %s for session %s at %s",
+            wakeup_id, session_id[:8], fire_at,
+        )
+        return wakeup_id
 
     @staticmethod
     def _model_supports_legacy_enabled_thinking(model: str | None) -> bool:
@@ -1727,6 +1806,12 @@ class AgentEngine:
         result_meta: dict | None = None  # ResultMessage fields beyond usage
         last_model: str | None = None  # model from most recent AssistantMessage
 
+        # Wakeup turns (fired by the cron-service sweep) carry a leading
+        # marker block so the UI shows a "scheduled wakeup" chip. Persisted
+        # in ordered_blocks (survives reload) and broadcast live below.
+        if source == "wakeup":
+            ordered_blocks.append({"type": "wakeup"})
+
         try:
             # Get or create persistent client for this session
             # Check if we need to fork from a parent
@@ -1821,6 +1906,10 @@ class AgentEngine:
                 "fork_from": fork_from,
             }
             _got_response_content = False
+            # Live marker so the UI shows the "scheduled wakeup" chip as the
+            # turn streams (the persisted block above covers reload).
+            if source == "wakeup":
+                await broadcaster.broadcast_wakeup(session_id)
             with lf_attrs(
                 session_id=session_id,
                 tags=_lf_tags,

--- a/nerve/agent/streaming.py
+++ b/nerve/agent/streaming.py
@@ -200,6 +200,10 @@ class StreamBroadcaster:
     async def broadcast_plan_update(self, session_id: str, content: str) -> None:
         await self.broadcast(session_id, {"type": "plan_update", "session_id": session_id, "content": content})
 
+    async def broadcast_wakeup(self, session_id: str) -> None:
+        """Mark the start of a turn fired by a self-scheduled ScheduleWakeup."""
+        await self.broadcast(session_id, {"type": "wakeup", "session_id": session_id})
+
     async def broadcast_interaction(self, session_id: str, interaction_type: str, interaction_id: str, tool_name: str, tool_input: dict) -> None:
         await self.broadcast(session_id, {
             "type": "interaction",

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -24,6 +24,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# How often to scan for due session wakeups (ScheduleWakeup harness). The
+# tool clamps delays to >= 60s, so a 20s sweep keeps fire latency well under
+# the granularity the model can request.
+_WAKEUP_SWEEP_SECONDS = 20
+
+# ScheduleWakeup autonomous-loop sentinels (Claude Code /loop). Nerve has no
+# /loop command, so resolve them to a plain continuation instruction.
+_WAKEUP_SENTINELS = {"<<autonomous-loop>>", "<<autonomous-loop-dynamic>>"}
+_WAKEUP_SENTINEL_PROMPT = (
+    "[Scheduled wakeup] Continue the task you were pacing. If there is "
+    "nothing left to do, stop and don't reschedule."
+)
+
+
+def _resolve_wakeup_prompt(prompt: str) -> str:
+    """Map an autonomous-loop sentinel to a usable prompt; pass others through."""
+    return _WAKEUP_SENTINEL_PROMPT if prompt.strip() in _WAKEUP_SENTINELS else prompt
+
 
 def _parse_interval(interval: str) -> int:
     """Parse an interval string like '2h', '30m', '1h30m' into seconds."""
@@ -124,6 +142,16 @@ class CronService:
             CronTrigger(hour=3, minute=0),
             id="cleanup",
             name="Cleanup expired data",
+            replace_existing=True,
+        )
+
+        # Fire due session wakeups (ScheduleWakeup harness). The CLI's own
+        # scheduler is disabled; Nerve owns wakeup timing here.
+        self.scheduler.add_job(
+            self._sweep_wakeups,
+            IntervalTrigger(seconds=_WAKEUP_SWEEP_SECONDS),
+            id="wakeup_sweep",
+            name="Fire due session wakeups",
             replace_existing=True,
         )
 
@@ -480,6 +508,64 @@ class CronService:
                 )
         except Exception as e:
             logger.error("Cleanup failed: %s", e, exc_info=True)
+
+    async def _sweep_wakeups(self) -> None:
+        """Fire due session wakeups recorded by the ScheduleWakeup hook.
+
+        Each due wakeup is atomically claimed (pending -> fired) so
+        overlapping sweeps can't double-fire it, then re-injected into its
+        session via ``engine.run(..., source="wakeup")``. The run is
+        dispatched (not awaited) so one long turn can't stall the sweep; the
+        per-session lock inside ``run`` serialises it behind any live turn.
+        """
+        try:
+            now_iso = datetime.now(timezone.utc).isoformat()
+            due = await self.db.get_due_wakeups(now_iso)
+        except Exception as e:
+            logger.error("Wakeup sweep query failed: %s", e, exc_info=True)
+            return
+
+        for wakeup in due:
+            session_id = wakeup["session_id"]
+            # Skip sessions mid-turn; a still-running turn may itself be
+            # rescheduling. Leave the wakeup pending and retry next sweep.
+            if self.engine.sessions.is_running(session_id):
+                continue
+            try:
+                claimed = await self.db.claim_wakeup(wakeup["id"])
+            except Exception as e:
+                logger.error(
+                    "Failed to claim wakeup %s: %s", wakeup["id"], e,
+                )
+                continue
+            if not claimed:
+                continue
+            self._dispatch_wakeup(session_id, wakeup)
+
+    def _dispatch_wakeup(self, session_id: str, wakeup: dict) -> None:
+        """Spawn the engine run for a claimed wakeup with error logging."""
+        prompt = _resolve_wakeup_prompt(wakeup["prompt"])
+        logger.info(
+            "Firing wakeup %s for session %s", wakeup["id"], session_id[:8],
+        )
+        task = asyncio.create_task(
+            self.engine.run(
+                session_id=session_id,
+                user_message=prompt,
+                source="wakeup",
+                internal=True,
+            )
+        )
+
+        def _done(t: asyncio.Task) -> None:
+            exc = t.exception() if not t.cancelled() else None
+            if exc is not None:
+                logger.error(
+                    "Wakeup %s run failed for session %s: %s",
+                    wakeup["id"], session_id, exc,
+                )
+
+        task.add_done_callback(_done)
 
     async def run_job(self, job_id: str) -> None:
         """Run a specific job manually (used by CLI)."""

--- a/nerve/db/base.py
+++ b/nerve/db/base.py
@@ -29,6 +29,7 @@ from nerve.db.sources import SourceStore
 from nerve.db.task_statuses import TaskStatusStore
 from nerve.db.tasks import TaskStore
 from nerve.db.usage import UsageStore
+from nerve.db.wakeups import WakeupStore
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,7 @@ class Database(
     AuditStore,
     UsageStore,
     FileStore,
+    WakeupStore,
 ):
     """Async SQLite database wrapper.
 

--- a/nerve/db/migrations/v031_session_wakeups.py
+++ b/nerve/db/migrations/v031_session_wakeups.py
@@ -1,0 +1,54 @@
+"""V31: Session wakeups (ScheduleWakeup harness).
+
+Adds a ``session_wakeups`` table that records self-scheduled wakeups
+requested by the model via the ``ScheduleWakeup`` tool.
+
+Background: the bundled Claude CLI fires ``ScheduleWakeup`` autonomously
+inside its own subprocess, but Nerve only reads the SDK message stream
+during an active ``engine.run()`` — so an autonomously-fired wakeup turn
+lands in an unread buffer and then desyncs the next real turn. The fix
+disables the CLI's own firing (``CLAUDE_CODE_DISABLE_CRON=1``) and makes
+Nerve the harness: a PostToolUse hook records the request here, and a
+periodic sweep fires it via ``engine.run(..., source="wakeup")``.
+
+One-shot only. ``ScheduleWakeup`` is always a one-shot wakeup; if the
+model wants to keep a loop alive it re-calls the tool each turn, which
+re-inserts a fresh row. Recurring crons are intentionally NOT supported
+here — Nerve has its own cron system and the CLI cron tools are removed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_wakeups (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id  TEXT NOT NULL
+                            REFERENCES sessions(id) ON DELETE CASCADE,
+            prompt      TEXT NOT NULL,
+            reason      TEXT NOT NULL DEFAULT '',
+            fire_at     TEXT NOT NULL,
+            status      TEXT NOT NULL DEFAULT 'pending',
+            created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    # Sweep query is WHERE status = 'pending' AND fire_at <= ?
+    await db.execute(
+        """CREATE INDEX IF NOT EXISTS idx_session_wakeups_due
+               ON session_wakeups (status, fire_at)"""
+    )
+    # Per-session de-dup / cascade lookups.
+    await db.execute(
+        """CREATE INDEX IF NOT EXISTS idx_session_wakeups_session
+               ON session_wakeups (session_id)"""
+    )
+    logger.info("v031: created session_wakeups table")

--- a/nerve/db/wakeups.py
+++ b/nerve/db/wakeups.py
@@ -1,0 +1,102 @@
+"""Session wakeup data access methods (ScheduleWakeup harness).
+
+A *wakeup* is a one-shot, self-scheduled prompt the model requested via
+the ``ScheduleWakeup`` tool. Rows are written by the PostToolUse capture
+hook and consumed by the cron-service sweep, which fires the prompt
+through ``engine.run(..., source="wakeup")`` at ``fire_at``.
+"""
+
+from __future__ import annotations
+
+
+class WakeupStore:
+    """Mixin providing session wakeup persistence."""
+
+    async def add_wakeup(
+        self,
+        session_id: str,
+        prompt: str,
+        fire_at: str,
+        reason: str = "",
+    ) -> int:
+        """Record a pending wakeup, replacing any prior pending one.
+
+        ``ScheduleWakeup`` keeps a single active wakeup per session (the
+        ``/loop`` self-pacing model re-calls the tool each turn). So a new
+        request supersedes any earlier pending wakeup for the session.
+
+        Returns the new wakeup id.
+        """
+        async with self._atomic():
+            await self.db.execute(
+                "DELETE FROM session_wakeups "
+                "WHERE session_id = ? AND status = 'pending'",
+                (session_id,),
+            )
+            cursor = await self.db.execute(
+                """INSERT INTO session_wakeups (session_id, prompt, reason, fire_at)
+                   VALUES (?, ?, ?, ?)""",
+                (session_id, prompt, reason, fire_at),
+            )
+            wakeup_id = cursor.lastrowid
+            await cursor.close()
+        return wakeup_id
+
+    async def get_due_wakeups(self, now_iso: str, limit: int = 50) -> list[dict]:
+        """Return pending wakeups whose ``fire_at`` is at or before ``now_iso``.
+
+        ``fire_at`` is a UTC ISO-8601 string (fixed width, ``+00:00``
+        offset) so lexicographic comparison matches chronological order.
+        """
+        async with self.db.execute(
+            """SELECT * FROM session_wakeups
+               WHERE status = 'pending' AND fire_at <= ?
+               ORDER BY fire_at ASC LIMIT ?""",
+            (now_iso, limit),
+        ) as cursor:
+            return [dict(row) async for row in cursor]
+
+    async def claim_wakeup(self, wakeup_id: int) -> bool:
+        """Atomically transition a wakeup pending -> fired.
+
+        Returns ``True`` only for the caller that actually flipped the row,
+        so overlapping sweeps can never fire the same wakeup twice.
+        """
+        cursor = await self.db.execute(
+            "UPDATE session_wakeups SET status = 'fired' "
+            "WHERE id = ? AND status = 'pending'",
+            (wakeup_id,),
+        )
+        claimed = (cursor.rowcount or 0) == 1
+        await cursor.close()
+        await self.db.commit()
+        return claimed
+
+    async def cancel_wakeups_for_session(self, session_id: str) -> int:
+        """Delete all pending wakeups for a session. Returns rows removed."""
+        cursor = await self.db.execute(
+            "DELETE FROM session_wakeups "
+            "WHERE session_id = ? AND status = 'pending'",
+            (session_id,),
+        )
+        deleted = cursor.rowcount or 0
+        await cursor.close()
+        await self.db.commit()
+        return deleted
+
+    async def list_pending_wakeups(self, session_id: str | None = None) -> list[dict]:
+        """List pending wakeups, optionally scoped to one session."""
+        if session_id is not None:
+            query = (
+                "SELECT * FROM session_wakeups "
+                "WHERE status = 'pending' AND session_id = ? ORDER BY fire_at ASC"
+            )
+            params: tuple = (session_id,)
+        else:
+            query = (
+                "SELECT * FROM session_wakeups "
+                "WHERE status = 'pending' ORDER BY fire_at ASC"
+            )
+            params = ()
+        async with self.db.execute(query, params) as cursor:
+            return [dict(row) async for row in cursor]

--- a/tests/test_wakeups.py
+++ b/tests/test_wakeups.py
@@ -1,0 +1,244 @@
+"""Tests for the ScheduleWakeup harness.
+
+Covers three layers:
+  * ``AgentEngine._wakeup_fire_at`` — delaySeconds clamping.
+  * ``WakeupStore`` — persistence, de-dup, atomic claim, FK cascade.
+  * ``CronService._sweep_wakeups`` — firing due wakeups via engine.run,
+    skipping busy sessions, and not double-firing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from nerve.agent.engine import AgentEngine
+from nerve.cron.service import CronService, _resolve_wakeup_prompt
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _past() -> str:
+    return _iso(datetime.now(timezone.utc) - timedelta(minutes=5))
+
+
+def _future() -> str:
+    return _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+
+
+# --------------------------------------------------------------------------- #
+#  _wakeup_fire_at — clamping                                                  #
+# --------------------------------------------------------------------------- #
+
+class TestWakeupFireAt:
+    @staticmethod
+    def _delay(value) -> float:
+        fire_at = AgentEngine._wakeup_fire_at(value)
+        return (datetime.fromisoformat(fire_at) - datetime.now(timezone.utc)).total_seconds()
+
+    @pytest.mark.parametrize("value,expected", [
+        (30, 60),        # below min -> clamp up
+        (60, 60),        # exact min
+        (120, 120),      # in range
+        (3600, 3600),    # exact max
+        (5000, 3600),    # above max -> clamp down
+        (90.7, 91),      # rounded
+    ])
+    def test_numeric_clamping(self, value, expected):
+        assert abs(self._delay(value) - expected) <= 2
+
+    @pytest.mark.parametrize("value,expected", [
+        (float("inf"), 3600),
+        (float("-inf"), 60),
+        (float("nan"), 60),
+        (None, 60),
+        ("not-a-number", 60),
+    ])
+    def test_non_finite_and_invalid(self, value, expected):
+        assert abs(self._delay(value) - expected) <= 2
+
+    def test_returns_iso_utc(self):
+        fire_at = AgentEngine._wakeup_fire_at(120)
+        parsed = datetime.fromisoformat(fire_at)
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timedelta(0)
+
+
+# --------------------------------------------------------------------------- #
+#  WakeupStore                                                                 #
+# --------------------------------------------------------------------------- #
+
+class TestWakeupStore:
+    @pytest_asyncio.fixture
+    async def seeded_db(self, db):
+        await db.create_session("s1", source="web")
+        await db.create_session("s2", source="web")
+        return db
+
+    @pytest.mark.asyncio
+    async def test_add_and_get_due(self, seeded_db):
+        await seeded_db.add_wakeup("s1", prompt="ping", fire_at=_past(), reason="r")
+        await seeded_db.add_wakeup("s2", prompt="later", fire_at=_future())
+
+        due = await seeded_db.get_due_wakeups(_iso(datetime.now(timezone.utc)))
+        assert len(due) == 1
+        assert due[0]["session_id"] == "s1"
+        assert due[0]["prompt"] == "ping"
+        assert due[0]["reason"] == "r"
+        assert due[0]["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_add_replaces_prior_pending(self, seeded_db):
+        await seeded_db.add_wakeup("s1", prompt="first", fire_at=_past())
+        await seeded_db.add_wakeup("s1", prompt="second", fire_at=_past())
+
+        pending = await seeded_db.list_pending_wakeups("s1")
+        assert len(pending) == 1
+        assert pending[0]["prompt"] == "second"
+
+    @pytest.mark.asyncio
+    async def test_claim_is_atomic(self, seeded_db):
+        wid = await seeded_db.add_wakeup("s1", prompt="ping", fire_at=_past())
+        assert await seeded_db.claim_wakeup(wid) is True
+        # Second claim of the same row loses — guarantees single fire.
+        assert await seeded_db.claim_wakeup(wid) is False
+        # No longer pending / not returned as due.
+        assert await seeded_db.get_due_wakeups(_iso(datetime.now(timezone.utc))) == []
+
+    @pytest.mark.asyncio
+    async def test_cancel_for_session(self, seeded_db):
+        await seeded_db.add_wakeup("s1", prompt="ping", fire_at=_past())
+        removed = await seeded_db.cancel_wakeups_for_session("s1")
+        assert removed == 1
+        assert await seeded_db.list_pending_wakeups("s1") == []
+
+    @pytest.mark.asyncio
+    async def test_list_pending_scoping(self, seeded_db):
+        await seeded_db.add_wakeup("s1", prompt="a", fire_at=_future())
+        await seeded_db.add_wakeup("s2", prompt="b", fire_at=_future())
+        assert len(await seeded_db.list_pending_wakeups()) == 2
+        assert len(await seeded_db.list_pending_wakeups("s1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_cascade_on_session_delete(self, seeded_db):
+        await seeded_db.add_wakeup("s1", prompt="ping", fire_at=_past())
+        await seeded_db.db.execute("DELETE FROM sessions WHERE id = ?", ("s1",))
+        await seeded_db.db.commit()
+        assert await seeded_db.list_pending_wakeups() == []
+
+
+# --------------------------------------------------------------------------- #
+#  CronService._sweep_wakeups                                                  #
+# --------------------------------------------------------------------------- #
+
+class TestWakeupSweep:
+    @pytest_asyncio.fixture
+    async def svc(self, db):
+        await db.create_session("s1", source="web")
+        config = MagicMock()
+        engine = AsyncMock()
+        # is_running is synchronous — default to "not running".
+        engine.sessions = MagicMock()
+        engine.sessions.is_running = MagicMock(return_value=False)
+        engine.run = AsyncMock(return_value="ok")
+        return CronService(config, engine, db)
+
+    @pytest.mark.asyncio
+    async def test_fires_due_wakeup(self, svc):
+        await svc.db.add_wakeup("s1", prompt="do the thing", fire_at=_past())
+
+        await svc._sweep_wakeups()
+        await asyncio.sleep(0.05)  # let the dispatched run task execute
+
+        svc.engine.run.assert_awaited_once()
+        kwargs = svc.engine.run.await_args.kwargs
+        assert kwargs["session_id"] == "s1"
+        assert kwargs["user_message"] == "do the thing"
+        assert kwargs["source"] == "wakeup"
+        assert kwargs["internal"] is True
+        # Claimed — no longer pending.
+        assert await svc.db.list_pending_wakeups("s1") == []
+
+    @pytest.mark.asyncio
+    async def test_skips_running_session(self, svc):
+        svc.engine.sessions.is_running = MagicMock(return_value=True)
+        await svc.db.add_wakeup("s1", prompt="ping", fire_at=_past())
+
+        await svc._sweep_wakeups()
+        await asyncio.sleep(0.05)
+
+        svc.engine.run.assert_not_called()
+        # Still pending — retried on a later sweep when the session is free.
+        assert len(await svc.db.list_pending_wakeups("s1")) == 1
+
+    @pytest.mark.asyncio
+    async def test_ignores_future_wakeup(self, svc):
+        await svc.db.add_wakeup("s1", prompt="ping", fire_at=_future())
+        await svc._sweep_wakeups()
+        await asyncio.sleep(0.05)
+        svc.engine.run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_double_fire_across_sweeps(self, svc):
+        await svc.db.add_wakeup("s1", prompt="ping", fire_at=_past())
+        await svc._sweep_wakeups()
+        await svc._sweep_wakeups()  # second sweep finds nothing to fire
+        await asyncio.sleep(0.05)
+        svc.engine.run.assert_awaited_once()
+
+
+class TestRecordWakeup:
+    """The capture path the PostToolUse hook delegates to."""
+
+    @pytest_asyncio.fixture
+    async def seeded_db(self, db):
+        await db.create_session("s1", source="web")
+        return db
+
+    @pytest.mark.asyncio
+    async def test_records_from_tool_input(self, seeded_db):
+        wid = await AgentEngine._record_wakeup(
+            seeded_db, "s1",
+            {"delaySeconds": 120, "prompt": "keep going", "reason": "loop"},
+        )
+        assert wid is not None
+        pending = await seeded_db.list_pending_wakeups("s1")
+        assert len(pending) == 1
+        assert pending[0]["prompt"] == "keep going"
+        assert pending[0]["reason"] == "loop"
+        # fire_at ~120s out, clamped within [60, 3600].
+        delta = (datetime.fromisoformat(pending[0]["fire_at"]) - datetime.now(timezone.utc)).total_seconds()
+        assert 60 <= delta <= 3600
+
+    @pytest.mark.asyncio
+    async def test_empty_prompt_is_ignored(self, seeded_db):
+        wid = await AgentEngine._record_wakeup(seeded_db, "s1", {"delaySeconds": 60, "prompt": "   "})
+        assert wid is None
+        assert await seeded_db.list_pending_wakeups("s1") == []
+
+    @pytest.mark.asyncio
+    async def test_missing_delay_defaults_to_min(self, seeded_db):
+        await AgentEngine._record_wakeup(seeded_db, "s1", {"prompt": "ping"})
+        pending = await seeded_db.list_pending_wakeups("s1")
+        delta = (datetime.fromisoformat(pending[0]["fire_at"]) - datetime.now(timezone.utc)).total_seconds()
+        assert abs(delta - 60) <= 2
+
+
+class TestResolveWakeupPrompt:
+    def test_passthrough(self):
+        assert _resolve_wakeup_prompt("keep monitoring X") == "keep monitoring X"
+
+    @pytest.mark.parametrize("sentinel", [
+        "<<autonomous-loop>>",
+        "<<autonomous-loop-dynamic>>",
+    ])
+    def test_sentinels_resolved(self, sentinel):
+        resolved = _resolve_wakeup_prompt(sentinel)
+        assert resolved != sentinel
+        assert "wakeup" in resolved.lower()

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -25,6 +25,7 @@ export type WSMessage =
   | { type: 'session_running'; session_id: string; is_running: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'timeout' }[] }
   | { type: 'hoa_progress'; session_id: string; event: Record<string, unknown> }
+  | { type: 'wakeup'; session_id: string }
   | { type: 'pong' };
 
 type MessageHandler = (msg: WSMessage) => void;

--- a/web/src/components/Chat/BlockRenderer.tsx
+++ b/web/src/components/Chat/BlockRenderer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Download, FileText } from 'lucide-react';
+import { Download, FileText, Clock } from 'lucide-react';
 import type { MessageBlock } from '../../types/chat';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolCallBlock } from './ToolCallBlock';
@@ -32,6 +32,17 @@ export function BlockRenderer({
         const isLast = streaming && i === renderItems.length - 1;
 
         switch (item.type) {
+          case 'wakeup':
+            return (
+              <div key={i} className="flex items-center gap-1.5 my-1.5 text-xs text-text-muted">
+                <span className="h-px flex-1 bg-border" />
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border border-border bg-surface">
+                  <Clock size={11} />
+                  Scheduled wakeup
+                </span>
+                <span className="h-px flex-1 bg-border" />
+              </div>
+            );
           case 'thinking':
             return <ThinkingBlock key={i} content={item.content} streaming={isLast} />;
           case 'tool_call':

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -8,7 +8,7 @@ import { hydrateMessage } from '../utils/hydrateMessage';
 import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './helpers/blockHelpers';
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
 // Handlers
-import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError } from './handlers/streamingHandlers';
+import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError, handleWakeup } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleAnswerInjected } from './handlers/sessionHandlers';
 import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress } from './handlers/panelHandlers';
 import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
@@ -512,6 +512,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       case 'tool_use':     return handleToolUse(msg, get, set);
       case 'tool_result':  return handleToolResult(msg, get, set);
       case 'done':         return handleDone(msg, get, set);
+      case 'wakeup':       return handleWakeup(msg, get, set);
       case 'stopped':      return handleStopped(msg, get, set);
       case 'error':        return handleError(msg, get, set);
       // Sessions

--- a/web/src/stores/handlers/streamingHandlers.ts
+++ b/web/src/stores/handlers/streamingHandlers.ts
@@ -77,6 +77,20 @@ export function handleToken(
   }
 }
 
+export function handleWakeup(
+  _msg: Extract<WSMessage, { type: 'wakeup' }>,
+  get: Get,
+  set: Set,
+): void {
+  // A self-scheduled wakeup just fired — prepend a marker so this turn
+  // renders with a "scheduled wakeup" chip, live and after reload.
+  const blocks = [...get().streamingBlocks];
+  if (!blocks.some((b) => b.type === 'wakeup')) {
+    blocks.unshift({ type: 'wakeup' });
+  }
+  set({ streamingBlocks: blocks, isStreaming: true });
+}
+
 export function handleToolUse(
   msg: Extract<WSMessage, { type: 'tool_use' }>,
   get: Get,

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -34,7 +34,12 @@ export interface FileBlockData {
   size?: number;
 }
 
-export type MessageBlock = ThinkingBlockData | TextBlockData | ToolCallBlockData | ImageBlockData | FileBlockData;
+/** Leading marker on a turn that fired from a self-scheduled ScheduleWakeup. */
+export interface WakeupBlockData {
+  type: 'wakeup';
+}
+
+export type MessageBlock = ThinkingBlockData | TextBlockData | ToolCallBlockData | ImageBlockData | FileBlockData | WakeupBlockData;
 
 export interface ChatMessage {
   id?: number;

--- a/web/src/utils/hydrateMessage.ts
+++ b/web/src/utils/hydrateMessage.ts
@@ -47,6 +47,9 @@ export function hydrateMessage(raw: any): ChatMessage {
     if (b.type === 'file') {
       return { type: 'file' as const, url: b.url || '', filename: b.filename || '', size: b.size };
     }
+    if (b.type === 'wakeup') {
+      return { type: 'wakeup' as const };
+    }
     // Default: text
     return { type: 'text' as const, content: b.content || '' };
   });


### PR DESCRIPTION
## Summary

Scheduled wakeups (`ScheduleWakeup`) never worked under Nerve. The bundled Claude CLI fires them autonomously inside its own subprocess, but Nerve only reads the SDK message stream during an active `run()` — so a fired wakeup turn landed in an **unread buffer** (invisible: no broadcast/persist/notify) and then **desynced the next real turn** (its buffered output was yielded first). Idle-client reaping (default 60 min) also silently dropped pending wakeups.

This makes Nerve the *harness* that owns wakeup timing:

- **Suppress the CLI's firing** — `CLAUDE_CODE_DISABLE_CRON=1` in the subprocess env. Tested: the tool still records + returns, it just no longer self-fires.
- **Drop the CLI's cron tools** — `disallowed_tools=[CronCreate, CronList, CronDelete]`; Nerve has its own cron system, so these are redundant.
- **Capture** — a `PostToolUse` hook on `ScheduleWakeup` records `delaySeconds`/`prompt`/`reason` to a new `session_wakeups` table (migration v031), clamped to `[60, 3600]`s, one pending wakeup per session.
- **Fire** — a 20s APScheduler sweep in the cron service atomically claims due wakeups (no double-fire), skips busy sessions, and re-injects via `engine.run(source="wakeup", internal=True)` — resuming the session like a persistent cron, so idle-reaping is no longer fatal.
- **UI** — the fired turn renders with a distinct "⏰ Scheduled wakeup" chip (live + on reload).

## Test plan

- [x] `pytest tests/` — 816 existing + 28 new wakeup tests pass
- [x] `npm run build` — clean (tsc + vite)
- [x] **Live end-to-end** on a running instance: `ScheduleWakeup` → hook wrote a `pending` row → sweep flipped it to `fired` and autonomously re-invoked the session ~one sweep tick after `fire_at`
- [ ] Reviewer: confirm the wakeup chip renders as expected in the chat stream

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*