### PR TITLE
fix(observability): stop double-yield in lf_attrs masking real exceptions

### DIFF
--- a/nerve/observability/langfuse.py
+++ b/nerve/observability/langfuse.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
@@ -170,8 +170,12 @@ def attributes(
 ) -> Iterator[None]:
     """Wrap a block so OTEL spans inside it carry these Langfuse attributes.
 
-    No-op when Langfuse is disabled. Never raises — wrap-failure must not
-    take down the caller.
+    No-op when Langfuse is disabled. Setup failures (missing optional
+    package, ``propagate_attributes`` raising on bad kwargs) are logged
+    and the block runs without propagation. Exceptions thrown into the
+    yielded block (e.g. ``asyncio.TimeoutError`` from the engine's idle-
+    timeout path) propagate normally — they are never swallowed and never
+    converted into a spurious ``RuntimeError`` from a double-yield.
     """
     if not _enabled:
         yield
@@ -196,11 +200,20 @@ def attributes(
         if clean_meta:
             kwargs["metadata"] = clean_meta
 
-    try:
-        with propagate_attributes(**kwargs):
-            yield
-    except Exception as e:
-        logger.debug("Langfuse propagate_attributes failed (%s) — continuing", e)
+    # Guard ENTER only — never wrap the yield. ExitStack closes the inner
+    # context on the way out even when the yielded block raises, so spans
+    # are still finalized correctly. A previous version wrapped the yield
+    # in a try/except Exception and yielded a second time on failure,
+    # which produced "RuntimeError: generator didn't stop after throw()"
+    # whenever an exception was thrown into the yield, masking the real
+    # exception (e.g. the engine's asyncio.TimeoutError).
+    with ExitStack() as stack:
+        try:
+            stack.enter_context(propagate_attributes(**kwargs))
+        except Exception as e:
+            logger.debug(
+                "Langfuse propagate_attributes failed (%s) — continuing", e,
+            )
         yield
 
 

--- a/tests/test_observability_langfuse.py
+++ b/tests/test_observability_langfuse.py
@@ -212,6 +212,74 @@ def test_attributes_calls_propagate_when_enabled(monkeypatch):
     assert call_kwargs["metadata"] == {"k": "v"}
 
 
+def test_attributes_propagates_exception_thrown_into_yield(monkeypatch):
+    """Regression: an exception raised inside the with-block must propagate
+    as itself, not get swallowed and rethrown as RuntimeError from a
+    double-yield.
+
+    Pre-fix the ``except Exception`` branch caught the thrown-in exception
+    and ``yield``ed a second time, which violated the
+    @contextmanager generator protocol and produced
+    ``RuntimeError("generator didn't stop after throw()")``. The engine's
+    idle-timeout path throws ``asyncio.TimeoutError`` into this context
+    manager and relies on the same type coming back out so its retry
+    logic catches it.
+    """
+    import asyncio
+
+    _install_fake_langfuse(monkeypatch, auth_ok=True)
+    cfg = _config_with(public_key="pk-lf", secret_key="sk-lf")
+    assert lf.init_langfuse(cfg) is True
+
+    with pytest.raises(asyncio.TimeoutError, match="idle"):
+        with lf.attributes(session_id="s1", tags=["a"]):
+            raise asyncio.TimeoutError("idle")
+
+
+def test_attributes_propagates_exception_when_setup_fails(monkeypatch):
+    """If ``propagate_attributes()`` itself raises during setup,
+    ``attributes()`` falls back to a bare yield AND must still propagate
+    exceptions raised inside the with-block.
+    """
+    import asyncio
+
+    _install_fake_langfuse(monkeypatch, auth_ok=True)
+    cfg = _config_with(public_key="pk-lf", secret_key="sk-lf")
+    assert lf.init_langfuse(cfg) is True
+    sys.modules["langfuse"].propagate_attributes = MagicMock(
+        side_effect=RuntimeError("bad kwargs"),
+    )
+
+    with pytest.raises(asyncio.TimeoutError, match="idle"):
+        with lf.attributes(session_id="s1"):
+            raise asyncio.TimeoutError("idle")
+
+
+def test_attributes_propagates_non_timeout_exceptions(monkeypatch):
+    """Generalize the regression: ANY exception type raised inside the
+    block must propagate unchanged (not just TimeoutError)."""
+    _install_fake_langfuse(monkeypatch, auth_ok=True)
+    cfg = _config_with(public_key="pk-lf", secret_key="sk-lf")
+    assert lf.init_langfuse(cfg) is True
+
+    with pytest.raises(ValueError, match="boom"):
+        with lf.attributes(session_id="s1"):
+            raise ValueError("boom")
+
+
+def test_attributes_normal_exit_when_block_succeeds(monkeypatch):
+    """Sanity: a clean exit through the block still works after the fix
+    (regression coverage doesn't paper over normal use)."""
+    _install_fake_langfuse(monkeypatch, auth_ok=True)
+    cfg = _config_with(public_key="pk-lf", secret_key="sk-lf")
+    assert lf.init_langfuse(cfg) is True
+
+    ran = False
+    with lf.attributes(session_id="s1", tags=["normal"]):
+        ran = True
+    assert ran is True
+
+
 # ---------------------------------------------------------------------------
 # redact()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `attributes()` context manager in `nerve/observability/langfuse.py` (imported as `lf_attrs` by the agent engine and the memU bridge) wraps its `yield` in `try/except Exception` and yields a second time on failure:

```python
try:
    with propagate_attributes(**kwargs):
        yield                  # ← exception thrown into HERE
except Exception as e:
    logger.debug("...failed (%s) — continuing", e)
    yield                      # ← second yield → RuntimeError
```

When an exception is raised inside the yielded block — most importantly an `asyncio.TimeoutError` thrown by the agent engine's per-message idle-timeout path (`_iter_response_with_timeout`) — the outer `except` catches it and the second yield violates the `@contextmanager` generator protocol, raising `RuntimeError: generator didn't stop after throw()`. That `RuntimeError` then *masks* the original exception, so the engine's `except asyncio.TimeoutError` handler in `_run_inner` never fires.

The user-visible result: when the Claude Agent SDK's CLI subprocess hangs (e.g. a stuck Bedrock inference request), the engine's idle-timeout safety net detects the hang correctly, but cleanup unwinding through `lf_attrs` converts the recoverable `TimeoutError` into a fatal `RuntimeError`. The turn aborts as a generic Agent error and the cron task is left stranded instead of letting the next run pick it up cleanly.

## Fix

Guard only the setup phase with `ExitStack`, leaving the `yield` outside any `try/except`:

- `stack.enter_context(propagate_attributes(**kwargs))` is wrapped in a narrow try/except so a setup failure (missing optional package, bad kwargs) is still logged and falls through to a bare yield.
- The `yield` lives outside the `try` — exceptions thrown into the block propagate unchanged.
- `ExitStack.__exit__` runs unconditionally on the way out, so the inner Langfuse span is still finalized correctly when the block raises.

## Tests

Adds four regression tests in `tests/test_observability_langfuse.py`:

- `test_attributes_propagates_exception_thrown_into_yield` — `asyncio.TimeoutError` raised inside the block must come back out as `TimeoutError`, not `RuntimeError`.
- `test_attributes_propagates_exception_when_setup_fails` — same, when `propagate_attributes()` itself raises during setup.
- `test_attributes_propagates_non_timeout_exceptions` — generalizes to any exception type.
- `test_attributes_normal_exit_when_block_succeeds` — sanity for the happy path.

The first and third tests fail on `main` with `RuntimeError: generator didn't stop after throw()` from `contextlib.py:198` — the exact pre-fix bug — and pass after the fix.

## Test plan

- [x] `tests/test_observability_langfuse.py` — 21/21 pass (17 existing + 4 new)
- [x] Full `pytest tests/` — 884 pass, 2 skip; the 7 unrelated `test_codex_*` failures are pre-existing on `main` (missing test fixture)
- [x] Verified regression tests fail on pre-fix code: 2 of the 3 new "throw-into-yield" tests fail with the documented `RuntimeError` from `contextlib.py:198`

## Notes

- No frontend changes — `npm run build` not required.
- No new dependencies, no config changes, no migrations.
- `lf_attrs` is also imported by `nerve/memory/memu_bridge.py` (memU LLM call wrapping) — same fix benefits it automatically; no callers need updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)