### PR TITLE
feat(memory): recall category breadcrumbs + drill-down tool

### DIFF
--- a/nerve/agent/tools/handlers/memory.py
+++ b/nerve/agent/tools/handlers/memory.py
@@ -20,6 +20,7 @@ from nerve.agent.tools.schemas import (
     CONVERSATION_HISTORY_SCHEMA,
     MEMORIZE_SCHEMA,
     MEMORY_DELETE_SCHEMA,
+    MEMORY_EXPAND_CATEGORY_SCHEMA,
     MEMORY_RECALL_SCHEMA,
     MEMORY_RECORDS_BY_DATE_SCHEMA,
     MEMORY_UPDATE_SCHEMA,
@@ -37,23 +38,100 @@ def _resolve_memu_db_path(ctx: ToolContext) -> str:
     return get_config().memory.sqlite_dsn.replace("sqlite:///", "")
 
 
+# Hard backstop on recall tool-output size. The breadcrumb fix keeps recall
+# small, but this guarantees the result can never exceed the harness's
+# inline-output limit (which would silently persist it to a file).
+_MAX_RECALL_BYTES = 10_000
+
+
+def _clip_to_budget(text: str, max_bytes: int = _MAX_RECALL_BYTES) -> str:
+    """Truncate text to a UTF-8 byte budget, appending a notice if clipped."""
+    data = text.encode("utf-8")
+    if len(data) <= max_bytes:
+        return text
+    clipped = data[:max_bytes].decode("utf-8", "ignore").rstrip()
+    return f"{clipped}\n… (truncated to fit recall size budget)"
+
+
 async def memory_recall_handler(ctx: ToolContext, args: dict) -> ToolResult:
     query = args["query"]
     limit = int(args.get("limit", 10))
+    category_limit = int(args.get("category_limit", 5))
 
     if ctx.memory_bridge:
         try:
-            results = await ctx.memory_bridge.recall(query, limit=limit)
-            if results:
-                lines = [f"- [{m['type']}] (id:{m['id']}) {m['summary']}" for m in results]
-                text = "\n".join(lines)
-                return ToolResult.text(f"Recalled {len(results)} memories:\n\n{text}")
-            return ToolResult.text("No relevant memories found.")
+            results = await ctx.memory_bridge.recall(
+                query, limit=limit, category_limit=category_limit,
+            )
+            if not results:
+                return ToolResult.text("No relevant memories found.")
+
+            items = [m for m in results if m.get("type") != "category"]
+            cats = [m for m in results if m.get("type") == "category"]
+
+            sections: list[str] = []
+            if items:
+                item_lines = [
+                    f"- [{m['type']}] (id:{m['id']}) {m['summary']}" for m in items
+                ]
+                sections.append("\n".join(item_lines))
+            if cats:
+                cat_lines = [
+                    f"- [{m.get('name') or 'topic'}] (id:{m['id']}) {m['summary']}"
+                    for m in cats
+                ]
+                sections.append(
+                    "Related topics — drill in with memory_expand_category "
+                    "(pass the cat:<id>):\n" + "\n".join(cat_lines)
+                )
+
+            body = _clip_to_budget("\n\n".join(sections))
+            header = f"Recalled {len(items)} memories"
+            if cats:
+                header += f" + {len(cats)} related topics"
+            return ToolResult.text(f"{header}:\n\n{body}")
         except Exception as e:
             logger.error("Memory recall failed: %s", e)
             return ToolResult.text(f"Memory recall error: {e}")
 
     return ToolResult.text("Memory service not configured.")
+
+
+async def memory_expand_category_handler(ctx: ToolContext, args: dict) -> ToolResult:
+    """Expand a category breadcrumb (from recall) into its memory items."""
+    category_id = (args.get("category_id") or "").strip()
+    if not category_id:
+        return ToolResult.text("category_id is required.", is_error=True)
+    query = (args.get("query") or "").strip()
+    limit = int(args.get("limit", 20))
+
+    if not ctx.memory_bridge or not ctx.memory_bridge.available:
+        return ToolResult.text("Memory service not available.")
+
+    try:
+        result = await ctx.memory_bridge.expand_category(
+            category_id, query=query, limit=limit,
+        )
+        if result.get("name") is None:
+            return ToolResult.text(
+                f"No category found with id '{category_id}'. "
+                "Use the cat:<id> value from a recall breadcrumb."
+            )
+        name = result["name"]
+        total = result.get("total", 0)
+        rows = result.get("items", [])
+        if not rows:
+            note = f" matching '{query}'" if query else ""
+            return ToolResult.text(f"Category '{name}' has no items{note}.")
+
+        lines = [f"- [{r['type']}] (id:{r['id']}) {r['summary']}" for r in rows]
+        scope = f"matching '{query}'" if query else "most recent"
+        header = f"Category '{name}' — showing {len(rows)} of {total} items ({scope}):"
+        body = _clip_to_budget(header + "\n\n" + "\n".join(lines))
+        return ToolResult.text(body)
+    except Exception as e:
+        logger.error("memory_expand_category failed: %s", e)
+        return ToolResult.text(f"Error: {e}")
 
 
 async def session_context_handler(ctx: ToolContext, args: dict) -> ToolResult:
@@ -342,9 +420,16 @@ async def category_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
 
 MEMORY_RECALL_SPEC = ToolSpec(
     name="memory_recall",
-    description="Recall relevant memories via semantic search (memU). Returns memories related to the query.",
+    description="Recall relevant memories via semantic search (memU). Returns matching memory items plus related-topic breadcrumbs (cat:<id>) you can drill into with memory_expand_category.",
     input_schema=MEMORY_RECALL_SCHEMA,
     handler=memory_recall_handler,
+)
+
+MEMORY_EXPAND_CATEGORY_SPEC = ToolSpec(
+    name="memory_expand_category",
+    description="Expand a category breadcrumb from memory_recall into its constituent memory items. Pass the cat:<id> shown in a recall 'related topics' line. Optionally keyword-filter with `query`. Results are most-recent-first and bounded.",
+    input_schema=MEMORY_EXPAND_CATEGORY_SCHEMA,
+    handler=memory_expand_category_handler,
 )
 
 SESSION_CONTEXT_SPEC = ToolSpec(
@@ -420,6 +505,7 @@ CATEGORY_UPDATE_SPEC = ToolSpec(
 
 MEMORY_SPECS = [
     MEMORY_RECALL_SPEC,
+    MEMORY_EXPAND_CATEGORY_SPEC,
     SESSION_CONTEXT_SPEC,
     CONVERSATION_HISTORY_SPEC,
     MEMORY_RECORDS_BY_DATE_SPEC,

--- a/nerve/agent/tools/schemas.py
+++ b/nerve/agent/tools/schemas.py
@@ -202,9 +202,35 @@ MEMORY_RECALL_SCHEMA = {
     "type": "object",
     "properties": {
         "query": {"type": "string", "description": "What to search for in memory"},
-        "limit": {"type": "number", "description": "Max results", "default": 10},
+        "limit": {"type": "number", "description": "Max memory items to return", "default": 10},
+        "category_limit": {
+            "type": "number",
+            "description": "Max related-topic breadcrumbs (categories) to return",
+            "default": 5,
+        },
     },
     "required": ["query"],
+}
+
+MEMORY_EXPAND_CATEGORY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "category_id": {
+            "type": "string",
+            "description": "Category id from a recall breadcrumb. The 'cat:' prefix is accepted and stripped.",
+        },
+        "query": {
+            "type": "string",
+            "description": "Optional keyword to filter the category's items by their text.",
+            "default": "",
+        },
+        "limit": {
+            "type": "number",
+            "description": "Max items to return (most recent first). Default 20.",
+            "default": 20,
+        },
+    },
+    "required": ["category_id"],
 }
 
 SESSION_CONTEXT_SCHEMA = {

--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -29,6 +29,41 @@ logger = logging.getLogger(__name__)
 # Semantic dedup threshold — set from config at init time.
 _SEMANTIC_DEDUP_THRESHOLD = 0.85
 
+# Max characters for a category breadcrumb in recall() output. A category
+# summary is a whole rolled-up topic document (often 5–20KB); recall must
+# surface it as a short navigable pointer, not dump the document.
+_CATEGORY_BREADCRUMB_MAXLEN = 200
+
+
+def _category_breadcrumb(name: str, description: str, summary: str) -> str:
+    """Build a short one-line breadcrumb for a category recall hit.
+
+    Prefers the curated ``description`` (a 1-line purpose). Falls back to the
+    first meaningful line of the rolled-up ``summary`` (with any ``[ref:ID]``
+    citation markers stripped). Never returns the full summary — that is what
+    ``memory_expand_category`` is for.
+    """
+    text = (description or "").strip()
+    if not text:
+        try:
+            from memu.utils.references import strip_references
+        except Exception:  # pragma: no cover - defensive
+            def strip_references(t: str | None) -> str | None:
+                return t
+        for raw in (summary or "").splitlines():
+            line = (strip_references(raw) or "").strip()
+            # Skip markdown headers — they just repeat the category name,
+            # which is returned separately. Take the first real content line.
+            if not line or line.startswith("#"):
+                continue
+            line = line.lstrip("-*").strip()
+            if line:
+                text = line
+                break
+    if len(text) > _CATEGORY_BREADCRUMB_MAXLEN:
+        text = text[: _CATEGORY_BREADCRUMB_MAXLEN - 1].rstrip() + "…"
+    return text
+
 
 class _BedrockLLMClient:
     """Drop-in replacement for memU's OpenAISDKClient that uses AsyncAnthropicBedrock.
@@ -2047,11 +2082,25 @@ class MemUBridge:
 
         return []
 
-    async def recall(self, query: str, limit: int = 10) -> list[dict[str, str]]:
+    async def recall(
+        self, query: str, limit: int = 10, category_limit: int = 5,
+    ) -> list[dict[str, str]]:
         """Recall relevant memories via semantic search.
 
-        Returns list of dicts with keys: id, type, summary.
-        Category results use id="cat:<id>".
+        Returns a list of dicts with keys: id, type, summary (plus ``name``
+        for category hits). Items come first (atomic, full content), followed
+        by category hits rendered as short breadcrumbs (``id="cat:<id>"``).
+
+        memU is hierarchical: an item is one atomic fact, a category is a
+        rolled-up topic *document* (often 5–20KB) that indexes many items.
+        Returning category documents verbatim blows past tool-output size
+        limits and duplicates the items, so category hits are reduced to a
+        one-line breadcrumb. Drill into a category's items with
+        ``expand_category`` / the ``memory_expand_category`` tool.
+
+        Args:
+            limit: max item hits to return (full content).
+            category_limit: max category breadcrumbs to return.
         """
         if not self._available or not self._service:
             return []
@@ -2061,9 +2110,10 @@ class MemUBridge:
                 queries=[{"role": "user", "content": query}],
             )
 
-            memories: list[dict[str, str]] = []
+            items_out: list[dict[str, str]] = []
+            cats_out: list[dict[str, str]] = []
 
-            # Extract from items (individual memory entries)
+            # Items — individual memory entries, returned with full content.
             for item in result.get("items", []):
                 if isinstance(item, dict):
                     text = item.get("summary", item.get("content", ""))
@@ -2078,34 +2128,103 @@ class MemUBridge:
                     item_id = ""
                     mtype = ""
                 if text:
-                    memories.append({"id": item_id, "type": mtype, "summary": text})
+                    items_out.append({"id": item_id, "type": mtype, "summary": text})
 
-            # Extract from categories (higher-level summaries)
+            # Categories — reduced to a one-line breadcrumb (never the full doc).
             for cat in result.get("categories", []):
                 if isinstance(cat, dict):
                     summary = cat.get("summary", "")
+                    description = cat.get("description", "")
                     name = cat.get("name", "")
                     cat_id = cat.get("id", "")
                 elif hasattr(cat, "summary"):
                     summary = cat.summary
+                    description = getattr(cat, "description", "")
                     name = getattr(cat, "name", "")
                     cat_id = getattr(cat, "id", "")
                 else:
                     continue
-                if summary:
-                    memories.append({
+                crumb = _category_breadcrumb(name, description, summary)
+                if crumb or name:
+                    cats_out.append({
                         "id": f"cat:{cat_id}",
                         "type": "category",
-                        "summary": f"[{name}] {summary}" if name else summary,
+                        "name": name,
+                        "summary": crumb,
                     })
 
             self._metrics.end_op(op_id, success=True)
-            return memories[:limit]
+            return items_out[:limit] + cats_out[:category_limit]
 
         except Exception as e:
             logger.error("memU recall failed: %s", e)
             self._metrics.end_op(op_id, success=False, error=str(e))
             return []
+
+    async def expand_category(
+        self, category_id: str, query: str = "", limit: int = 20,
+    ) -> dict[str, Any]:
+        """Drill into a category and return its constituent memory items.
+
+        Categories surface in ``recall`` as one-line breadcrumbs; this expands
+        one into its atomic items via the ``memu_category_items`` membership
+        table. Results are ordered most-recent-first and bounded by ``limit``;
+        an optional ``query`` keyword-filters item summaries.
+
+        Returns a dict: ``{name, total, items: [{id, type, summary}]}``.
+        ``name`` is ``None`` when the category id is unknown.
+        """
+        if not self._available or not self._service:
+            return {"name": None, "total": 0, "items": []}
+
+        cat_id = category_id[4:] if category_id.startswith("cat:") else category_id
+        cat_id = cat_id.strip()
+        if not cat_id:
+            return {"name": None, "total": 0, "items": []}
+
+        def _run() -> dict[str, Any]:
+            import sqlite3
+
+            dsn = self.config.memory.sqlite_dsn.replace("sqlite:///", "")
+            db = sqlite3.connect(dsn)
+            db.row_factory = sqlite3.Row
+            try:
+                crow = db.execute(
+                    "SELECT name FROM memu_memory_categories WHERE id = ?",
+                    (cat_id,),
+                ).fetchone()
+                if not crow:
+                    return {"name": None, "total": 0, "items": []}
+                total = db.execute(
+                    "SELECT count(*) FROM memu_category_items WHERE category_id = ?",
+                    (cat_id,),
+                ).fetchone()[0]
+                sql = (
+                    "SELECT i.id, i.memory_type, i.summary "
+                    "FROM memu_category_items ci "
+                    "JOIN memu_memory_items i ON i.id = ci.item_id "
+                    "WHERE ci.category_id = ?"
+                )
+                params: list[Any] = [cat_id]
+                if query:
+                    sql += " AND lower(i.summary) LIKE ?"
+                    params.append(f"%{query.lower()}%")
+                sql += " ORDER BY i.updated_at DESC, i.created_at DESC LIMIT ?"
+                params.append(limit)
+                rows = db.execute(sql, params).fetchall()
+                items = [
+                    {"id": r["id"], "type": r["memory_type"], "summary": r["summary"]}
+                    for r in rows
+                ]
+                return {"name": crow["name"], "total": total, "items": items}
+            finally:
+                db.close()
+
+        try:
+            return await asyncio.to_thread(_run)
+        except Exception as e:
+            logger.error("expand_category failed for %s: %s", cat_id, e)
+            return {"name": None, "total": 0, "items": []}
 
     async def list_items(self) -> list[dict[str, Any]]:
         """List all memory items."""

--- a/tests/test_recall_breadcrumbs.py
+++ b/tests/test_recall_breadcrumbs.py
@@ -1,0 +1,300 @@
+"""Tests for recall category breadcrumbs + memory_expand_category drill-down.
+
+memU categories are rolled-up topic *documents* (often 5–20KB). recall must
+surface them as short navigable breadcrumbs, never dump the document — that
+blows past the harness tool-output limit. These tests lock in that contract
+and the drill-down path that replaces the lost detail.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nerve.agent.tools.handlers.memory import (
+    _clip_to_budget,
+    memory_expand_category_handler,
+    memory_recall_handler,
+)
+from nerve.agent.tools.registry import ToolContext
+from nerve.config import MemoryConfig, NerveConfig
+from nerve.memory.memu_bridge import MemUBridge, _category_breadcrumb
+
+
+def _make_config(tmp_path: Path) -> NerveConfig:
+    config = NerveConfig()
+    config.memory = MemoryConfig(sqlite_dsn=f"sqlite:///{tmp_path / 'memu.sqlite'}")
+    config.anthropic_api_key = "test-key"
+    return config
+
+
+def _stub_bridge(config: NerveConfig) -> MemUBridge:
+    """A MemUBridge marked available with a mockable _service."""
+    bridge = MemUBridge(config)
+    bridge._available = True
+    bridge._service = MagicMock()
+    return bridge
+
+
+def _ctx(bridge) -> ToolContext:
+    return ToolContext(
+        session_id="s-1",
+        workspace=Path("/tmp/ws"),
+        db=None,
+        memory_bridge=bridge,
+        config=None,
+    )
+
+
+# --- pure helpers ----------------------------------------------------------
+
+
+def test_breadcrumb_prefers_description() -> None:
+    crumb = _category_breadcrumb(
+        name="preferences",
+        description="Communication style and tool preferences",
+        summary="# preferences\n\n## A\n- huge\n" + ("x" * 5000),
+    )
+    assert crumb == "Communication style and tool preferences"
+    assert len(crumb) < 200
+
+
+def test_breadcrumb_falls_back_to_first_summary_line() -> None:
+    crumb = _category_breadcrumb(
+        name="agent_ops",
+        description="",
+        summary="# agent_ops\n\n- First real fact [ref:abc123]\n- second",
+    )
+    # header '#' skipped, first bullet used, [ref:] stripped
+    assert "First real fact" in crumb
+    assert "ref:" not in crumb
+    assert "#" not in crumb
+
+
+def test_breadcrumb_truncates_long_text() -> None:
+    crumb = _category_breadcrumb("c", "y" * 500, "")
+    assert len(crumb) <= 200
+    assert crumb.endswith("…")
+
+
+def test_clip_to_budget_passes_small_text() -> None:
+    assert _clip_to_budget("hello", max_bytes=100) == "hello"
+
+
+def test_clip_to_budget_truncates_large_text() -> None:
+    out = _clip_to_budget("a" * 50_000, max_bytes=1000)
+    assert len(out.encode("utf-8")) <= 1000 + 64
+    assert "truncated" in out
+
+
+# --- bridge.recall() -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_categories_become_breadcrumbs(tmp_path) -> None:
+    config = _make_config(tmp_path)
+    bridge = _stub_bridge(config)
+
+    fat_summary = "# preferences\n\n" + ("- a giant bullet\n" * 2000)  # ~30KB
+    bridge._service.retrieve = AsyncMock(return_value={
+        "items": [
+            {"id": "i1", "memory_type": "profile", "summary": "Alice lives in Metropolis"},
+            {"id": "i2", "memory_type": "behavior", "summary": "Prefers dark mode"},
+        ],
+        "categories": [
+            {
+                "id": "c1",
+                "name": "preferences",
+                "description": "How things should be done",
+                "summary": fat_summary,
+            },
+        ],
+    })
+
+    out = await bridge.recall("prefs", limit=10, category_limit=5)
+
+    items = [m for m in out if m["type"] != "category"]
+    cats = [m for m in out if m["type"] == "category"]
+    assert len(items) == 2
+    assert items[0]["summary"] == "Alice lives in Metropolis"  # full content kept
+    assert len(cats) == 1
+    cat = cats[0]
+    assert cat["id"] == "cat:c1"
+    assert cat["name"] == "preferences"
+    assert cat["summary"] == "How things should be done"  # breadcrumb, not the doc
+    # The fat document must not leak anywhere into the result.
+    assert "giant bullet" not in repr(out)
+
+
+@pytest.mark.asyncio
+async def test_recall_caps_items_and_categories(tmp_path) -> None:
+    config = _make_config(tmp_path)
+    bridge = _stub_bridge(config)
+    bridge._service.retrieve = AsyncMock(return_value={
+        "items": [
+            {"id": f"i{n}", "memory_type": "knowledge", "summary": f"fact {n}"}
+            for n in range(20)
+        ],
+        "categories": [
+            {"id": f"c{n}", "name": f"cat{n}", "description": f"desc {n}", "summary": "x"}
+            for n in range(20)
+        ],
+    })
+
+    out = await bridge.recall("q", limit=3, category_limit=2)
+    items = [m for m in out if m["type"] != "category"]
+    cats = [m for m in out if m["type"] == "category"]
+    assert len(items) == 3
+    assert len(cats) == 2
+    # items come before categories
+    assert out[0]["type"] != "category"
+
+
+# --- bridge.expand_category() ---------------------------------------------
+
+
+def _create_category_schema(db_path: str) -> None:
+    db = sqlite3.connect(db_path)
+    db.executescript(
+        """
+        CREATE TABLE memu_memory_items (
+            id TEXT PRIMARY KEY, memory_type TEXT, summary TEXT,
+            created_at TEXT, updated_at TEXT
+        );
+        CREATE TABLE memu_memory_categories (
+            id TEXT PRIMARY KEY, name TEXT, description TEXT, summary TEXT
+        );
+        CREATE TABLE memu_category_items (
+            id TEXT PRIMARY KEY, item_id TEXT, category_id TEXT
+        );
+        """
+    )
+    db.commit()
+    db.close()
+
+
+def _seed_category(db_path: str) -> None:
+    db = sqlite3.connect(db_path)
+    db.execute(
+        "INSERT INTO memu_memory_categories (id, name, description) VALUES (?,?,?)",
+        ("cat-pref", "preferences", "How things should be done"),
+    )
+    rows = [
+        ("it-1", "profile", "Likes the color teal", "2026-06-01 10:00:00"),
+        ("it-2", "behavior", "Prefers dark mode", "2026-06-02 10:00:00"),
+        ("it-3", "profile", "Drinks black coffee", "2026-05-30 10:00:00"),
+    ]
+    for iid, mt, summ, upd in rows:
+        db.execute(
+            "INSERT INTO memu_memory_items (id, memory_type, summary, created_at, updated_at) "
+            "VALUES (?,?,?,?,?)",
+            (iid, mt, summ, upd, upd),
+        )
+        db.execute(
+            "INSERT INTO memu_category_items (id, item_id, category_id) VALUES (?,?,?)",
+            (f"link-{iid}", iid, "cat-pref"),
+        )
+    db.commit()
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_expand_category_returns_recent_items(tmp_path) -> None:
+    config = _make_config(tmp_path)
+    db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+    _create_category_schema(db_path)
+    _seed_category(db_path)
+
+    bridge = _stub_bridge(config)
+    result = await bridge.expand_category("cat:cat-pref", limit=2)
+
+    assert result["name"] == "preferences"
+    assert result["total"] == 3
+    assert len(result["items"]) == 2
+    # most-recent-first: it-2 (Jun 2) then it-1 (Jun 1)
+    assert [i["id"] for i in result["items"]] == ["it-2", "it-1"]
+
+
+@pytest.mark.asyncio
+async def test_expand_category_keyword_filter(tmp_path) -> None:
+    config = _make_config(tmp_path)
+    db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+    _create_category_schema(db_path)
+    _seed_category(db_path)
+
+    bridge = _stub_bridge(config)
+    result = await bridge.expand_category("cat-pref", query="coffee", limit=10)
+    assert [i["id"] for i in result["items"]] == ["it-3"]
+
+
+@pytest.mark.asyncio
+async def test_expand_category_unknown_id(tmp_path) -> None:
+    config = _make_config(tmp_path)
+    db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+    _create_category_schema(db_path)
+    _seed_category(db_path)
+
+    bridge = _stub_bridge(config)
+    result = await bridge.expand_category("cat:nope")
+    assert result["name"] is None
+    assert result["items"] == []
+
+
+# --- handlers --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_renders_two_sections(tmp_path) -> None:
+    bridge = MagicMock()
+    bridge.available = True
+    bridge.recall = AsyncMock(return_value=[
+        {"id": "i1", "type": "profile", "summary": "Alice lives in Metropolis"},
+        {"id": "cat:c1", "type": "category", "name": "preferences",
+         "summary": "How things should be done"},
+    ])
+    result = await memory_recall_handler(_ctx(bridge), {"query": "x"})
+    text = result.content[0]["text"]
+    assert "Recalled 1 memories" in text
+    assert "1 related topics" in text
+    assert "Alice lives in Metropolis" in text
+    assert "memory_expand_category" in text
+    assert "cat:c1" in text
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_passes_category_limit(tmp_path) -> None:
+    bridge = MagicMock()
+    bridge.available = True
+    bridge.recall = AsyncMock(return_value=[])
+    await memory_recall_handler(_ctx(bridge), {"query": "x", "category_limit": 2})
+    _, kwargs = bridge.recall.call_args
+    assert kwargs["category_limit"] == 2
+
+
+@pytest.mark.asyncio
+async def test_expand_category_handler(tmp_path) -> None:
+    bridge = MagicMock()
+    bridge.available = True
+    bridge.expand_category = AsyncMock(return_value={
+        "name": "preferences",
+        "total": 5,
+        "items": [{"id": "it-1", "type": "profile", "summary": "Likes the color teal"}],
+    })
+    result = await memory_expand_category_handler(
+        _ctx(bridge), {"category_id": "cat:cat-pref"}
+    )
+    text = result.content[0]["text"]
+    assert "preferences" in text
+    assert "1 of 5" in text
+    assert "Likes the color teal" in text
+
+
+@pytest.mark.asyncio
+async def test_expand_category_handler_requires_id(tmp_path) -> None:
+    bridge = MagicMock()
+    bridge.available = True
+    result = await memory_expand_category_handler(_ctx(bridge), {"category_id": ""})
+    assert result.is_error


### PR DESCRIPTION
## Summary

memU is hierarchical: an *item* is one atomic fact, a *category* is a rolled-up topic **document** (5–20KB) that indexes many items. `recall()` returned category hits with their **full summary** inlined, so a handful of category hits ballooned the tool output past the harness's inline-output limit — it got silently persisted to a file (`Output too large (54.9KB)`) instead of reaching the model. The same fat summaries also bloated every new session's pre-recall system prompt (`engine.py`), and duplicated the items `recall()` already returns.

This reframes a category as an **index entry, not a payload**: recall surfaces it as a one-line breadcrumb you can drill into on demand.

## What changed

- **`recall()`** now returns items first (atomic, full content) followed by category **breadcrumbs** — the curated `description` (or first content line of the summary, with `[ref:]` markers stripped), capped to 200 chars. Items and categories are capped independently (`limit`, `category_limit`).
- **New `memory_expand_category` tool** drills a `cat:<id>` breadcrumb into its constituent items via the `memu_category_items` membership table — most-recent-first, optional keyword filter, bounded.
- **Hard byte-budget backstop** (`_clip_to_budget`) on the recall handler output, so it can never trip the persister again regardless of content.
- All three `recall()` consumers (recall tool, `session_context`, engine pre-recall) benefit automatically — the fix is at the bridge layer.

## Impact (measured on real data)

The 5 fattest categories dumped verbatim = **80,964 bytes**. As breadcrumbs = **384 bytes** — a **99.5%** reduction. Verified live: the query that previously returned `Output too large (54.9KB)` now returns `5 memories + 5 related topics`, and `memory_expand_category` drills a category of 858 items down to a bounded, filtered list.

## Test plan

- [x] `tests/test_recall_breadcrumbs.py` — 14 tests: breadcrumb extraction (description / summary fallback / truncation), byte-budget clipping, recall item/category split + caps, `expand_category` recency ordering / keyword filter / unknown-id, both handlers.
- [x] Full suite: `844 passed`.
- [x] Backend-only — no frontend build needed.
- [x] Verified live against the production memU DB.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*