### PR TITLE
Render syntax-highlighted diffs with @pierre/diffs

### DIFF
--- a/nerve/gateway/diff.py
+++ b/nerve/gateway/diff.py
@@ -228,6 +228,11 @@ def _parse_unified_diff(
     if current_hunk:
         hunks.append(current_hunk)
 
+    # Raw git-style patch string for the @pierre/diffs renderer. Built from the
+    # same difflib output but truncated at whole-hunk boundaries so the emitted
+    # patch is always valid.
+    patch, patch_truncated = _build_patch(lines, short_path, MAX_DIFF_LINES)
+
     return {
         "path": file_path,
         "short_path": short_path,
@@ -235,8 +240,86 @@ def _parse_unified_diff(
         "binary": False,
         "stats": {"additions": additions, "deletions": deletions},
         "hunks": hunks,
-        "truncated": truncated,
+        "patch": patch,
+        "truncated": truncated or patch_truncated,
     }
+
+
+def _build_patch(
+    raw_lines: list[str],
+    short_path: str,
+    max_content_lines: int,
+) -> tuple[str, bool]:
+    """Assemble a git-style unified-diff patch from raw difflib output.
+
+    difflib's own ``---``/``+++`` header lines are regenerated as git-style
+    headers (with a leading ``diff --git`` line) so the @pierre/diffs parser
+    strips the ``a/``/``b/`` prefixes and detects the file correctly. Only
+    whole hunks are emitted; truncation always lands on a hunk boundary so the
+    result is a valid, parseable patch.
+
+    Returns ``(patch_text, truncated)``.
+    """
+    hunks: list[list[str]] = []
+    current: list[str] | None = None
+    for raw in raw_lines:
+        if raw.startswith(("---", "+++")):
+            continue  # regenerated below
+        if raw.startswith("@@"):
+            current = [raw]
+            hunks.append(current)
+        elif current is not None:
+            current.append(raw)
+
+    if not hunks:
+        return "", False
+
+    out: list[str] = [
+        f"diff --git a/{short_path} b/{short_path}\n",
+        f"--- a/{short_path}\n",
+        f"+++ b/{short_path}\n",
+    ]
+    total = 0
+    truncated = False
+    for hunk in hunks:
+        body = hunk[1:]
+        if total > 0 and total + len(body) > max_content_lines:
+            truncated = True
+            break
+        for line in hunk:
+            out.append(line if line.endswith("\n") else line + "\n")
+        total += len(body)
+    return "".join(out), truncated
+
+
+def _new_file_patch(short_path: str, lines: list[str]) -> str:
+    """git-style patch for a created file — every line is an addition."""
+    if not lines:
+        return ""
+    out = [
+        f"diff --git a/{short_path} b/{short_path}\n",
+        "new file mode 100644\n",
+        "--- /dev/null\n",
+        f"+++ b/{short_path}\n",
+        f"@@ -0,0 +1,{len(lines)} @@\n",
+    ]
+    out.extend(f"+{l}\n" for l in lines)
+    return "".join(out)
+
+
+def _deleted_file_patch(short_path: str, lines: list[str]) -> str:
+    """git-style patch for a deleted file — every line is a deletion."""
+    if not lines:
+        return ""
+    out = [
+        f"diff --git a/{short_path} b/{short_path}\n",
+        "deleted file mode 100644\n",
+        f"--- a/{short_path}\n",
+        "+++ /dev/null\n",
+        f"@@ -1,{len(lines)} +0,0 @@\n",
+    ]
+    out.extend(f"-{l}\n" for l in lines)
+    return "".join(out)
 
 
 def _make_new_file_diff(
@@ -267,6 +350,7 @@ def _make_new_file_diff(
                 for i, l in enumerate(lines)
             ],
         }] if lines else [],
+        "patch": _new_file_patch(short_path, lines),
         "truncated": truncated,
     }
 
@@ -299,6 +383,7 @@ def _make_deleted_file_diff(
                 for i, l in enumerate(lines)
             ],
         }] if lines else [],
+        "patch": _deleted_file_patch(short_path, lines),
         "truncated": truncated,
     }
 
@@ -315,5 +400,6 @@ def _empty_diff(
         "binary": False,
         "stats": {"additions": 0, "deletions": 0},
         "hunks": [],
+        "patch": "",
         "truncated": False,
     }

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,119 @@
+"""Tests for unified-diff computation, including the git-style ``patch`` string
+consumed by the @pierre/diffs frontend renderer."""
+
+from __future__ import annotations
+
+import difflib
+
+from nerve.gateway.diff import (
+    MAX_DIFF_LINES,
+    _build_patch,
+    compute_file_diff,
+)
+
+
+def test_modified_file_patch_is_git_style():
+    orig = "line1\nline2\nline3\nline4\n"
+    curr = "line1\nline2 changed\nline3\nline4\nline5\n"
+    d = compute_file_diff(orig, curr, "/ws/src/app.py", workspace="/ws")
+
+    assert d["status"] == "modified"
+    assert d["short_path"] == "src/app.py"
+    patch = d["patch"]
+    # git-style header lets the parser strip a/ b/ prefixes
+    assert patch.startswith("diff --git a/src/app.py b/src/app.py\n")
+    assert "--- a/src/app.py\n" in patch
+    assert "+++ b/src/app.py\n" in patch
+    # hunk + the actual change
+    assert "@@ -1,4 +1,5 @@" in patch
+    assert "-line2\n" in patch
+    assert "+line2 changed\n" in patch
+    assert "+line5\n" in patch
+    assert not d["truncated"]
+
+
+def test_created_file_patch():
+    d = compute_file_diff(None, "a\nb\nc\n", "/ws/new.ts", workspace="/ws")
+
+    assert d["status"] == "created"
+    patch = d["patch"]
+    assert "diff --git a/new.ts b/new.ts\n" in patch
+    assert "new file mode 100644\n" in patch
+    assert "--- /dev/null\n" in patch
+    assert "+++ b/new.ts\n" in patch
+    assert patch.count("\n+") >= 3  # additions present
+
+
+def test_deleted_file_patch():
+    d = compute_file_diff("x\ny\n", None, "/ws/gone.go", workspace="/ws")
+
+    assert d["status"] == "deleted"
+    patch = d["patch"]
+    assert "diff --git a/gone.go b/gone.go\n" in patch
+    assert "deleted file mode 100644\n" in patch
+    assert "--- a/gone.go\n" in patch
+    assert "+++ /dev/null\n" in patch
+    assert "-x\n" in patch and "-y\n" in patch
+
+
+def test_unchanged_file_has_empty_patch():
+    d = compute_file_diff("same\n", "same\n", "/ws/same.py", workspace="/ws")
+    assert d["status"] == "unchanged"
+    assert d["patch"] == ""
+    assert d["hunks"] == []
+
+
+def test_patch_filename_carries_extension_for_language_inference():
+    # Language inference in the renderer relies on the extension surviving in
+    # the patch header.
+    d = compute_file_diff("import x\n", "import y\n", "/ws/a/b/Component.tsx", workspace="/ws")
+    assert "b/a/b/Component.tsx\n" in d["patch"]
+
+
+def test_build_patch_truncates_on_hunk_boundary():
+    # Two well-separated hunks; budget admits only the first.
+    orig = "".join(f"{c}\n" for c in "abcdefghij")
+    curr = orig.replace("b\n", "B\n").replace("i\n", "I\n")
+    raw = list(
+        difflib.unified_diff(
+            orig.splitlines(keepends=True),
+            curr.splitlines(keepends=True),
+            fromfile="a/x.py",
+            tofile="b/x.py",
+            n=1,
+        )
+    )
+    patch, truncated = _build_patch(raw, "x.py", max_content_lines=3)
+
+    assert truncated is True
+    # first hunk (b -> B) kept, second hunk (i -> I) dropped
+    assert "+B\n" in patch
+    assert "+I\n" not in patch
+    # still a valid patch: header + exactly one hunk
+    assert patch.startswith("diff --git a/x.py b/x.py\n")
+    assert patch.count("@@ -") == 1
+
+
+def test_build_patch_keeps_first_hunk_even_if_over_budget():
+    # A single oversized hunk must still be emitted whole (never an empty patch).
+    orig = "".join(f"{i}\n" for i in range(20))
+    curr = "".join(f"X{i}\n" for i in range(20))
+    raw = list(
+        difflib.unified_diff(
+            orig.splitlines(keepends=True),
+            curr.splitlines(keepends=True),
+            fromfile="a/x.py",
+            tofile="b/x.py",
+            n=3,
+        )
+    )
+    patch, _ = _build_patch(raw, "x.py", max_content_lines=1)
+    assert "@@ -" in patch
+    assert "+X0\n" in patch
+
+
+def test_large_created_file_truncated_flag():
+    content = "".join(f"line {i}\n" for i in range(MAX_DIFF_LINES + 50))
+    d = compute_file_diff(None, content, "/ws/big.txt", workspace="/ws")
+    assert d["truncated"] is True
+    assert d["patch"]  # still produced

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@pierre/diffs": "^1.2.7",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.575.0",
         "react": "^19.2.0",
@@ -1018,6 +1019,33 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@pierre/diffs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.7.tgz",
+      "integrity": "sha512-YrHmFZLDtiLZ4DkiVqMDUFqTFIct3ML3t20nMp0UeuiUtqrmRcenYVxPb4IafiNkhZZURhCiwcs89tVb/HrSDA==",
+      "license": "apache-2.0",
+      "dependencies": {
+        "@pierre/theme": "1.0.3",
+        "@shikijs/transformers": "^3.0.0",
+        "diff": "8.0.3",
+        "hast-util-to-html": "9.0.5",
+        "lru_map": "0.4.1",
+        "shiki": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/@pierre/theme": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz",
+      "integrity": "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1374,6 +1402,83 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-3.23.0.tgz",
+      "integrity": "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
@@ -2148,7 +2253,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2382,7 +2486,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2393,7 +2496,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2435,7 +2537,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2558,6 +2659,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3018,6 +3128,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3066,7 +3199,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -3111,6 +3243,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -3657,6 +3799,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3930,7 +4078,6 @@
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4597,6 +4744,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4770,7 +4934,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4883,6 +5046,30 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/rehype-highlight": {
       "version": "7.0.2",
@@ -5068,6 +5255,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5082,7 +5285,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5093,7 +5295,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -5192,7 +5393,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5330,7 +5530,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@pierre/diffs": "^1.2.7",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.575.0",
     "react": "^19.2.0",

--- a/web/src/components/Chat/DiffView.tsx
+++ b/web/src/components/Chat/DiffView.tsx
@@ -1,149 +1,64 @@
-import { Fragment } from 'react';
-import type { FileDiff, DiffHunk, DiffLine as DiffLineType } from '../../types/chat';
+import { PatchDiff, MultiFileDiff } from '@pierre/diffs/react';
+import { useDiffOptions } from './diffTheme';
+import { MAX_DIFF_LINES } from '../../types/chat';
+import type { FileDiff } from '../../types/chat';
 
-// ------------------------------------------------------------------ //
-//  Hunk header — @@ -old,count +new,count @@ context                  //
-// ------------------------------------------------------------------ //
-
-function HunkHeader({ hunk }: { hunk: DiffHunk }) {
+function Notice({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-accent/10 text-[11px] px-3 py-1 border-y border-accent/20 select-none flex items-center gap-2 sticky top-0 z-[1]">
-      <span className="text-link font-mono">
-        @@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@
-      </span>
-      {hunk.header && (
-        <span className="text-text-faint truncate">{hunk.header}</span>
-      )}
+    <div className="px-4 py-6 text-center text-[13px] text-text-faint">
+      {children}
     </div>
   );
 }
 
 // ------------------------------------------------------------------ //
-//  Diff line — single line with gutters                                //
-// ------------------------------------------------------------------ //
-
-const LINE_STYLES: Record<string, string> = {
-  addition: 'bg-diff-add-bg/25',
-  deletion: 'bg-diff-del-bg/25',
-  context: '',
-  info: '',
-};
-
-const TEXT_STYLES: Record<string, string> = {
-  addition: 'text-diff-add/90',
-  deletion: 'text-diff-del/90',
-  context: 'text-text-muted',
-  info: 'text-text-faint italic',
-};
-
-const PREFIX: Record<string, string> = {
-  addition: '+',
-  deletion: '\u2212',  // minus sign
-  context: ' ',
-  info: '',
-};
-
-const GUTTER_STYLES: Record<string, string> = {
-  addition: 'bg-diff-add-bg/15 border-diff-add-bg/30',
-  deletion: 'bg-diff-del-bg/15 border-diff-del-bg/30',
-  context: 'border-surface-raised',
-  info: 'border-surface-raised',
-};
-
-function DiffLine({ line }: { line: DiffLineType }) {
-  const bg = LINE_STYLES[line.type] || '';
-  const text = TEXT_STYLES[line.type] || 'text-text-muted';
-  const prefix = PREFIX[line.type] || '';
-  const gutterBg = GUTTER_STYLES[line.type] || '';
-
-  return (
-    <div className={`flex ${bg} hover:brightness-125 transition-[filter] duration-75 group`}>
-      {/* Old line number gutter */}
-      <span
-        className={`w-[48px] shrink-0 text-right pr-2 text-[10px] leading-[20px] text-text-faint select-none border-r ${gutterBg} font-mono`}
-      >
-        {line.old_line ?? ''}
-      </span>
-      {/* New line number gutter */}
-      <span
-        className={`w-[48px] shrink-0 text-right pr-2 text-[10px] leading-[20px] text-text-faint select-none border-r ${gutterBg} font-mono`}
-      >
-        {line.new_line ?? ''}
-      </span>
-      {/* Prefix (+/-/space) */}
-      <span className={`w-[20px] shrink-0 text-center select-none text-[12px] leading-[20px] ${text}`}>
-        {prefix}
-      </span>
-      {/* Content */}
-      <span className={`text-[12px] leading-[20px] font-mono whitespace-pre flex-1 pr-4 ${text}`}>
-        {line.content}
-      </span>
-    </div>
-  );
-}
-
-// ------------------------------------------------------------------ //
-//  Collapsed context between hunks                                     //
-// ------------------------------------------------------------------ //
-
-function CollapsedLines({ count }: { count: number }) {
-  if (count <= 0) return null;
-  return (
-    <div className="flex items-center justify-center py-1 text-[11px] text-text-faint bg-bg border-y border-surface-raised">
-      <span className="px-3">⋯ {count} unchanged line{count !== 1 ? 's' : ''} ⋯</span>
-    </div>
-  );
-}
-
-function prevHunkEnd(hunk: DiffHunk): number {
-  return hunk.old_start + hunk.old_count;
-}
-
-// ------------------------------------------------------------------ //
-//  Main DiffView component                                             //
+//  DiffView — backend-computed file diff, rendered from a patch string //
 // ------------------------------------------------------------------ //
 
 export function DiffView({ diff }: { diff: FileDiff }) {
+  const options = useDiffOptions();
+
   if (diff.binary) {
-    return (
-      <div className="px-4 py-6 text-center text-[13px] text-text-faint">
-        Binary file — diff not available
-      </div>
-    );
+    return <Notice>Binary file — diff not available</Notice>;
   }
 
-  if (diff.status === 'unchanged' || diff.hunks.length === 0) {
-    return (
-      <div className="px-4 py-6 text-center text-[13px] text-text-faint">
-        No changes
-      </div>
-    );
+  if (diff.status === 'unchanged' || !diff.patch) {
+    return <Notice>No changes</Notice>;
   }
 
   return (
-    <div className="font-mono text-[12px] leading-[20px] overflow-x-auto">
-      {diff.hunks.map((hunk, i) => (
-        <Fragment key={i}>
-          {/* Collapsed context between hunks */}
-          {i > 0 && (
-            <CollapsedLines count={hunk.old_start - prevHunkEnd(diff.hunks[i - 1])} />
-          )}
-
-          {/* Hunk header */}
-          <HunkHeader hunk={hunk} />
-
-          {/* Lines */}
-          {hunk.lines.map((line, j) => (
-            <DiffLine key={j} line={line} />
-          ))}
-        </Fragment>
-      ))}
-
+    <div className="diff-view">
+      <PatchDiff patch={diff.patch} options={options} />
       {diff.truncated && (
         <div className="text-center py-3 text-[11px] text-text-faint bg-bg border-t border-border-subtle">
-          Diff truncated at {2000} lines
+          Diff truncated at {MAX_DIFF_LINES} lines
         </div>
       )}
+    </div>
+  );
+}
+
+// ------------------------------------------------------------------ //
+//  EditDiff — before/after diff for an Edit tool call (old/new text)  //
+// ------------------------------------------------------------------ //
+
+export function EditDiff({
+  fileName,
+  oldString,
+  newString,
+}: {
+  fileName: string;
+  oldString: string;
+  newString: string;
+}) {
+  const options = useDiffOptions();
+  return (
+    <div className="diff-view">
+      <MultiFileDiff
+        oldFile={{ name: fileName, contents: oldString }}
+        newFile={{ name: fileName, contents: newString }}
+        options={options}
+      />
     </div>
   );
 }

--- a/web/src/components/Chat/FileChangesPanel.tsx
+++ b/web/src/components/Chat/FileChangesPanel.tsx
@@ -1,10 +1,13 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { ArrowLeft, FilePlus, FileEdit, FileX, Loader2, RefreshCw } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 import { api } from '../../api/client';
-import { DiffView } from './DiffView';
 import { SelectionToolbar } from './SelectionToolbar';
 import type { FileDiff, ModifiedFileSummary } from '../../types/chat';
+
+// The diff renderer pulls in @pierre/diffs + Shiki — only loaded when a file
+// diff is actually opened, keeping it off the initial bundle.
+const DiffView = lazy(() => import('./DiffView').then((m) => ({ default: m.DiffView })));
 
 // ------------------------------------------------------------------ //
 //  File list view                                                      //
@@ -132,7 +135,17 @@ function FileDetailView({ file, onBack }: { file: ModifiedFileSummary; onBack: (
         {error && (
           <div className="px-4 py-4 text-[13px] text-hue-red">Failed to load diff: {error}</div>
         )}
-        {diff && !loading && <DiffView diff={diff} />}
+        {diff && !loading && (
+          <Suspense
+            fallback={
+              <div className="flex items-center gap-2 justify-center py-8 text-[13px] text-text-faint">
+                <Loader2 size={14} className="animate-spin" /> Loading diff…
+              </div>
+            }
+          >
+            <DiffView diff={diff} />
+          </Suspense>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/Chat/SelectionToolbar.tsx
+++ b/web/src/components/Chat/SelectionToolbar.tsx
@@ -9,6 +9,51 @@ interface ToolbarPosition {
   text: string;
 }
 
+interface FoundSelection {
+  text: string;
+  rect: DOMRect;
+}
+
+const QUOTE_SCOPE = '[data-role="assistant"], [data-role="plan"]';
+
+function readSelection(sel: Selection | null): { text: string; range: Range } | null {
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
+  const text = sel.toString().trim();
+  if (!text) return null;
+  return { text, range: sel.getRangeAt(0) };
+}
+
+/**
+ * Resolve the active text selection, looking in both the light DOM (chat /
+ * plan text) and inside any `<diffs-container>` shadow roots. @pierre/diffs
+ * renders the diff into a shadow root whose selection is not surfaced through
+ * `window.getSelection()` in Chromium, so we read it via the non-standard
+ * `ShadowRoot.getSelection()` and fall back gracefully where it's absent.
+ */
+function findSelection(container: HTMLElement): FoundSelection | null {
+  // 1) Light DOM selection.
+  const docSel = window.getSelection();
+  const light = readSelection(docSel);
+  if (light) {
+    const anchor = docSel!.anchorNode;
+    const anchorEl = anchor instanceof Element ? anchor : anchor?.parentElement ?? null;
+    if (anchor && container.contains(anchor) && anchorEl?.closest(QUOTE_SCOPE)) {
+      return { text: light.text, rect: light.range.getBoundingClientRect() };
+    }
+  }
+
+  // 2) Shadow DOM selections (syntax-highlighted diffs).
+  const hosts = container.querySelectorAll<HTMLElement>('diffs-container');
+  for (const host of hosts) {
+    if (!host.closest(QUOTE_SCOPE)) continue;
+    const root = host.shadowRoot as (ShadowRoot & { getSelection?: () => Selection | null }) | null;
+    const found = readSelection(root?.getSelection?.() ?? null);
+    if (found) return { text: found.text, rect: found.range.getBoundingClientRect() };
+  }
+
+  return null;
+}
+
 const ACTIONS: { action: QuoteAction; icon: typeof Plus; label: string }[] = [
   { action: 'add', icon: Plus, label: 'Add' },
   { action: 'remove', icon: Trash2, label: 'Remove' },
@@ -22,31 +67,19 @@ export function SelectionToolbar({ containerRef }: { containerRef: React.RefObje
   const toolbarRef = useRef<HTMLDivElement>(null);
 
   const checkSelection = useCallback(() => {
-    const sel = window.getSelection();
-    if (!sel || sel.isCollapsed || !sel.toString().trim()) {
-      setPosition(null);
-      return;
-    }
-
-    const text = sel.toString().trim();
     const container = containerRef.current;
-    if (!container || !text) return;
-
-    const anchorNode = sel.anchorNode;
-    if (!anchorNode || !container.contains(anchorNode)) {
+    if (!container) {
       setPosition(null);
       return;
     }
 
-    // Only activate inside assistant messages or plan panel
-    const anchorEl = anchorNode instanceof Element ? anchorNode : anchorNode.parentElement;
-    if (!anchorEl?.closest('[data-role="assistant"], [data-role="plan"]')) {
+    const found = findSelection(container);
+    if (!found) {
       setPosition(null);
       return;
     }
 
-    const range = sel.getRangeAt(0);
-    const rect = range.getBoundingClientRect();
+    const { text, rect } = found;
     const containerRect = container.getBoundingClientRect();
 
     setPosition({

--- a/web/src/components/Chat/diffTheme.ts
+++ b/web/src/components/Chat/diffTheme.ts
@@ -1,0 +1,42 @@
+import { useThemeStore } from '../../stores/themeStore';
+
+// Shared theming for all @pierre/diffs renders in Nerve. Kept free of any
+// @pierre/diffs import so it stays lightweight and can be used by components
+// that lazy-load the (heavy) diff renderer.
+
+// Shiki themes for the dark/light variants. github-* matches the palette Nerve
+// already uses for markdown code blocks, so syntax colors stay consistent.
+export const DIFF_THEME = { dark: 'github-dark', light: 'github-light' };
+
+// Injected into the diffs-container shadow root via the library's `unsafeCSS`
+// option, which lands in the highest CSS @layer (unsafe) — so it overrides the
+// renderer's own theme styles, including the surface background the library
+// sets on :host. Everything maps onto Nerve's --theme-* tokens, which are
+// inherited across the shadow boundary and already adapt to light/dark.
+export const DIFF_THEME_CSS = `:host {
+  /* Surface flush with the Nerve panel background. */
+  --diffs-bg: var(--theme-bg);
+  /* Added/removed line tints — Nerve's muted diff backgrounds. */
+  --diffs-bg-addition-override: var(--theme-diff-add-bg);
+  --diffs-bg-deletion-override: var(--theme-diff-del-bg);
+  /* +/- indicators, gutter numbers and inline emphasis derive from these. */
+  --diffs-addition-color-override: var(--theme-diff-add);
+  --diffs-deletion-color-override: var(--theme-diff-del);
+}`;
+
+/**
+ * Shared @pierre/diffs options for every Nerve diff render — unified layout,
+ * Nerve theming, and no library file header (Nerve renders its own chrome).
+ * `themeType` follows the app theme store ('system' | 'light' | 'dark').
+ */
+export function useDiffOptions() {
+  const themeType = useThemeStore((s) => s.preference);
+  return {
+    diffStyle: 'unified' as const,
+    themeType,
+    theme: DIFF_THEME,
+    disableFileHeader: true,
+    diffIndicators: 'classic' as const,
+    unsafeCSS: DIFF_THEME_CSS,
+  };
+}

--- a/web/src/components/Chat/tools/EditToolBlock.tsx
+++ b/web/src/components/Chat/tools/EditToolBlock.tsx
@@ -1,6 +1,10 @@
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { ChevronRight, ChevronDown, FileEdit, Loader2 } from 'lucide-react';
 import type { ToolCallBlockData } from '../../../types/chat';
+
+// The diff renderer pulls in @pierre/diffs + Shiki — only loaded when an Edit
+// block is expanded. Shares the lazy chunk with FileChangesPanel's DiffView.
+const EditDiff = lazy(() => import('../DiffView').then((m) => ({ default: m.EditDiff })));
 
 export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
   const [expanded, setExpanded] = useState(false);
@@ -8,9 +12,6 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
   const filePath = String(block.input.file_path || '');
   const oldString = String(block.input.old_string || '');
   const newString = String(block.input.new_string || '');
-
-  const oldLines = oldString.split('\n');
-  const newLines = newString.split('\n');
 
   return (
     <div className="my-1.5 border border-border rounded-lg bg-surface overflow-hidden">
@@ -32,17 +33,16 @@ export function EditToolBlock({ block }: { block: ToolCallBlockData }) {
       {expanded && (
         <div className="border-t border-border">
           {/* Diff view */}
-          <div className="font-mono text-[12px] overflow-x-auto max-h-80 overflow-y-auto">
-            {oldLines.map((line, i) => (
-              <div key={`old-${i}`} className="px-3 py-0.5 bg-diff-del-bg/15 text-diff-del/80">
-                <span className="select-none text-diff-del/40 mr-2">-</span>{line}
-              </div>
-            ))}
-            {newLines.map((line, i) => (
-              <div key={`new-${i}`} className="px-3 py-0.5 bg-diff-add-bg/15 text-diff-add/80">
-                <span className="select-none text-diff-add/40 mr-2">+</span>{line}
-              </div>
-            ))}
+          <div className="max-h-80 overflow-y-auto">
+            <Suspense
+              fallback={
+                <div className="px-3 py-3 text-[12px] text-text-dim flex items-center gap-2">
+                  <Loader2 size={12} className="animate-spin" /> Loading diff…
+                </div>
+              }
+            >
+              <EditDiff fileName={filePath} oldString={oldString} newString={newString} />
+            </Suspense>
           </div>
 
           {/* Error */}

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -95,6 +95,9 @@ export interface PanelTab {
 
 // --- Session modified files & diff types ---
 
+/** Mirrors MAX_DIFF_LINES in nerve/gateway/diff.py — diffs are truncated past this. */
+export const MAX_DIFF_LINES = 2000;
+
 export interface DiffLine {
   type: 'addition' | 'deletion' | 'context' | 'info';
   content: string;
@@ -118,6 +121,8 @@ export interface FileDiff {
   binary: boolean;
   stats: { additions: number; deletions: number };
   hunks: DiffHunk[];
+  /** Raw git-style unified-diff string for the @pierre/diffs renderer. */
+  patch: string;
   truncated: boolean;
 }
 


### PR DESCRIPTION
## Summary

Replaces the hand-rolled diff renderers with [`@pierre/diffs`](https://diffs.com) (a Shiki-based diff library) for **syntax-highlighted, line-matched diffs** that follow the Nerve theme. Covers both diff surfaces in the UI:

- **File-changes panel** (`DiffView`) — renders a backend-computed patch via `<PatchDiff>`.
- **`Edit` tool calls** (`EditToolBlock`) — renders `old_string`/`new_string` via `<MultiFileDiff>`, replacing the previous "list every old line then every new line" dump with a real diff.

## What changed

**Backend** (`nerve/gateway/diff.py`)
- Emit a git-style `patch` string per file diff, truncated at whole-hunk boundaries so the result is always a valid, parseable patch. Kept alongside the existing structured `hunks`/`stats` (no breaking change to the response).
- New `tests/test_diff.py` (8 tests) covering modified/created/deleted/unchanged patches, language-extension preservation, and hunk-boundary truncation.

**Frontend**
- `DiffView` (`<PatchDiff>`) and `EditDiff` (`<MultiFileDiff>`) share options via `diffTheme.ts`.
- Theme the renderer onto Nerve's `--theme-*` tokens through the shadow-root `unsafeCSS` hook (highest CSS `@layer`), so the diff surface + tints match the app in light/dark. Syntax palette is `github-dark`/`github-light` — the same Nerve already uses for markdown code blocks.
- `SelectionToolbar` is now shadow-DOM-aware, so quote-to-comment keeps working over diffs (Chromium `ShadowRoot.getSelection()`; degrades gracefully elsewhere).
- The renderer (Shiki) is **lazy-loaded** and shared between both surfaces, so the initial bundle is unchanged (~405 KB / 115 KB gz on-demand chunk; Shiki grammars/themes are further code-split per language).

## Verification

- `pytest` — full suite passes (901 incl. 8 new).
- `tsc -b && vite build` clean.
- Headless SSR render (`@pierre/diffs/ssr`) confirms backend patches and Edit old/new strings produce highlighted, line-matched diffs with correct language inference (Python, TSX).

## Notes

- The shadow-aware selection relies on a non-standard Chromium API; on Firefox/Safari quoting simply isn't offered inside diffs (no regression elsewhere).
- `MultiEdit` still falls through to the generic tool renderer — easy follow-up to give it the same treatment.
- The dependabot advisories on this branch are pre-existing on `main` (react-router etc.), unrelated to this change.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*