### PR TITLE
feat(cron): run gates — task-status & message preconditions

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -62,6 +62,93 @@ jobs:
 | `reminder_mode` | bool | no | Persistent only: send short reminder instead of full prompt on subsequent runs (default: false) |
 | `catchup` | bool | no | Fire once on startup if the job missed a run while the server was down (default: true) |
 | `enabled` | bool | no | Whether the job is active (default: true) |
+| `lock` | bool | no | Prevent concurrent runs of this job — the next fire waits for the previous one (default: false) |
+| `run_if` | list | no | Run gates — preconditions that must all hold for the job to fire. See [Run Gates](#run-gates) |
+
+## Run Gates
+
+A **run gate** is a precondition evaluated right before a job fires. It answers
+one question: *should this cron run right now?* Gates let a job stay idle until
+there is actually something to do — no agent session is spawned (and nothing is
+logged beyond a skip line) when a gate is unsatisfied.
+
+Declare gates with the `run_if` key — a list of gate specs. **All gates must be
+satisfied (logical AND)** for the job to run:
+
+```yaml
+jobs:
+  - id: task-planner
+    schedule: "0 */4 * * *"
+    prompt: "Review open tasks and propose plans..."
+    run_if:
+      - type: tasks            # only when there's something to plan
+        status: pending
+```
+
+When multiple gates are listed, the job runs only if every one passes:
+
+```yaml
+  - id: triage
+    schedule: "30m"
+    prompt: "Triage incoming work..."
+    run_if:
+      - type: tasks            # there is an open task AND
+        status: pending
+      - type: messages         # a source has unread mail
+        sources: [gmail, github]
+```
+
+Gates are **fail-open**: if a gate errors while checking (e.g. a transient DB
+issue), the run proceeds rather than being skipped — an occasional wasted run
+beats a cron that silently never fires.
+
+### Gate types
+
+#### `tasks`
+
+Satisfied when enough tasks match a status/tag filter. The canonical use is
+"only run the planner when there is something to plan."
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `status` | string \| list \| `"all"` | omitted = any **open** (non-done) task | Status name(s) to count. A list counts across all of them; `"all"` counts every task regardless of status |
+| `tag` | string | — | Optional tag filter |
+| `min_count` | int | 1 | Minimum number of matching tasks required to run |
+
+```yaml
+run_if:
+  - type: tasks
+    status: [pending, in_progress]   # any of these statuses
+    tag: backend                     # ...tagged "backend"
+    min_count: 3                     # ...and at least 3 of them
+```
+
+#### `messages`
+
+Satisfied when monitored sync sources have unread messages (compares each
+source's max ingested rowid against the consumer cursor; never advances it).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sources` | list | — (required) | Source names to check (e.g. `gmail`, `github`) |
+| `consumer` | string | `inbox` | Consumer cursor name used for the unread check |
+
+```yaml
+run_if:
+  - type: messages
+    sources: [gmail, github]
+    consumer: inbox
+```
+
+> **Legacy shorthand.** The older `skip_when_idle: [<sources>]` /
+> `idle_consumer: <name>` fields still work — they are translated into an
+> equivalent `messages` gate at load time. Prefer `run_if` for new jobs.
+
+### Adding a new gate type
+
+Gates live in `nerve/cron/gates.py`. To add one: subclass `CronGate`, set its
+`type`, implement `is_satisfied`, `describe`, and `from_config`, then register
+the class in `GATE_REGISTRY`. It becomes usable from `run_if` immediately.
 
 ## Session Modes
 
@@ -123,7 +210,7 @@ These ship in `~/.nerve/cron/system.yaml` and are managed by `nerve init`. Runni
 |-----|----------|-------------|-------------|:--------:|:------:|
 | `memory-maintenance` | Daily 5 AM | isolated | Dedup, prune stale entries, improve memory wording. Runs silently. | ✅ always | ✅ always |
 | `inbox-processor` | Every 30 min | persistent (24h rotation, reminder mode) | Polls all sync sources (email, GitHub, Telegram). Triages, creates tasks, memorizes facts, sends notifications for urgent items. | ✅ default | — |
-| `task-planner` | Every 4 hours | persistent (168h rotation) | Reviews open tasks, explores codebases, proposes implementation plans via plan-approve workflow. | ✅ default | ✅ default |
+| `task-planner` | Every 4 hours | persistent (168h rotation) | Reviews open tasks, explores codebases, proposes implementation plans via plan-approve workflow. Gated on `tasks` (status `pending`) — stays idle when there's nothing to plan. | ✅ default | ✅ default |
 | `skill-extractor` | Every 12 hours | persistent | Identifies repeated workflows from recent conversations, memory, and completed tasks. Proposes new skills via task+plan system. | ✅ optional | ✅ default |
 | `skill-reviser` | Weekly (Sun 3 AM) | persistent | Reviews existing skills for accuracy (outdated paths, credentials), completeness (missing steps), and quality (trigger phrases, examples). Proposes revisions via task+plan. | ✅ optional | ✅ default |
 

--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -93,6 +93,8 @@ PRODUCTIVITY_CRONS = [
         "session_mode": "persistent",
         "context_rotate_hours": 168,
         "reminder_mode": False,
+        # Only fire when there is actually something to plan.
+        "run_if": [{"type": "tasks", "status": "pending"}],
         "prompt": (
             "You are a proactive planning agent. Your job is to find a task worth working on and produce an implementation plan.\n\n"
             "1. Use task_list to browse open tasks\n"
@@ -1869,6 +1871,8 @@ class SetupWizard:
                     job["context_rotate_hours"] = cron["context_rotate_hours"]
                 if cron.get("reminder_mode"):
                     job["reminder_mode"] = cron["reminder_mode"]
+                if cron.get("run_if"):
+                    job["run_if"] = cron["run_if"]
                 jobs.append(job)
         elif self.choices.mode == "worker":
             # Workers get skill crons — they create skills during onboarding
@@ -1892,6 +1896,8 @@ class SetupWizard:
                     job["context_rotate_hours"] = cron["context_rotate_hours"]
                 if cron.get("reminder_mode"):
                     job["reminder_mode"] = cron["reminder_mode"]
+                if cron.get("run_if"):
+                    job["run_if"] = cron["run_if"]
                 jobs.append(job)
 
         # Write system crons (managed by nerve init, safe to regenerate)

--- a/nerve/cron/gates.py
+++ b/nerve/cron/gates.py
@@ -1,0 +1,288 @@
+"""Cron run gates — preconditions evaluated before a job fires.
+
+A *gate* answers a single question: should this cron run **right now**?
+Jobs declare zero or more gates via the ``run_if`` config key. All gates
+must be satisfied (logical AND) for the job to run; if any gate is
+unsatisfied the run is skipped — logged, with no agent invocation.
+
+Design:
+
+* A gate is a pure declaration built from config (:meth:`CronGate.from_config`).
+  It reaches the database only at evaluation time, through :class:`GateContext`,
+  so gate objects are cheap to build and hold no live resources.
+* Gate types are looked up in :data:`GATE_REGISTRY` by their ``type`` key,
+  which mirrors the ``type:`` field in the YAML spec.
+* Adding a new gate = subclass :class:`CronGate`, set ``type``, implement the
+  three abstract methods, and register the class in :data:`GATE_REGISTRY`.
+
+Example config::
+
+    run_if:
+      - type: tasks            # run only when there is something to plan
+        status: pending
+      - type: messages         # ...and only when sources have new messages
+        sources: [gmail, github]
+
+Evaluation is AND across the list, so the job above runs only when *both*
+hold.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from nerve.db import Database
+
+logger = logging.getLogger(__name__)
+
+
+class GateConfigError(ValueError):
+    """Raised when a gate spec in config is malformed."""
+
+
+@dataclass
+class GateContext:
+    """Runtime dependencies handed to a gate at evaluation time."""
+
+    job_id: str
+    db: "Database"
+
+
+@dataclass
+class GateDecision:
+    """Outcome of evaluating a job's gates.
+
+    ``reason`` is a short human-readable explanation, populated only when
+    ``should_run`` is False, for logging the skip.
+    """
+
+    should_run: bool
+    reason: str = ""
+
+
+class CronGate(ABC):
+    """A precondition checked before a cron job runs."""
+
+    #: Registry key — must match the ``type`` field in the YAML spec.
+    type: ClassVar[str] = ""
+
+    @abstractmethod
+    async def is_satisfied(self, ctx: GateContext) -> bool:
+        """Return True if the job is allowed to run under this condition."""
+
+    @abstractmethod
+    def describe(self) -> str:
+        """Short human-readable description of the condition (UI + logs)."""
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, spec: dict) -> "CronGate":
+        """Build an instance from its config dict (``type`` key included)."""
+
+
+class MessagesGate(CronGate):
+    """Satisfied when monitored sync sources have unread messages.
+
+    Generalises the legacy ``skip_when_idle`` / ``idle_consumer`` fields:
+    a job that only wants to run when an inbox has new mail.
+
+    Config::
+
+        type: messages
+        sources: [gmail, github]   # source names to check (required)
+        consumer: inbox            # consumer cursor name (default "inbox")
+
+    The check compares each source's max ingested rowid against the
+    consumer's cursor position; it never advances any cursor.
+    """
+
+    type = "messages"
+
+    def __init__(self, sources: list[str], consumer: str = "inbox") -> None:
+        if not sources:
+            raise GateConfigError("'messages' gate requires at least one source")
+        self.sources = sources
+        self.consumer = consumer
+
+    async def is_satisfied(self, ctx: GateContext) -> bool:
+        for source in self.sources:
+            cursor_seq = await ctx.db.get_consumer_cursor(self.consumer, source)
+            max_seq = await ctx.db.get_source_max_rowid(source)
+            if max_seq > cursor_seq:
+                return True
+        return False
+
+    def describe(self) -> str:
+        return (
+            f"new messages in {', '.join(self.sources)} "
+            f"(consumer={self.consumer})"
+        )
+
+    @classmethod
+    def from_config(cls, spec: dict) -> "MessagesGate":
+        # Accept the new "sources" key, plus the legacy "skip_when_idle"
+        # spelling so an old shorthand maps cleanly onto this gate.
+        sources = spec.get("sources")
+        if sources is None:
+            sources = spec.get("skip_when_idle", [])
+        if isinstance(sources, str):
+            sources = [sources]
+        consumer = spec.get("consumer") or spec.get("idle_consumer") or "inbox"
+        return cls(sources=list(sources), consumer=consumer)
+
+
+class TasksGate(CronGate):
+    """Satisfied when enough tasks match a status/tag filter.
+
+    The motivating case: only run the task-planner when there is actually
+    something to plan.
+
+    Config::
+
+        type: tasks
+        status: pending            # status name, list of names, "all",
+                                   # or omitted (= any non-done task)
+        tag: backend               # optional tag filter
+        min_count: 1               # minimum matching tasks (default 1)
+
+    ``status`` semantics:
+
+    * omitted / null  → any *open* task (non-done), the common case
+    * ``"all"``       → any task regardless of status
+    * a single name   → tasks in exactly that status (e.g. ``pending``)
+    * a list of names → tasks in any of those statuses (counts summed)
+    """
+
+    type = "tasks"
+
+    def __init__(
+        self,
+        targets: list[str | None],
+        tag: str | None = None,
+        min_count: int = 1,
+    ) -> None:
+        # Each element is passed straight to ``count_tasks(status=...)``:
+        #   None    → non-done    ("all" handled by count_tasks directly)
+        #   "all"   → every task
+        #   "<name>"→ that status
+        self.targets: list[str | None] = targets or [None]
+        self.tag = tag
+        self.min_count = max(1, int(min_count))
+
+    async def is_satisfied(self, ctx: GateContext) -> bool:
+        count = 0
+        for status in self.targets:
+            count += await ctx.db.count_tasks(status=status, tag=self.tag)
+            if count >= self.min_count:
+                return True
+        return count >= self.min_count
+
+    def describe(self) -> str:
+        labels = ["open" if t is None else t for t in self.targets]
+        status_str = "/".join(labels)
+        tag_str = f" tagged '{self.tag}'" if self.tag else ""
+        thresh = "" if self.min_count == 1 else f" (>= {self.min_count})"
+        return f"{status_str} tasks{tag_str}{thresh} exist"
+
+    @classmethod
+    def from_config(cls, spec: dict) -> "TasksGate":
+        raw = spec.get("status")
+        if raw is None:
+            targets: list[str | None] = [None]
+        elif isinstance(raw, str):
+            targets = [raw]  # includes the "all" sentinel
+        elif isinstance(raw, (list, tuple)):
+            targets = [str(s) for s in raw] or [None]
+        else:
+            raise GateConfigError(
+                f"'tasks' gate 'status' must be a string or list, "
+                f"got {type(raw).__name__}"
+            )
+
+        min_count = spec.get("min_count", 1)
+        try:
+            min_count = int(min_count)
+        except (TypeError, ValueError):
+            raise GateConfigError(
+                f"'tasks' gate 'min_count' must be an integer, got {min_count!r}"
+            )
+
+        tag = spec.get("tag")
+        return cls(targets=targets, tag=tag, min_count=min_count)
+
+
+#: Maps a gate's ``type`` key to its implementing class. Register new gate
+#: types here to make them usable from config.
+GATE_REGISTRY: dict[str, type[CronGate]] = {
+    MessagesGate.type: MessagesGate,
+    TasksGate.type: TasksGate,
+}
+
+
+def build_gate(spec: dict) -> CronGate:
+    """Build a single gate from a config dict.
+
+    Raises :class:`GateConfigError` if the spec is malformed or names an
+    unknown gate type.
+    """
+    if not isinstance(spec, dict):
+        raise GateConfigError(
+            f"gate spec must be a mapping, got {type(spec).__name__}"
+        )
+    gate_type = spec.get("type")
+    if not gate_type:
+        raise GateConfigError("gate spec missing required 'type' key")
+    cls = GATE_REGISTRY.get(gate_type)
+    if cls is None:
+        known = ", ".join(sorted(GATE_REGISTRY)) or "(none)"
+        raise GateConfigError(
+            f"unknown gate type {gate_type!r} (known types: {known})"
+        )
+    return cls.from_config(spec)
+
+
+def build_gates(specs: list[dict]) -> list[CronGate]:
+    """Build gates from a list of config specs.
+
+    Invalid specs are logged and skipped rather than raising, so one bad
+    gate can't take down the whole cron service at load time. A job whose
+    gates all fail to build behaves as if it has no gates (runs normally).
+    """
+    gates: list[CronGate] = []
+    for spec in specs or []:
+        try:
+            gates.append(build_gate(spec))
+        except GateConfigError as e:
+            logger.warning("Ignoring invalid cron gate %s: %s", spec, e)
+    return gates
+
+
+async def evaluate_gates(
+    gates: list[CronGate], ctx: GateContext,
+) -> GateDecision:
+    """Evaluate gates with AND semantics — every gate must be satisfied.
+
+    Fail-open: if a gate raises while checking, it's treated as satisfied
+    (the run proceeds) and a warning is logged. Silently skipping forever
+    on a transient DB error would be worse than an occasional wasted run —
+    and a wasted run is just the pre-gate behaviour.
+    """
+    for gate in gates:
+        try:
+            ok = await gate.is_satisfied(ctx)
+        except Exception as e:  # noqa: BLE001 — fail open, never block forever
+            logger.warning(
+                "Cron gate %r for job %s errored; allowing run: %s",
+                gate.type, ctx.job_id, e,
+            )
+            continue
+        if not ok:
+            return GateDecision(
+                should_run=False,
+                reason=f"gate {gate.type!r} not satisfied ({gate.describe()})",
+            )
+    return GateDecision(should_run=True)

--- a/nerve/cron/jobs.py
+++ b/nerve/cron/jobs.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
+
+if TYPE_CHECKING:
+    from nerve.cron.gates import CronGate
 
 logger = logging.getLogger(__name__)
 
@@ -30,10 +33,38 @@ class CronJob:
     catchup: bool = True  # Fire once on startup if missed while server was down
     enabled: bool = True
     lock: bool = False  # When True, prevent concurrent runs of this job (next run waits for previous)
+    # Run gates — preconditions evaluated before each fire. Each entry is a
+    # spec dict like {"type": "tasks", "status": "pending"}. All gates must
+    # pass (AND) for the job to run. See nerve/cron/gates.py.
+    run_if: list[dict] = field(default_factory=list)
+    # Legacy shorthand for a "messages" gate, kept for backward compatibility.
     skip_when_idle: list[str] = field(default_factory=list)  # Source names to check; skip run if no new messages
     idle_consumer: str = "inbox"  # Consumer cursor name for the idle check
     show_session_label: bool = True  # Show "Session: ..." in notification messages
     metadata: dict = field(default_factory=dict)
+    # Built run gates (derived from run_if + legacy fields in __post_init__).
+    # Not serialized; excluded from equality/repr.
+    gates: list["CronGate"] = field(
+        default_factory=list, init=False, repr=False, compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        self.gates = self._build_gates()
+
+    def _build_gates(self) -> list["CronGate"]:
+        """Construct gate objects from run_if plus the legacy shorthand."""
+        from nerve.cron.gates import build_gates
+
+        specs: list[dict] = list(self.run_if)
+        # Translate the legacy skip_when_idle shorthand into a messages gate
+        # so old configs keep working without rewrites.
+        if self.skip_when_idle:
+            specs.append({
+                "type": "messages",
+                "sources": list(self.skip_when_idle),
+                "consumer": self.idle_consumer,
+            })
+        return build_gates(specs)
 
     @classmethod
     def from_dict(cls, d: dict) -> CronJob:
@@ -50,6 +81,7 @@ class CronJob:
             catchup=d.get("catchup", True),
             enabled=d.get("enabled", True),
             lock=bool(d.get("lock", False)),
+            run_if=d.get("run_if", []),
             skip_when_idle=d.get("skip_when_idle", []),
             idle_consumer=d.get("idle_consumer", "inbox"),
             show_session_label=d.get("show_session_label", True),
@@ -103,6 +135,7 @@ def save_jobs(jobs: list[CronJob], jobs_file: Path) -> None:
             "catchup": job.catchup,
             "enabled": job.enabled,
             "lock": job.lock,
+            "run_if": job.run_if,
             "skip_when_idle": job.skip_when_idle,
             "idle_consumer": job.idle_consumer,
             "show_session_label": job.show_session_label,

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -359,21 +359,6 @@ class CronService:
 
         return list(jobs_by_id.values())
 
-    async def _has_pending_messages(
-        self, consumer: str, sources: list[str],
-    ) -> bool:
-        """Check if any of the listed sources have unread messages.
-
-        Uses existing consumer cursor position vs source max rowid.
-        Does not advance any cursors.
-        """
-        for source in sources:
-            cursor_seq = await self.db.get_consumer_cursor(consumer, source)
-            max_seq = await self.db.get_source_max_rowid(source)
-            if max_seq > cursor_seq:
-                return True
-        return False
-
     async def _run_job_wrapper(self, job: CronJob) -> None:
         """Wrapper to run a cron job with logging and optional lock."""
         if job.lock:
@@ -385,16 +370,15 @@ class CronService:
 
     async def _run_job_inner(self, job: CronJob) -> None:
         """Inner implementation of job execution."""
-        # Pre-check: skip if no new messages in monitored sources
-        if job.skip_when_idle:
-            has_pending = await self._has_pending_messages(
-                job.idle_consumer, job.skip_when_idle,
+        # Pre-check: skip if any configured run gate is unsatisfied.
+        if job.gates:
+            from nerve.cron.gates import GateContext, evaluate_gates
+
+            decision = await evaluate_gates(
+                job.gates, GateContext(job_id=job.id, db=self.db),
             )
-            if not has_pending:
-                logger.info(
-                    "Skipping cron job %s: no new messages in %s",
-                    job.id, job.skip_when_idle,
-                )
+            if not decision.should_run:
+                logger.info("Skipping cron job %s: %s", job.id, decision.reason)
                 return
 
         log_id = await self.db.log_cron_start(job.id)
@@ -649,6 +633,7 @@ class CronService:
                 "enabled": job.enabled,
                 "session_mode": job.session_mode,
                 "lock": job.lock,
+                "gates": [gate.describe() for gate in job.gates],
                 "next_run": next_run.isoformat() if next_run else None,
             })
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -441,3 +441,73 @@ class TestJobLock:
 
         # Different jobs run concurrently even with lock=True
         assert call_order == ["start", "start", "end", "end"]
+
+
+# ---------------------------------------------------------------------------
+# Run gates — service-level skip/run behaviour
+# ---------------------------------------------------------------------------
+
+class TestRunGates:
+    @pytest.mark.asyncio
+    async def test_skips_when_tasks_gate_unsatisfied(self, cron_service):
+        """A tasks gate with no matching tasks skips the run entirely."""
+        cron_service.db.count_tasks = AsyncMock(return_value=0)
+        job = _make_job(
+            id="planner", run_if=[{"type": "tasks", "status": "pending"}],
+        )
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.db.log_cron_start.assert_not_called()
+        cron_service.engine.run_cron.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_when_tasks_gate_satisfied(self, cron_service):
+        """A tasks gate with matching tasks lets the run proceed."""
+        cron_service.db.count_tasks = AsyncMock(return_value=2)
+        job = _make_job(
+            id="planner", run_if=[{"type": "tasks", "status": "pending"}],
+        )
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.db.log_cron_start.assert_called_once_with("planner")
+        cron_service.engine.run_cron.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_gates_always_runs(self, cron_service):
+        """A job with no gates runs unconditionally (no gate queries)."""
+        job = _make_job(id="ungated")
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.engine.run_cron.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_skip_when_idle_skips(self, cron_service):
+        """Legacy skip_when_idle still gates via the messages gate path."""
+        cron_service.db.get_consumer_cursor = AsyncMock(return_value=9)
+        cron_service.db.get_source_max_rowid = AsyncMock(return_value=9)
+        job = _make_job(id="inbox", skip_when_idle=["gmail"])
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.engine.run_cron.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_and_semantics_one_gate_blocks(self, cron_service):
+        """With two gates, one unsatisfied is enough to skip (AND)."""
+        cron_service.db.count_tasks = AsyncMock(return_value=5)        # tasks: ok
+        cron_service.db.get_consumer_cursor = AsyncMock(return_value=9)
+        cron_service.db.get_source_max_rowid = AsyncMock(return_value=9)  # msgs: not ok
+        job = _make_job(
+            id="both",
+            run_if=[
+                {"type": "tasks", "status": "pending"},
+                {"type": "messages", "sources": ["gmail"]},
+            ],
+        )
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.engine.run_cron.assert_not_called()

--- a/tests/test_cron_gates.py
+++ b/tests/test_cron_gates.py
@@ -1,0 +1,332 @@
+"""Tests for cron run gates (nerve/cron/gates.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from nerve.cron.gates import (
+    GATE_REGISTRY,
+    CronGate,
+    GateConfigError,
+    GateContext,
+    MessagesGate,
+    TasksGate,
+    build_gate,
+    build_gates,
+    evaluate_gates,
+)
+from nerve.cron.jobs import CronJob
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ctx(db: AsyncMock, job_id: str = "test-job") -> GateContext:
+    return GateContext(job_id=job_id, db=db)
+
+
+def _db(**methods) -> AsyncMock:
+    """Build a mock db with the given async methods preconfigured."""
+    db = AsyncMock()
+    for name, value in methods.items():
+        getattr(db, name).return_value = value
+    return db
+
+
+# ---------------------------------------------------------------------------
+# TasksGate
+# ---------------------------------------------------------------------------
+
+class TestTasksGate:
+    @pytest.mark.asyncio
+    async def test_pending_status_satisfied(self):
+        db = _db(count_tasks=3)
+        gate = TasksGate(targets=["pending"])
+        assert await gate.is_satisfied(_ctx(db)) is True
+        db.count_tasks.assert_awaited_once_with(status="pending", tag=None)
+
+    @pytest.mark.asyncio
+    async def test_pending_status_unsatisfied(self):
+        db = _db(count_tasks=0)
+        gate = TasksGate(targets=["pending"])
+        assert await gate.is_satisfied(_ctx(db)) is False
+
+    @pytest.mark.asyncio
+    async def test_default_status_means_open(self):
+        """No status → count_tasks(status=None) (non-done)."""
+        db = _db(count_tasks=1)
+        gate = TasksGate(targets=[None])
+        assert await gate.is_satisfied(_ctx(db)) is True
+        db.count_tasks.assert_awaited_once_with(status=None, tag=None)
+
+    @pytest.mark.asyncio
+    async def test_min_count_threshold(self):
+        db = _db(count_tasks=2)
+        gate = TasksGate(targets=["pending"], min_count=3)
+        assert await gate.is_satisfied(_ctx(db)) is False
+
+        db2 = _db(count_tasks=3)
+        gate2 = TasksGate(targets=["pending"], min_count=3)
+        assert await gate2.is_satisfied(_ctx(db2)) is True
+
+    @pytest.mark.asyncio
+    async def test_status_list_sums_counts(self):
+        """Counts across multiple statuses are summed until threshold."""
+        db = AsyncMock()
+        db.count_tasks.side_effect = [1, 2]  # pending=1, in_progress=2
+        gate = TasksGate(targets=["pending", "in_progress"], min_count=3)
+        assert await gate.is_satisfied(_ctx(db)) is True
+        assert db.count_tasks.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_status_list_short_circuits(self):
+        """Stops counting once the threshold is reached."""
+        db = AsyncMock()
+        db.count_tasks.side_effect = [5, 0]
+        gate = TasksGate(targets=["pending", "in_progress"], min_count=1)
+        assert await gate.is_satisfied(_ctx(db)) is True
+        # Second status never queried — threshold already met.
+        assert db.count_tasks.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_tag_filter_passed_through(self):
+        db = _db(count_tasks=1)
+        gate = TasksGate(targets=["pending"], tag="backend")
+        await gate.is_satisfied(_ctx(db))
+        db.count_tasks.assert_awaited_once_with(status="pending", tag="backend")
+
+    def test_min_count_floor_is_one(self):
+        assert TasksGate(targets=["pending"], min_count=0).min_count == 1
+        assert TasksGate(targets=["pending"], min_count=-5).min_count == 1
+
+    def test_describe(self):
+        assert "pending tasks" in TasksGate(targets=["pending"]).describe()
+        assert "open tasks" in TasksGate(targets=[None]).describe()
+        assert "pending/in_progress" in TasksGate(
+            targets=["pending", "in_progress"]).describe()
+        d = TasksGate(targets=["pending"], tag="urgent", min_count=2).describe()
+        assert "urgent" in d and ">= 2" in d
+
+    # -- from_config --------------------------------------------------------
+
+    def test_from_config_string_status(self):
+        gate = TasksGate.from_config({"type": "tasks", "status": "pending"})
+        assert gate.targets == ["pending"]
+        assert gate.min_count == 1
+
+    def test_from_config_omitted_status(self):
+        gate = TasksGate.from_config({"type": "tasks"})
+        assert gate.targets == [None]
+
+    def test_from_config_all_status(self):
+        gate = TasksGate.from_config({"type": "tasks", "status": "all"})
+        assert gate.targets == ["all"]
+
+    def test_from_config_list_status(self):
+        gate = TasksGate.from_config(
+            {"type": "tasks", "status": ["pending", "blocked"]})
+        assert gate.targets == ["pending", "blocked"]
+
+    def test_from_config_empty_list_falls_back_to_open(self):
+        gate = TasksGate.from_config({"type": "tasks", "status": []})
+        assert gate.targets == [None]
+
+    def test_from_config_with_tag_and_min_count(self):
+        gate = TasksGate.from_config(
+            {"type": "tasks", "status": "pending", "tag": "ci", "min_count": 4})
+        assert gate.tag == "ci"
+        assert gate.min_count == 4
+
+    def test_from_config_bad_status_type(self):
+        with pytest.raises(GateConfigError):
+            TasksGate.from_config({"type": "tasks", "status": 123})
+
+    def test_from_config_bad_min_count(self):
+        with pytest.raises(GateConfigError):
+            TasksGate.from_config(
+                {"type": "tasks", "status": "pending", "min_count": "lots"})
+
+
+# ---------------------------------------------------------------------------
+# MessagesGate
+# ---------------------------------------------------------------------------
+
+class TestMessagesGate:
+    @pytest.mark.asyncio
+    async def test_satisfied_when_new_messages(self):
+        db = _db(get_consumer_cursor=5, get_source_max_rowid=9)
+        gate = MessagesGate(sources=["gmail"])
+        assert await gate.is_satisfied(_ctx(db)) is True
+
+    @pytest.mark.asyncio
+    async def test_unsatisfied_when_caught_up(self):
+        db = _db(get_consumer_cursor=9, get_source_max_rowid=9)
+        gate = MessagesGate(sources=["gmail"])
+        assert await gate.is_satisfied(_ctx(db)) is False
+
+    @pytest.mark.asyncio
+    async def test_any_source_with_new_messages_satisfies(self):
+        db = AsyncMock()
+        db.get_consumer_cursor.side_effect = [9, 2]   # gmail caught up, github behind
+        db.get_source_max_rowid.side_effect = [9, 7]
+        gate = MessagesGate(sources=["gmail", "github"])
+        assert await gate.is_satisfied(_ctx(db)) is True
+
+    def test_empty_sources_raises(self):
+        with pytest.raises(GateConfigError):
+            MessagesGate(sources=[])
+
+    def test_from_config_sources(self):
+        gate = MessagesGate.from_config(
+            {"type": "messages", "sources": ["gmail"], "consumer": "inbox2"})
+        assert gate.sources == ["gmail"]
+        assert gate.consumer == "inbox2"
+
+    def test_from_config_string_source(self):
+        gate = MessagesGate.from_config({"type": "messages", "sources": "gmail"})
+        assert gate.sources == ["gmail"]
+
+    def test_from_config_legacy_keys(self):
+        """Legacy skip_when_idle / idle_consumer keys map onto this gate."""
+        gate = MessagesGate.from_config({
+            "type": "messages",
+            "skip_when_idle": ["gmail", "github"],
+            "idle_consumer": "inbox",
+        })
+        assert gate.sources == ["gmail", "github"]
+        assert gate.consumer == "inbox"
+
+
+# ---------------------------------------------------------------------------
+# build_gate / build_gates
+# ---------------------------------------------------------------------------
+
+class TestBuildGate:
+    def test_build_known_types(self):
+        assert isinstance(build_gate({"type": "tasks"}), TasksGate)
+        assert isinstance(
+            build_gate({"type": "messages", "sources": ["gmail"]}), MessagesGate)
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(GateConfigError):
+            build_gate({"type": "weather"})
+
+    def test_missing_type_raises(self):
+        with pytest.raises(GateConfigError):
+            build_gate({"status": "pending"})
+
+    def test_non_dict_raises(self):
+        with pytest.raises(GateConfigError):
+            build_gate(["not", "a", "dict"])  # type: ignore[arg-type]
+
+    def test_build_gates_skips_invalid(self):
+        """An invalid spec is dropped; valid ones still build."""
+        gates = build_gates([
+            {"type": "tasks", "status": "pending"},
+            {"type": "bogus"},
+            {"type": "messages"},  # no sources → invalid
+        ])
+        assert len(gates) == 1
+        assert isinstance(gates[0], TasksGate)
+
+    def test_build_gates_empty(self):
+        assert build_gates([]) == []
+        assert build_gates(None) == []  # type: ignore[arg-type]
+
+    def test_registry_keys_match_class_type(self):
+        for key, cls in GATE_REGISTRY.items():
+            assert issubclass(cls, CronGate)
+            assert cls.type == key
+
+
+# ---------------------------------------------------------------------------
+# evaluate_gates (AND semantics + fail-open)
+# ---------------------------------------------------------------------------
+
+class _StubGate(CronGate):
+    type = "stub"
+
+    def __init__(self, satisfied: bool | Exception):
+        self._satisfied = satisfied
+
+    async def is_satisfied(self, ctx: GateContext) -> bool:
+        if isinstance(self._satisfied, Exception):
+            raise self._satisfied
+        return self._satisfied
+
+    def describe(self) -> str:
+        return "stub gate"
+
+    @classmethod
+    def from_config(cls, spec: dict) -> "_StubGate":
+        return cls(spec.get("satisfied", True))
+
+
+class TestEvaluateGates:
+    @pytest.mark.asyncio
+    async def test_no_gates_runs(self):
+        decision = await evaluate_gates([], _ctx(AsyncMock()))
+        assert decision.should_run is True
+
+    @pytest.mark.asyncio
+    async def test_all_satisfied_runs(self):
+        gates = [_StubGate(True), _StubGate(True)]
+        decision = await evaluate_gates(gates, _ctx(AsyncMock()))
+        assert decision.should_run is True
+
+    @pytest.mark.asyncio
+    async def test_one_unsatisfied_skips(self):
+        gates = [_StubGate(True), _StubGate(False)]
+        decision = await evaluate_gates(gates, _ctx(AsyncMock()))
+        assert decision.should_run is False
+        assert "stub" in decision.reason
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_error(self):
+        """A gate that raises is treated as satisfied (run proceeds)."""
+        gates = [_StubGate(RuntimeError("db down")), _StubGate(True)]
+        decision = await evaluate_gates(gates, _ctx(AsyncMock()))
+        assert decision.should_run is True
+
+
+# ---------------------------------------------------------------------------
+# CronJob integration (run_if + legacy translation)
+# ---------------------------------------------------------------------------
+
+class TestCronJobGates:
+    def _job(self, **kwargs) -> CronJob:
+        return CronJob(id="j", schedule="1h", prompt="p", **kwargs)
+
+    def test_no_gates_by_default(self):
+        assert self._job().gates == []
+
+    def test_run_if_builds_gates(self):
+        job = self._job(run_if=[{"type": "tasks", "status": "pending"}])
+        assert len(job.gates) == 1
+        assert isinstance(job.gates[0], TasksGate)
+
+    def test_legacy_skip_when_idle_builds_messages_gate(self):
+        job = self._job(skip_when_idle=["gmail"], idle_consumer="inbox")
+        assert len(job.gates) == 1
+        assert isinstance(job.gates[0], MessagesGate)
+        assert job.gates[0].sources == ["gmail"]
+        assert job.gates[0].consumer == "inbox"
+
+    def test_run_if_and_legacy_combine(self):
+        job = self._job(
+            run_if=[{"type": "tasks", "status": "pending"}],
+            skip_when_idle=["gmail"],
+        )
+        kinds = {type(g) for g in job.gates}
+        assert kinds == {TasksGate, MessagesGate}
+
+    def test_from_dict_parses_run_if(self):
+        job = CronJob.from_dict({
+            "id": "x", "schedule": "1h", "prompt": "p",
+            "run_if": [{"type": "tasks", "status": "pending"}],
+        })
+        assert len(job.gates) == 1
+        assert isinstance(job.gates[0], TasksGate)

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
   RefreshCw, RotateCw, Play, Loader2, Clock, Inbox,
-  CheckCircle2, XCircle, Timer,
+  CheckCircle2, XCircle, Timer, Filter,
 } from 'lucide-react';
 import { useCronStore, type CronJob, type CronLog } from '../stores/cronStore';
 
@@ -243,6 +243,22 @@ function JobInfoCard({ job }: { job: CronJob }) {
           </div>
         </div>
       </div>
+
+      {job.gates && job.gates.length > 0 && (
+        <div className="mt-3 pt-3 border-t border-border-subtle">
+          <div className="text-[11px] text-text-dim mb-1.5 flex items-center gap-1">
+            <Filter size={11} /> Runs only if{job.gates.length > 1 ? ' (all)' : ''}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {job.gates.map((gate, i) => (
+              <span key={i}
+                className="text-[12px] px-2 py-0.5 rounded bg-surface-raised text-text-secondary border border-border-subtle">
+                {gate}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/stores/cronStore.ts
+++ b/web/src/stores/cronStore.ts
@@ -8,6 +8,8 @@ export interface CronJob {
   description: string;
   enabled: boolean;
   session_mode?: string;
+  /** Human-readable run-gate conditions; job runs only if all are satisfied. */
+  gates?: string[];
   next_run: string | null;
 }
 


### PR DESCRIPTION
## Summary

Generalizes the one-off `skip_when_idle` message check into a pluggable **run-gate** abstraction for cron jobs. A *gate* is a precondition evaluated right before a job fires — *should this cron run right now?* Jobs declare any number of gates via a new `run_if` list; **all must pass (AND)** or the run is skipped (logged, no agent session spawned).

The motivating feature: **run a cron only if there are tasks in a given status** (e.g. `pending`).

```yaml
- id: task-planner
  schedule: "0 */4 * * *"
  run_if:
    - type: tasks
      status: pending        # string | list | "all" | omitted (= any open task)
      tag: backend           # optional
      min_count: 1           # optional
```

## What's included

- **`nerve/cron/gates.py`** (new) — `CronGate` ABC (`is_satisfied` / `describe` / `from_config`), `GateContext`, `GateDecision`, a `GATE_REGISTRY`, and `build_gates` / `evaluate_gates`.
  - `MessagesGate` — the existing "new messages in source" logic, lifted out of the service.
  - `TasksGate` — new: satisfied when tasks match a status/tag filter (`min_count` threshold).
- **AND semantics, fail-open**: if a gate errors while checking (transient DB issue), the run proceeds rather than silently blocking the cron forever.
- **Backward compatible**: the legacy `skip_when_idle` / `idle_consumer` fields still work — they're translated into an equivalent `messages` gate at load time. No existing config breaks.
- **`task-planner`** now ships gated on `tasks/pending`, so it stays idle when there's nothing to plan.
- Gate descriptions are exposed in `list_jobs()` and rendered as a "Runs only if" chip row on the Cron page.
- Adding a new gate type = subclass `CronGate`, set `type`, register one line.

## Test plan

- [x] `pytest tests/test_cron_gates.py tests/test_cron.py` — gate unit tests (TasksGate/MessagesGate/build/evaluate/AND/fail-open/legacy) + service skip/run behavior
- [x] Full suite: `pytest tests/` — 889 passed
- [x] `npm run build` — frontend builds clean
- [x] Docs updated (`docs/cron.md` — Run Gates section)

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*