### PR TITLE
feat(interactive): 1h AskUserQuestion timeout + sidebar waiting indicator

### DIFF
--- a/nerve/agent/interactive.py
+++ b/nerve/agent/interactive.py
@@ -29,8 +29,8 @@ from claude_agent_sdk.types import (
 
 logger = logging.getLogger(__name__)
 
-# Default timeout for interactive tool waits (5 minutes)
-INTERACTION_TIMEOUT = 300
+# Default timeout for interactive tool waits (1 hour)
+INTERACTION_TIMEOUT = 3600
 
 # Tools that require user interaction before execution
 INTERACTIVE_TOOLS = frozenset({
@@ -175,6 +175,9 @@ class InteractiveToolHandler:
             "tool_name": tool_name,
             "tool_input": tool_input,
         })
+        # Tell every connected client this session is now waiting for input,
+        # so the sidebar can show the "waiting" indicator (blue dot).
+        await self._broadcast_awaiting()
 
         logger.info(
             "Session %s: waiting for user input on %s (interaction %s)",
@@ -182,37 +185,59 @@ class InteractiveToolHandler:
         )
 
         try:
-            await asyncio.wait_for(pending.event.wait(), timeout=INTERACTION_TIMEOUT)
-        except asyncio.TimeoutError:
+            try:
+                await asyncio.wait_for(pending.event.wait(), timeout=INTERACTION_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Session %s: interaction %s timed out after %ds",
+                    self.session_id, interaction_id[:8], INTERACTION_TIMEOUT,
+                )
+                return PermissionResultDeny(
+                    message=f"No response received after {_humanize_seconds(INTERACTION_TIMEOUT)} — timed out.",
+                )
+            except asyncio.CancelledError:
+                logger.info("Session %s: interaction %s cancelled", self.session_id, interaction_id[:8])
+                return PermissionResultDeny(
+                    message="Session stopped by user.",
+                    interrupt=True,
+                )
+
+            if pending.denied:
+                logger.info("Session %s: %s denied by user", self.session_id, tool_name)
+                return PermissionResultDeny(message=pending.deny_message or "Declined by user.")
+
+            # For AskUserQuestion: inject answers into the tool input
+            if tool_name == "AskUserQuestion" and pending.result:
+                updated = {**tool_input, "answers": pending.result}
+                return PermissionResultAllow(updated_input=updated)
+
+            # For ExitPlanMode/EnterPlanMode: just allow
+            return PermissionResultAllow()
+        finally:
+            # Always drop the pending entry and refresh the waiting indicator,
+            # regardless of how the wait resolved (answered, denied, timeout,
+            # cancelled). has_pending then reflects any remaining interaction.
             self._pending.pop(interaction_id, None)
-            logger.warning(
-                "Session %s: interaction %s timed out after %ds",
-                self.session_id, interaction_id[:8], INTERACTION_TIMEOUT,
+            await self._broadcast_awaiting()
+
+    async def _broadcast_awaiting(self) -> None:
+        """Broadcast this session's waiting-for-input state to all clients.
+
+        Sent on the global channel so every connected client updates the
+        sidebar indicator for this session, even when viewing another one.
+        Best-effort: a broadcast failure must not break the interaction flow.
+        """
+        try:
+            await self._broadcast("__global__", {
+                "type": "session_awaiting_input",
+                "session_id": self.session_id,
+                "awaiting": self.has_pending,
+            })
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(
+                "Failed to broadcast awaiting-input state for %s: %s",
+                self.session_id, e,
             )
-            return PermissionResultDeny(
-                message=f"No response received after {INTERACTION_TIMEOUT // 60} minutes — timed out.",
-            )
-        except asyncio.CancelledError:
-            self._pending.pop(interaction_id, None)
-            logger.info("Session %s: interaction %s cancelled", self.session_id, interaction_id[:8])
-            return PermissionResultDeny(
-                message="Session stopped by user.",
-                interrupt=True,
-            )
-
-        self._pending.pop(interaction_id, None)
-
-        if pending.denied:
-            logger.info("Session %s: %s denied by user", self.session_id, tool_name)
-            return PermissionResultDeny(message=pending.deny_message or "Declined by user.")
-
-        # For AskUserQuestion: inject answers into the tool input
-        if tool_name == "AskUserQuestion" and pending.result:
-            updated = {**tool_input, "answers": pending.result}
-            return PermissionResultAllow(updated_input=updated)
-
-        # For ExitPlanMode/EnterPlanMode: just allow
-        return PermissionResultAllow()
 
     def resolve(self, interaction_id: str, result: dict[str, Any] | None = None) -> bool:
         """Resolve a pending interaction with the user's answer.
@@ -303,6 +328,16 @@ def get_handler(session_id: str) -> InteractiveToolHandler | None:
     return _handlers.get(session_id)
 
 
+def get_awaiting_ids() -> set[str]:
+    """Return session IDs currently paused waiting for user input.
+
+    Mirrors ``SessionManager.get_running_ids`` for the interactive layer:
+    the REST sessions list uses it so a freshly-loaded UI shows the
+    "waiting for input" indicator without relying on the live broadcast.
+    """
+    return {sid for sid, handler in _handlers.items() if handler.has_pending}
+
+
 def _interaction_type(tool_name: str) -> str:
     """Map tool name to a UI-friendly interaction type."""
     return {
@@ -310,3 +345,12 @@ def _interaction_type(tool_name: str) -> str:
         "ExitPlanMode": "plan_exit",
         "EnterPlanMode": "plan_enter",
     }.get(tool_name, "unknown")
+
+
+def _humanize_seconds(seconds: int) -> str:
+    """Human-readable duration for timeout messages (e.g. '1 hour', '5 minutes')."""
+    if seconds >= 3600 and seconds % 3600 == 0:
+        hours = seconds // 3600
+        return f"{hours} hour{'s' if hours != 1 else ''}"
+    minutes = max(1, seconds // 60)
+    return f"{minutes} minute{'s' if minutes != 1 else ''}"

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from nerve.agent.interactive import get_awaiting_ids
 from nerve.config import get_config
 from nerve.gateway.auth import require_auth
 from nerve.gateway.routes._deps import get_deps
@@ -71,8 +72,10 @@ async def list_sessions(user: dict = Depends(require_auth)):
     deps = get_deps()
     sessions = await deps.engine.sessions.list_sessions()
     running_ids = deps.engine.sessions.get_running_ids()
+    awaiting_ids = get_awaiting_ids()
     for s in sessions:
         s["is_running"] = s["id"] in running_ids
+        s["awaiting_input"] = s["id"] in awaiting_ids
     return {"sessions": sessions}
 
 
@@ -84,8 +87,10 @@ async def search_sessions(q: str, user: dict = Depends(require_auth)):
     deps = get_deps()
     sessions = await deps.db.search_sessions(q.strip())
     running_ids = deps.engine.sessions.get_running_ids()
+    awaiting_ids = get_awaiting_ids()
     for s in sessions:
         s["is_running"] = s["id"] in running_ids
+        s["awaiting_input"] = s["id"] in awaiting_ids
     return {"sessions": sessions}
 
 
@@ -198,6 +203,7 @@ async def session_status(session_id: str, user: dict = Depends(require_auth)):
         "session_id": session_id,
         "status": session.get("status", "unknown"),
         "is_running": is_running,
+        "awaiting_input": session_id in get_awaiting_ids(),
         "sdk_session_id": session.get("sdk_session_id"),
         "connected_at": session.get("connected_at"),
         "parent_session_id": session.get("parent_session_id"),

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,115 @@
+"""Tests for the interactive tool handler: timeout, waiting-input indicator."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+from nerve.agent.interactive import (
+    INTERACTION_TIMEOUT,
+    InteractiveToolHandler,
+    _humanize_seconds,
+    get_awaiting_ids,
+    register_handler,
+    unregister_handler,
+)
+
+
+def test_interaction_timeout_is_one_hour():
+    """AskUserQuestion / plan-mode waits give the user a full hour to respond."""
+    assert INTERACTION_TIMEOUT == 3600
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [
+        (3600, "1 hour"),
+        (7200, "2 hours"),
+        (300, "5 minutes"),
+        (60, "1 minute"),
+        (90, "1 minute"),  # floor division -> 1
+        (5400, "90 minutes"),  # not a whole number of hours
+    ],
+)
+def test_humanize_seconds(seconds, expected):
+    assert _humanize_seconds(seconds) == expected
+
+
+async def _wait_until_pending(handler: InteractiveToolHandler) -> None:
+    """Spin briefly until the handler registers its pending interaction."""
+    for _ in range(200):
+        if handler.has_pending:
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("handler never became pending")
+
+
+@pytest.mark.asyncio
+async def test_awaiting_input_broadcast_and_registry():
+    """An interactive wait sets the registry flag and broadcasts awaiting=true,
+    then clears both once the user answers."""
+    messages: list[tuple[str, dict]] = []
+
+    async def broadcast(channel: str, msg: dict) -> None:
+        messages.append((channel, msg))
+
+    handler = InteractiveToolHandler("sess-await", broadcast, interactive_capable=True)
+    register_handler("sess-await", handler)
+    try:
+        task = asyncio.create_task(
+            handler._handle_interactive("AskUserQuestion", {"questions": []})
+        )
+        await _wait_until_pending(handler)
+
+        # Registry reports the session as waiting for input.
+        assert "sess-await" in get_awaiting_ids()
+
+        # A global awaiting=true broadcast was emitted.
+        awaiting = [m for (_c, m) in messages if m["type"] == "session_awaiting_input"]
+        assert awaiting and awaiting[-1]["awaiting"] is True
+        assert any(c == "__global__" for (c, m) in messages if m["type"] == "session_awaiting_input")
+
+        # Resolve with an answer.
+        interaction = next(m for (_c, m) in messages if m["type"] == "interaction")
+        assert handler.resolve(interaction["interaction_id"], {"q": "a"})
+        result = await task
+
+        assert isinstance(result, PermissionResultAllow)
+        assert result.updated_input == {"questions": [], "answers": {"q": "a"}}
+
+        # Waiting state cleared in registry and via a final awaiting=false broadcast.
+        assert not handler.has_pending
+        assert "sess-await" not in get_awaiting_ids()
+        awaiting = [m for (_c, m) in messages if m["type"] == "session_awaiting_input"]
+        assert awaiting[-1]["awaiting"] is False
+    finally:
+        unregister_handler("sess-await")
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_awaiting():
+    """Stopping a session mid-wait denies the interaction and clears the flag."""
+    messages: list[tuple[str, dict]] = []
+
+    async def broadcast(channel: str, msg: dict) -> None:
+        messages.append((channel, msg))
+
+    handler = InteractiveToolHandler("sess-cancel", broadcast, interactive_capable=True)
+    register_handler("sess-cancel", handler)
+    try:
+        task = asyncio.create_task(handler._handle_interactive("EnterPlanMode", {}))
+        await _wait_until_pending(handler)
+        assert "sess-cancel" in get_awaiting_ids()
+
+        handler.cancel_all()
+        result = await task
+
+        assert isinstance(result, PermissionResultDeny)
+        assert not handler.has_pending
+        assert "sess-cancel" not in get_awaiting_ids()
+        awaiting = [m for (_c, m) in messages if m["type"] == "session_awaiting_input"]
+        assert awaiting[-1]["awaiting"] is False
+    finally:
+        unregister_handler("sess-cancel")

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -23,6 +23,7 @@ export type WSMessage =
   | { type: 'notification_answered'; notification_id: string; session_id: string; answer: string; answered_by: string; approval_status?: 'answered' | 'snoozed'; dispatch_ok?: boolean }
   | { type: 'answer_injected'; session_id: string; notification_id: string; title: string; answer: string; answered_by: string; content: string }
   | { type: 'session_running'; session_id: string; is_running: boolean }
+  | { type: 'session_awaiting_input'; session_id: string; awaiting: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'timeout' }[] }
   | { type: 'hoa_progress'; session_id: string; event: Record<string, unknown> }
   | { type: 'wakeup'; session_id: string }

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -328,6 +328,18 @@ function StatusIndicator({ session, isActive, isRunning }: {
   isActive: boolean;
   isRunning: boolean;
 }) {
+  // Waiting for user input (AskUserQuestion / plan mode): pulsing blue dot.
+  // Takes priority over the running spinner/dot — the session is paused, not
+  // working, and needs the user's attention.
+  if (session.awaiting_input) {
+    return (
+      <span className="relative flex h-2 w-2 shrink-0" title="Waiting for your input">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+      </span>
+    );
+  }
+
   // Active + running: spinner
   if (isActive && isRunning) {
     return <Loader2 size={12} className="shrink-0 text-accent animate-spin" />;

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -9,7 +9,7 @@ import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
 // Handlers
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError, handleWakeup } from './handlers/streamingHandlers';
-import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleAnswerInjected } from './handlers/sessionHandlers';
+import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected } from './handlers/sessionHandlers';
 import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress } from './handlers/panelHandlers';
 import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
 
@@ -523,6 +523,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       case 'session_resumed':  return handleSessionResumed(msg, get, set);
       case 'session_archived': return handleSessionArchived(msg, get, set);
       case 'session_running':  return handleSessionRunning(msg, get, set);
+      case 'session_awaiting_input': return handleSessionAwaitingInput(msg, get, set);
       case 'answer_injected':  return handleAnswerInjected(msg, get, set);
       // Panels
       case 'plan_update':        return handlePlanUpdate(msg, get, set);

--- a/web/src/stores/handlers/sessionHandlers.ts
+++ b/web/src/stores/handlers/sessionHandlers.ts
@@ -223,6 +223,27 @@ export function handleSessionRunning(
   });
 }
 
+export function handleSessionAwaitingInput(
+  msg: Extract<WSMessage, { type: 'session_awaiting_input' }>,
+  _get: Get,
+  set: Set,
+): void {
+  // Global broadcast: a session entered or left the "waiting for input" state
+  // (paused on AskUserQuestion / plan mode). Drives the sidebar blue dot.
+  set(s => ({
+    sessions: s.sessions.map(sess =>
+      sess.id === msg.session_id
+        ? { ...sess, awaiting_input: msg.awaiting }
+        : sess,
+    ),
+    searchResults: s.searchResults?.map(sess =>
+      sess.id === msg.session_id
+        ? { ...sess, awaiting_input: msg.awaiting }
+        : sess,
+    ) ?? null,
+  }));
+}
+
 export function handleAnswerInjected(
   msg: Extract<WSMessage, { type: 'answer_injected' }>,
   get: Get,

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -64,6 +64,9 @@ export interface Session {
   model?: string;
   // Real-time running status (set by backend + WS updates)
   is_running?: boolean;
+  // Paused mid-turn waiting for user input (AskUserQuestion / plan mode).
+  // Drives the sidebar "waiting" indicator. Set by backend + WS updates.
+  awaiting_input?: boolean;
   starred?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Two small interactive-input UX improvements:

1. **AskUserQuestion timeout: 5 min → 1 hour.** `INTERACTION_TIMEOUT` 300 → 3600 in `nerve/agent/interactive.py`. Added a `_humanize_seconds()` helper so the timeout deny message reads *"No response received after 1 hour"* instead of *"60 minutes"*.

2. **"Waiting for input" indicator in the session sidebar.** When a session pauses on `AskUserQuestion` / plan mode, the left sidebar now shows a **pulsing blue dot** — distinct from the green "running" dot — so it's obvious which session needs your attention.

## How it works

- **Backend** (`interactive.py`): `_handle_interactive` is restructured so a global `session_awaiting_input` message is broadcast on enter, and always cleared via `try/finally` on every exit path (answer, deny, timeout, stop). New `get_awaiting_ids()` mirrors `get_running_ids()`.
- **REST** (`routes/sessions.py`): the session list / search / status endpoints now include `awaiting_input`, so the indicator survives a page refresh (not just live WS updates).
- **Frontend**: new `session_awaiting_input` WS type + `handleSessionAwaitingInput` handler, `awaiting_input` field on `Session`, and the blue dot in `StatusIndicator` (takes priority over the running spinner — a paused session is waiting, not working).

A waiting session keeps `is_running=true` (the engine is still mid-turn), so it stays pinned under the sidebar's **Running** group, just with a blue dot. Keeps it visible up top where it needs action.

## Test plan

- [x] `pytest tests/` — 819 existing + 9 new (`tests/test_interactive.py`: timeout value, humanize formatting, awaiting broadcast/registry lifecycle, stop-clears-waiting)
- [x] `npm run build` — clean
- [ ] Manual: trigger an `AskUserQuestion` in a background session, confirm the blue dot appears in the sidebar and clears on answer/refresh

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*