### PR TITLE
fix(deps): pull boto3/botocore via anthropic[bedrock] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
     "websockets>=14.0",
     "click>=8.1.0",
     "telethon>=1.38.0",
-    "anthropic>=0.45.0",  # used by memu_bridge for event date resolution
+    # [bedrock] pulls boto3/botocore, required by AnthropicBedrock for AWS SigV4
+    # request signing (session title generation and other direct-SDK fast-model calls).
+    "anthropic[bedrock]>=0.45.0",  # used by memu_bridge for event date resolution
     "memu-py==1.4.0",  # pinned — nerve monkey-patches memU internals (see memu_bridge._patch_sqlite_bugs)
     "watchfiles>=1.0.0",
     "html2text>=2024.2.26",


### PR DESCRIPTION
## Summary

`AnthropicBedrock` (the raw `anthropic` SDK client used for direct fast-model calls like session title generation) requires `botocore` for AWS SigV4 request signing. The plain `anthropic` dependency does **not** pull it in, so on Bedrock deployments every such call failed at request time.

Observed symptom: chat sessions were never renamed. The log showed, on each new session:

```
[WARNING] nerve.agent.engine: Failed to generate session title: No module named 'botocore'
```

The error is swallowed by the `try/except` in `_generate_session_title`, so it surfaced only as "titles never update."

This was **not** a model-identifier problem — `config.yaml` already had the correct Bedrock title model (`us.anthropic.claude-haiku-4-5-...-v1:0`). The fix is purely to declare the `[bedrock]` extra so `boto3`/`botocore` get installed.

## Change

- `anthropic>=0.45.0` → `anthropic[bedrock]>=0.45.0` in `pyproject.toml`

No code change.

## Test plan

- [x] Reproduced: `AnthropicBedrock` request raised `ModuleNotFoundError: No module named 'botocore'`
- [x] Installed `anthropic[bedrock]` → boto3/botocore present
- [x] End-to-end: `_generate_session_title` path now returns a title via `us.anthropic.claude-haiku-4-5-20251001-v1:0` and updates the session
- [x] `pyproject.toml` parses; `nerve.config` / `nerve.agent.engine` import clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)