### PR TITLE
fix(db): repair tasks_fts join key so search & dedup reach all tasks

### DIFF
--- a/nerve/db/__init__.py
+++ b/nerve/db/__init__.py
@@ -22,12 +22,18 @@ async def get_db() -> Database:
     return _db
 
 
-async def init_db(db_path: Path | None = None) -> Database:
-    """Initialize the global database."""
+async def init_db(db_path: Path | None = None, workspace: Path | None = None) -> Database:
+    """Initialize the global database.
+
+    Args:
+        db_path: Path to the SQLite file. Defaults to ``~/.nerve/nerve.db``.
+        workspace: Workspace root for resolving task file paths during FTS
+            reseed. When omitted, the DB falls back to the DB's parent dir.
+    """
     global _db
     if db_path is None:
         db_path = Path("~/.nerve/nerve.db").expanduser()
-    _db = Database(db_path)
+    _db = Database(db_path, workspace=workspace)
     await _db.connect()
     return _db
 

--- a/nerve/db/base.py
+++ b/nerve/db/base.py
@@ -60,8 +60,13 @@ class Database(
     and all domain-specific data access methods via mixin inheritance.
     """
 
-    def __init__(self, db_path: Path):
+    def __init__(self, db_path: Path, workspace: Path | None = None):
         self.db_path = db_path
+        # Workspace root used to resolve task file_path values during FTS
+        # reseed. Defaults to the DB's parent dir for backward compatibility,
+        # but production passes the configured workspace (task files live in
+        # the workspace, NOT next to the DB in ~/.nerve).
+        self.workspace = workspace
         self._db: aiosqlite.Connection | None = None
         self._write_lock = asyncio.Lock()
 
@@ -113,8 +118,11 @@ class Database(
                 task_count, fts_count,
             )
             await self.db.execute("DELETE FROM tasks_fts")
-            # Read content from disk files (source of truth) instead of seeding empty
-            workspace = self.db_path.parent
+            # Read content from disk files (source of truth) instead of seeding
+            # empty. Task file_path values are relative to the workspace root,
+            # which is NOT the DB directory (~/.nerve) — fall back to it only
+            # when no workspace was provided.
+            workspace = (self.workspace or self.db_path.parent).expanduser()
             async with self.db.execute("SELECT id, title, file_path FROM tasks") as cur:
                 rows = await cur.fetchall()
             for row in rows:

--- a/nerve/db/migrations/v032_tasks_fts_raw_id.py
+++ b/nerve/db/migrations/v032_tasks_fts_raw_id.py
@@ -1,0 +1,38 @@
+"""V32: Fix the tasks_fts join-key format — unify on the raw task_id.
+
+A regression made ``upsert_task`` store the FTS join key as a space-normalized
+slug (``task_id`` with hyphens replaced by spaces) while the reseed path and the
+schema migrations kept storing the raw ``id``. The readers joined via
+``f.task_id = REPLACE(t.id, '-', ' ')`` (space form), so only the handful of
+tasks written *since* the regression were reachable — the rest were stranded in
+raw-id form. In practice ~96% of tasks became invisible to FTS search
+(``search_tasks`` strategy 2) and to dedup (``search_tasks_similar``, which has
+no LIKE fallback). The space double-write also left duplicate rows, so the FTS
+row count drifted above the task count and forced a reseed on every startup.
+
+The fix unifies everyone on the raw ``id`` and joins on ``f.task_id = t.id``.
+The FTS5 tokenizer still splits the hyphenated slug into individual words
+(``2026-03-10-distribution`` → ``2026``, ``03``, ``10``, ``distribution``), so
+slug search is fully preserved.
+
+This migration clears ``tasks_fts`` so the startup FTS integrity check
+(``Database._check_fts_integrity``) rebuilds it from disk with the correct
+raw-id key and real content. Clearing also drops the stale mixed-format and
+duplicate rows accumulated by the old double-write, reconciling the row count.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Empty the index; the row count now differs from the task count, so
+    # _check_fts_integrity() reseeds on this same connect() with the correct
+    # raw-id key and content read from the configured workspace.
+    await db.execute("DELETE FROM tasks_fts")
+    logger.info("V32 migration: cleared tasks_fts for raw-id rebuild on startup")

--- a/nerve/db/tasks.py
+++ b/nerve/db/tasks.py
@@ -32,15 +32,16 @@ class TaskStore:
                        deadline=excluded.deadline, tags=excluded.tags, updated_at=?""",
                 (task_id, file_path, title, status, source, source_url, deadline, tags, now, now, now),
             )
-            # Sync FTS index — include tags and slug so they're all searchable
+            # Sync FTS index — include tags and content so they're all searchable.
+            # The join key is the RAW task_id; readers join on `f.task_id = t.id`.
+            # The FTS5 tokenizer already splits the hyphenated slug into words
+            # ("2026-03-10-distribution" → 2026, 03, 10, distribution), so slug
+            # search works without rewriting the key — and the key stays joinable.
             fts_content = f"{content} {tags.replace(',', ' ')}" if tags else content
-            # Normalize slug: replace hyphens with spaces so "2026-03-10-distribution"
-            # becomes searchable as individual words
-            fts_slug = task_id.replace("-", " ")
-            await self.db.execute("DELETE FROM tasks_fts WHERE task_id = ?", (fts_slug,))
+            await self.db.execute("DELETE FROM tasks_fts WHERE task_id = ?", (task_id,))
             await self.db.execute(
                 "INSERT INTO tasks_fts (task_id, title, content) VALUES (?, ?, ?)",
-                (fts_slug, title, fts_content),
+                (task_id, title, fts_content),
             )
 
     async def get_task(self, task_id: str) -> dict | None:
@@ -247,7 +248,7 @@ class TaskStore:
 
             async with self.db.execute(
                 f"SELECT t.* FROM tasks t "
-                f"JOIN tasks_fts f ON f.task_id = REPLACE(t.id, '-', ' ') "
+                f"JOIN tasks_fts f ON f.task_id = t.id "
                 f"WHERE tasks_fts MATCH ?{where_extra} "
                 f"ORDER BY f.rank LIMIT ?",
                 tuple(fts_params),
@@ -326,7 +327,7 @@ class TaskStore:
 
         sql = (
             "SELECT t.* FROM tasks t "
-            "JOIN tasks_fts f ON f.task_id = REPLACE(t.id, '-', ' ') "
+            "JOIN tasks_fts f ON f.task_id = t.id "
             "WHERE tasks_fts MATCH ? "
         )
         params: list = [fts_query]

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -131,7 +131,7 @@ async def lifespan(app: FastAPI):
 
     # Initialize database
     db_path = Path("~/.nerve/nerve.db").expanduser()
-    db = await init_db(db_path)
+    db = await init_db(db_path, workspace=config.workspace)
     logger.info("Database initialized at %s", db_path)
 
     # Optional Langfuse observability — must be set up BEFORE the engine

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -595,6 +595,142 @@ class TestTaskSearch:
         assert await db.count_tasks(status="done") == 0
 
 
+@pytest.mark.asyncio
+class TestTaskFtsJoinRegression:
+    """Guards against the tasks_fts join-key format regression.
+
+    The FTS join key must be the RAW task_id so readers can join on
+    ``f.task_id = t.id``. A past regression stored a space-normalized slug in
+    ``upsert_task`` while the reseed path and readers expected the raw id,
+    making ~96% of tasks invisible to FTS search and to dedup. These tests fail
+    if the writer (upsert_task / reseed) and the reader joins drift apart again.
+
+    Note: the older TestTaskSearch tests pass with EITHER format because, in a
+    single fresh DB, upsert and the readers agree — and the id-substring /
+    title LIKE fallbacks mask a dead FTS join. These tests deliberately probe
+    body/tag-only words and the no-fallback dedup path to catch the real bug.
+    """
+
+    DATED_ID = "2026-02-11-distribution-pipeline-rework"
+
+    async def _create(self, db, task_id, title, content="", status="pending", tags=""):
+        await db.upsert_task(
+            task_id=task_id, file_path=f"memory/tasks/active/{task_id}.md",
+            title=title, status=status, content=content, tags=tags,
+        )
+
+    async def test_fts_row_stores_raw_id(self, db: Database):
+        """upsert_task must store the raw id as the FTS join key (not a slug)."""
+        await self._create(db, self.DATED_ID, "Pipeline rework")
+        async with db.db.execute("SELECT task_id FROM tasks_fts") as cur:
+            row = await cur.fetchone()
+        assert row[0] == self.DATED_ID  # raw, NOT "2026 02 11 ..."
+
+    async def test_content_only_word_found_for_dated_task(self, db: Database):
+        """A word only in the BODY (not title/slug) is reachable only via the
+        FTS join — the exact path the regression broke for dated ids."""
+        await self._create(
+            db, self.DATED_ID, title="Pipeline rework",
+            content="The throughput bottleneck is the shuffler stage.",
+        )
+        # "shuffler" is in neither the title nor the slug → only FTS can find it.
+        results = await db.search_tasks("shuffler")
+        assert [r["id"] for r in results] == [self.DATED_ID]
+
+    async def test_tag_only_word_found_for_dated_task(self, db: Database):
+        """Tags are indexed into FTS content; reachable only via the join."""
+        await self._create(
+            db, self.DATED_ID, title="Pipeline rework",
+            content="body", tags="backfill,throughput",
+        )
+        results = await db.search_tasks("backfill")
+        assert [r["id"] for r in results] == [self.DATED_ID]
+
+    async def test_search_similar_finds_dated_task(self, db: Database):
+        """search_tasks_similar (dedup) has NO LIKE fallback — it relies purely
+        on the FTS join, so it silently broke for dated ids. Guard it."""
+        await self._create(
+            db, self.DATED_ID, title="Distribution pipeline rework",
+            content="rework the distribution pipeline",
+        )
+        sim = await db.search_tasks_similar("distribution pipeline")
+        assert self.DATED_ID in [r["id"] for r in sim]
+
+
+@pytest.mark.asyncio
+class TestTaskFtsReseed:
+    """Guards the FTS integrity reseed: it must produce joinable raw-id rows and
+    read task content from the configured workspace, not the DB directory."""
+
+    async def test_reseed_produces_joinable_raw_id_rows(self, tmp_path):
+        """After a reseed (triggered by a count mismatch), tasks stay reachable
+        via the FTS join. The reseed writes raw-id rows; readers join on t.id."""
+        db = Database(tmp_path / "t.db", workspace=tmp_path)
+        await db.connect()
+        try:
+            await db.upsert_task(
+                task_id="2026-03-01-redis-eviction",
+                file_path="memory/tasks/active/2026-03-01-redis-eviction.md",
+                title="Redis eviction tuning", status="pending", content="",
+            )
+            # Force a tasks/tasks_fts count mismatch so the check reseeds.
+            await db.db.execute(
+                "INSERT INTO tasks_fts (task_id, title, content) VALUES ('x','y','z')"
+            )
+            await db.db.commit()
+            await db._check_fts_integrity()
+            # The reseed wrote a single raw-id row...
+            async with db.db.execute("SELECT task_id FROM tasks_fts") as cur:
+                rows = [r[0] async for r in cur]
+            assert rows == ["2026-03-01-redis-eviction"]
+            # ...reachable via the FTS join. Use search_tasks_similar (dedup),
+            # which has NO LIKE fallback, so it isolates the join: with the old
+            # space-form reader join this returns nothing for a reseeded row.
+            sim = await db.search_tasks_similar("eviction")
+            assert "2026-03-01-redis-eviction" in [r["id"] for r in sim]
+        finally:
+            await db.close()
+
+    async def test_reseed_reads_content_from_workspace_not_db_dir(self, tmp_path):
+        """The reseed must resolve task file_path against the workspace root,
+        not the DB directory — otherwise body content is silently empty.
+
+        DB dir and workspace are deliberately different so this fails with the
+        old ``self.db_path.parent`` behaviour.
+        """
+        db_dir = tmp_path / ".nerve"
+        workspace = tmp_path / "workspace"
+        db_dir.mkdir()
+        workspace.mkdir()
+        db = Database(db_dir / "t.db", workspace=workspace)
+        await db.connect()
+        try:
+            file_path = "memory/tasks/active/2026-03-02-segment-merge.md"
+            md = workspace / file_path
+            md.parent.mkdir(parents=True, exist_ok=True)
+            md.write_text(
+                "# Segment merge\n\nDistinct body marker: quasarflux\n",
+                encoding="utf-8",
+            )
+            # Index with EMPTY content; only the reseed (reading the file from
+            # the workspace) can make the body word searchable.
+            await db.upsert_task(
+                task_id="2026-03-02-segment-merge", file_path=file_path,
+                title="Segment merge", status="pending", content="",
+            )
+            assert await db.search_tasks("quasarflux") == []  # not indexed yet
+            # Force a mismatch → reseed reads the file from the workspace.
+            await db.db.execute(
+                "INSERT INTO tasks_fts (task_id, title, content) VALUES ('x','y','z')"
+            )
+            await db.db.commit()
+            await db._check_fts_integrity()
+            results = await db.search_tasks("quasarflux")
+            assert "2026-03-02-segment-merge" in [r["id"] for r in results]
+        finally:
+            await db.close()
+
+
 class TestTagParsing:
     """Test tag string parsing handles various agent input formats."""
 


### PR DESCRIPTION
## Summary

The task full-text index (`tasks_fts`) join key was written in **two incompatible formats**, so after any startup reseed the FTS join matched **0 tasks** — silently breaking FTS-ranked `search_tasks` and, more damagingly, `search_tasks_similar` (the dedup path used by `task_create`, which has **no LIKE fallback**). Ordinary "search by name" queries kept working via the exact-id / id-substring / title LIKE fallbacks, which is why it went unnoticed.

## Root cause

- `upsert_task` stored the FTS key as a **space-normalized slug** (`task_id.replace("-", " ")`).
- The reseed path (`_check_fts_integrity`) and the schema migrations stored the **raw id**.
- Both readers joined via `f.task_id = REPLACE(t.id, '-', ' ')` — i.e. they only matched the **space form**.

So rows written by the reseed (raw-id) were unjoinable. Since the reseed rewrites the whole index on every startup where the row count drifts (the space double-write also left duplicate rows, guaranteeing drift), the steady state after a restart was **0% of tasks reachable** via FTS.

A second, related bug: the reseed read task files from `db_path.parent` (`~/.nerve`) instead of the workspace, so every reseeded row got **empty content**.

## Changes

- **Unify on the raw `task_id`** and join on `f.task_id = t.id` in `search_tasks` and `search_tasks_similar`. The FTS5 tokenizer already splits the hyphenated slug into words (`2026-03-10-distribution` → `2026`, `03`, `10`, `distribution`), so slug search is fully preserved — the space-normalization was unnecessary and only broke the join.
- **Thread the workspace into `Database`** (`Database(db_path, workspace=...)`, `init_db(..., workspace=...)`, passed from the gateway) so the reseed resolves task `file_path`s against the real workspace and repopulates content. Falls back to `db_path.parent` when not provided (backward-compatible).
- **Migration `v032`** clears `tasks_fts` so the startup integrity check rebuilds it in raw-id form with real content, also dropping stale mixed-format / duplicate rows.

## Verification

- Replayed the migration + reseed against a copy of a real DB (373 tasks): **0% → 100% joinable (373/373)**, content restored for 327/373 (the rest are old tasks whose `.md` files aren't in the workspace — still searchable by title+slug), and previously-invisible tasks are found again by both search and dedup.
- New regression tests isolate the FTS join via body/tag-only words and the no-fallback dedup path, plus the reseed's workspace content read. **Confirmed they fail on the old join** and pass on the fix.

## Test plan

- [x] `pytest tests/` — 907 passed
- [x] New `TestTaskFtsJoinRegression` + `TestTaskFtsReseed` verified red on the old join, green on the fix
- [ ] Requires a Nerve restart to apply (migration `v032` runs on connect)

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*