### PR TITLE
feat(memory): optional xmemory.ai layer alongside memU

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -104,6 +104,23 @@ Sources pull data from external services on a schedule. See [sources.md](sources
 | `memory.knowledge_filter` | bool | `false` | Post-extraction LLM filter that deletes generic knowledge items (extra Haiku API call per memorize) |
 | `memory.categories` | list | `[]` | Seed categories — each entry has `name` and `description` fields. Used for semantic routing when memorizing and recalling facts. `nerve init` populates mode-appropriate defaults (personal: relationships, finances, health, etc.; worker: patterns, procedures, approvals, etc.). |
 
+## xmemory (optional, alongside memU)
+
+[xmemory.ai](https://xmemory.ai) is an optional schema-backed memory layer that runs **alongside** memU — it never replaces it. Activated only when both `xmemory.api_key` and `xmemory.instance_id` are set (put them in `config.local.yaml`); otherwise it is completely inert (no SDK calls, zero overhead). The instance and its schema are created out of band on xmemory's side.
+
+When active:
+- The `memorize` tool **dual-writes**: memU (as always) plus an async `write_async` to xmemory. Failures on the xmemory side never fail the tool.
+- `memory_recall` appends xmemory's single synthesized answer (its `SINGLE_ANSWER` read mode) to memU's N items, run concurrently so the dual lookup is one round-trip.
+- The memorization **sweep** (session-close / cron) stays memU-only — it does not go through the `memorize` tool handler.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `xmemory.api_key` | string | *(empty)* | xmemory bearer token (invite-only). Secret → `config.local.yaml`. |
+| `xmemory.instance_id` | string | *(empty)* | The xmemory instance to bind. Both this and `api_key` are required to activate. |
+| `xmemory.api_url` | string | `https://api.xmemory.ai` | API base URL. |
+| `xmemory.extraction_logic` | string | `deep` | Write extraction mode: `deep` (accurate) or `fast` (high-volume). |
+| `xmemory.timeout` | float | `60.0` | Per-request timeout in seconds. |
+
 ## Docker
 
 Configuration for Docker deployment. Only relevant when `deployment: docker`.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -174,6 +174,20 @@ nerve migrate-openclaw --timeout 180  # longer per-session timeout
 
 Resumes automatically — skips sessions already indexed in the database.
 
+## xmemory (optional structured layer)
+
+[xmemory.ai](https://xmemory.ai) is an optional **schema-backed** memory store that can run alongside memU. memU keeps free-form facts in a semantic index; xmemory keeps typed objects/relations defined by a schema and answers natural-language queries from that knowledge graph. The two are complementary and run side by side — xmemory never replaces memU.
+
+It is inert unless both `xmemory.api_key` and `xmemory.instance_id` are configured (see [config reference](config.md#xmemory-optional-alongside-memu)). The instance and its schema are created out of band on xmemory's side; Nerve only binds to an existing instance.
+
+When active:
+
+- **`memorize` dual-writes** — the fact goes to memU (file + extraction, as always) **and** is enqueued to xmemory via async `write_async`. xmemory failures are swallowed (logged) so the tool never fails on them. The result message shows `(+ xmemory)` when the xmemory enqueue succeeded.
+- **`memory_recall` adds a synthesized answer** — alongside memU's N items + category breadcrumbs, recall runs xmemory's `SINGLE_ANSWER` read **concurrently** and appends a `[xmemory] synthesized answer` section. When xmemory is disabled or returns nothing, recall output is byte-for-byte the memU-only shape.
+- **The memorization sweep stays memU-only** — session-close / cron indexing goes through the bridge directly, not the `memorize` tool handler, so it is unaffected.
+
+Implementation: `nerve/memory/xmemory_bridge.py` (`XmemoryBridge`), wired into `ToolContext.xmemory_bridge` next to `memory_bridge`. Backed by the `xmemory-ai` SDK (`AsyncXmemoryClient`).
+
 ## Web UI
 
 - **Files tab** (`/files`) — File browser with markdown editing for workspace files

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -266,6 +266,7 @@ class AgentEngine:
         )
         self._semaphore = asyncio.Semaphore(config.agent.max_concurrent)
         self._memory_bridge = None
+        self._xmemory_bridge = None
         self._skill_manager: SkillManager | None = None
         self._memorize_lock = asyncio.Lock()
         self._session_locks: dict[str, asyncio.Lock] = {}
@@ -307,6 +308,13 @@ class AgentEngine:
         self._memory_bridge = MemUBridge(self.config, audit_db=self.db)
         await self._memory_bridge.initialize()
 
+        # Optional xmemory.ai structured-memory layer — inert unless both a
+        # token and instance_id are configured. Runs alongside memU; never
+        # replaces it. ``initialize`` never raises.
+        from nerve.memory.xmemory_bridge import XmemoryBridge
+        self._xmemory_bridge = XmemoryBridge(self.config.xmemory)
+        await self._xmemory_bridge.initialize()
+
         # Initialize skill manager and discover skills from filesystem
         self._skill_manager = SkillManager(self.config.workspace, self.db)
         try:
@@ -325,6 +333,7 @@ class AgentEngine:
         init_tools(
             self.config.workspace, self.db,
             memory_bridge=self._memory_bridge,
+            xmemory_bridge=self._xmemory_bridge,
             config=self.config,
             skill_manager=self._skill_manager,
             engine=self,
@@ -569,6 +578,13 @@ class AgentEngine:
 
         self.sessions._clients.clear()
         self.sessions._client_locks.clear()
+
+        # Close the optional xmemory HTTP client (no-op when disabled).
+        if self._xmemory_bridge is not None:
+            try:
+                await self._xmemory_bridge.aclose()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("Error closing xmemory bridge: %s", e)
 
     # ------------------------------------------------------------------ #
     #  Channel router                                                      #
@@ -988,6 +1004,7 @@ class AgentEngine:
             workspace=self.config.workspace,
             db=self.db,
             memory_bridge=self._memory_bridge,
+            xmemory_bridge=self._xmemory_bridge,
             config=self.config,
             skill_manager=self._skill_manager,
             engine=self,

--- a/nerve/agent/tools/__init__.py
+++ b/nerve/agent/tools/__init__.py
@@ -57,6 +57,7 @@ logger = logging.getLogger(__name__)
 _workspace: Path | None = None
 _db: Any = None
 _memory_bridge: Any = None
+_xmemory_bridge: Any = None
 _config: Any = None
 _skill_manager: Any = None
 _engine: Any = None
@@ -72,6 +73,7 @@ def init_tools(
     workspace: Path,
     db: Any,
     memory_bridge: Any = None,
+    xmemory_bridge: Any = None,
     config: Any = None,
     skill_manager: Any = None,
     engine: Any = None,
@@ -83,10 +85,11 @@ def init_tools(
     ``_*_impl`` helpers (used by tests) and the SdkMcpTool re-exports
     (used by HTTP routes pre-migration) working.
     """
-    global _workspace, _db, _memory_bridge, _config, _skill_manager, _engine
+    global _workspace, _db, _memory_bridge, _xmemory_bridge, _config, _skill_manager, _engine
     _workspace = workspace
     _db = db
     _memory_bridge = memory_bridge
+    _xmemory_bridge = xmemory_bridge
     _config = config
     _skill_manager = skill_manager
     _engine = engine
@@ -104,6 +107,7 @@ def _legacy_ctx(session_id: str | None = None) -> ToolContext:
         workspace=_workspace,
         db=_db,
         memory_bridge=_memory_bridge,
+        xmemory_bridge=_xmemory_bridge,
         config=_config,
         skill_manager=_skill_manager,
         engine=_engine,

--- a/nerve/agent/tools/handlers/memory.py
+++ b/nerve/agent/tools/handlers/memory.py
@@ -8,6 +8,7 @@ All handlers read collaborators (``memory_bridge``, ``config``) from
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sqlite3
 import tempfile
@@ -43,6 +44,10 @@ def _resolve_memu_db_path(ctx: ToolContext) -> str:
 # inline-output limit (which would silently persist it to a file).
 _MAX_RECALL_BYTES = 10_000
 
+# Sub-budget for xmemory's synthesized answer so it can never crowd out the
+# memU items it's shown alongside.
+_MAX_XMEM_ANSWER_BYTES = 4_000
+
 
 def _clip_to_budget(text: str, max_bytes: int = _MAX_RECALL_BYTES) -> str:
     """Truncate text to a UTF-8 byte budget, appending a notice if clipped."""
@@ -58,23 +63,32 @@ async def memory_recall_handler(ctx: ToolContext, args: dict) -> ToolResult:
     limit = int(args.get("limit", 10))
     category_limit = int(args.get("category_limit", 5))
 
-    if ctx.memory_bridge:
-        try:
-            results = await ctx.memory_bridge.recall(
-                query, limit=limit, category_limit=category_limit,
-            )
-            if not results:
-                return ToolResult.text("No relevant memories found.")
+    if not ctx.memory_bridge:
+        return ToolResult.text("Memory service not configured.")
 
-            items = [m for m in results if m.get("type") != "category"]
-            cats = [m for m in results if m.get("type") == "category"]
+    # Fire the optional xmemory read concurrently with the memU recall so the
+    # dual lookup costs one round-trip, not two. Inert (no task) when xmemory
+    # is disabled; ``recall_answer`` swallows its own errors and returns None.
+    xmem_task: asyncio.Task | None = None
+    if ctx.xmemory_bridge is not None and ctx.xmemory_bridge.available:
+        xmem_task = asyncio.ensure_future(ctx.xmemory_bridge.recall_answer(query))
 
+    memu_block: str | None = None  # None => memU returned no hits
+    try:
+        results = await ctx.memory_bridge.recall(
+            query, limit=limit, category_limit=category_limit,
+        )
+        items = [m for m in results if m.get("type") != "category"]
+        cats = [m for m in results if m.get("type") == "category"]
+
+        if items or cats:
             sections: list[str] = []
             if items:
-                item_lines = [
-                    f"- [{m['type']}] (id:{m['id']}) {m['summary']}" for m in items
-                ]
-                sections.append("\n".join(item_lines))
+                sections.append(
+                    "\n".join(
+                        f"- [{m['type']}] (id:{m['id']}) {m['summary']}" for m in items
+                    )
+                )
             if cats:
                 cat_lines = [
                     f"- [{m.get('name') or 'topic'}] (id:{m['id']}) {m['summary']}"
@@ -84,17 +98,35 @@ async def memory_recall_handler(ctx: ToolContext, args: dict) -> ToolResult:
                     "Related topics — drill in with memory_expand_category "
                     "(pass the cat:<id>):\n" + "\n".join(cat_lines)
                 )
-
             body = _clip_to_budget("\n\n".join(sections))
             header = f"Recalled {len(items)} memories"
             if cats:
                 header += f" + {len(cats)} related topics"
-            return ToolResult.text(f"{header}:\n\n{body}")
-        except Exception as e:
-            logger.error("Memory recall failed: %s", e)
-            return ToolResult.text(f"Memory recall error: {e}")
+            memu_block = f"{header}:\n\n{body}"
+    except Exception as e:
+        logger.error("Memory recall failed: %s", e)
+        memu_block = f"Memory recall error: {e}"
 
-    return ToolResult.text("Memory service not configured.")
+    # Collect xmemory's synthesized answer (None when disabled/empty/error).
+    xmem_answer: str | None = None
+    if xmem_task is not None:
+        try:
+            xmem_answer = await xmem_task
+        except Exception as e:  # pragma: no cover - recall_answer is guarded
+            logger.warning("xmemory recall task failed: %s", e)
+
+    # xmemory contributed nothing → preserve the exact original output shape.
+    if not xmem_answer:
+        if memu_block is None:
+            return ToolResult.text("No relevant memories found.")
+        return ToolResult.text(memu_block)
+
+    # Both stores in play → label each source so the two are distinguishable.
+    memu_part = memu_block if memu_block is not None else "No relevant memories found."
+    xmem_part = _clip_to_budget(xmem_answer, _MAX_XMEM_ANSWER_BYTES)
+    return ToolResult.text(
+        f"[memU] {memu_part}\n\n---\n\n[xmemory] synthesized answer:\n\n{xmem_part}"
+    )
 
 
 async def memory_expand_category_handler(ctx: ToolContext, args: dict) -> ToolResult:
@@ -330,19 +362,34 @@ async def memorize_handler(ctx: ToolContext, args: dict) -> ToolResult:
     if not ctx.memory_bridge or not ctx.memory_bridge.available:
         return ToolResult.text("Memory service not available.")
 
+    # Primary write: memU (file + extraction pipeline).
+    memu_ok = False
+    memu_err: str | None = None
     try:
         mem_dir = Path("~/.nerve/memu-manual").expanduser()
         mem_dir.mkdir(parents=True, exist_ok=True)
         mem_path = mem_dir / f"memorize-{int(time.time())}.txt"
         mem_path.write_text(f"{memory_type}: {content}", encoding="utf-8")
 
-        success = await ctx.memory_bridge.memorize_file(str(mem_path), modality="document")
-        if success:
-            return ToolResult.text(f"Memorized: {content}")
-        return ToolResult.text("Failed to memorize.")
+        memu_ok = await ctx.memory_bridge.memorize_file(str(mem_path), modality="document")
     except Exception as e:
-        logger.error("Memorize failed: %s", e)
-        return ToolResult.text(f"Error: {e}")
+        logger.error("Memorize (memU) failed: %s", e)
+        memu_err = str(e)
+
+    # Optional dual-write to xmemory (async, fire-and-forget). Independent of
+    # the memU outcome and never fails the tool; inert when xmemory is
+    # disabled. The memorization *sweep* does not go through this handler, so
+    # it stays memU-only as intended.
+    xmem_written = False
+    if ctx.xmemory_bridge is not None and ctx.xmemory_bridge.available:
+        xmem_written = await ctx.xmemory_bridge.memorize(f"{memory_type}: {content}")
+
+    if memu_ok:
+        suffix = " (+ xmemory)" if xmem_written else ""
+        return ToolResult.text(f"Memorized: {content}{suffix}")
+    if memu_err is not None:
+        return ToolResult.text(f"Error: {memu_err}")
+    return ToolResult.text("Failed to memorize.")
 
 
 async def memory_update_handler(ctx: ToolContext, args: dict) -> ToolResult:

--- a/nerve/agent/tools/registry.py
+++ b/nerve/agent/tools/registry.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from nerve.config import NerveConfig
     from nerve.db import Database
     from nerve.memory.memu_bridge import MemUBridge
+    from nerve.memory.xmemory_bridge import XmemoryBridge
     from nerve.notifications.service import NotificationService
     from nerve.skills.manager import SkillManager
 
@@ -44,6 +45,7 @@ class ToolContext:
     workspace: "Path | None" = None
     db: "Database | None" = None
     memory_bridge: "MemUBridge | None" = None
+    xmemory_bridge: "XmemoryBridge | None" = None
     config: "NerveConfig | None" = None
     skill_manager: "SkillManager | None" = None
     engine: "AgentEngine | None" = None

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -823,6 +823,41 @@ class LangfuseConfig:
 
 
 @dataclass
+class XmemoryConfig:
+    """xmemory.ai structured memory — optional, runs alongside memU.
+
+    Activated only when both ``api_key`` (the bearer token) and
+    ``instance_id`` are set. When active, the ``memorize`` tool dual-writes
+    to xmemory (async) and ``memory_recall`` appends xmemory's synthesized
+    answer to the memU results. The memorization sweep stays memU-only.
+
+    Empty keys = no-op, zero overhead, no SDK calls. The instance and its
+    schema are created out of band (by the operator) on xmemory's side.
+    """
+
+    api_key: str = ""
+    instance_id: str = ""
+    api_url: str = "https://api.xmemory.ai"
+    extraction_logic: str = "deep"  # "deep" (default) or "fast"
+    timeout: float = 60.0
+
+    @property
+    def enabled(self) -> bool:
+        """True only when both the token and an instance are configured."""
+        return bool(self.api_key and self.instance_id)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "XmemoryConfig":
+        return cls(
+            api_key=d.get("api_key", ""),
+            instance_id=d.get("instance_id", ""),
+            api_url=d.get("api_url", "https://api.xmemory.ai"),
+            extraction_logic=d.get("extraction_logic", "deep"),
+            timeout=float(d.get("timeout", 60.0)),
+        )
+
+
+@dataclass
 class NerveConfig:
     workspace: Path = field(default_factory=lambda: Path("~/nerve-workspace"))
     timezone: str = "America/New_York"
@@ -844,6 +879,7 @@ class NerveConfig:
     proxy: ProxyConfig = field(default_factory=ProxyConfig)
     houseofagents: HouseOfAgentsConfig = field(default_factory=HouseOfAgentsConfig)
     langfuse: LangfuseConfig = field(default_factory=LangfuseConfig)
+    xmemory: XmemoryConfig = field(default_factory=XmemoryConfig)
     mcp_endpoint: McpEndpointConfig = field(default_factory=McpEndpointConfig)
     mcp_servers: list[McpServerConfig] = field(default_factory=list)
     external_agents: ExternalAgentsConfig = field(default_factory=ExternalAgentsConfig)
@@ -953,6 +989,7 @@ class NerveConfig:
             proxy=ProxyConfig.from_dict(d.get("proxy", {})),
             houseofagents=HouseOfAgentsConfig.from_dict(d.get("houseofagents", {})),
             langfuse=LangfuseConfig.from_dict(d.get("langfuse", {})),
+            xmemory=XmemoryConfig.from_dict(d.get("xmemory", {})),
             mcp_endpoint=McpEndpointConfig.from_dict(d.get("mcp_endpoint", {})),
             mcp_servers=_parse_mcp_servers(d),
             external_agents=ExternalAgentsConfig.from_dict(d.get("external_agents", {})),

--- a/nerve/gateway/routes/_deps.py
+++ b/nerve/gateway/routes/_deps.py
@@ -89,6 +89,7 @@ def build_route_tool_context(session_id: str = "system") -> "ToolContext":
         workspace=engine.config.workspace,
         db=deps.db,
         memory_bridge=engine._memory_bridge,
+        xmemory_bridge=engine._xmemory_bridge,
         config=engine.config,
         skill_manager=engine._skill_manager,
         engine=engine,

--- a/nerve/mcp_server/http.py
+++ b/nerve/mcp_server/http.py
@@ -125,6 +125,7 @@ def build_ctx_resolver(engine: "AgentEngine", resolver: SatelliteSessionResolver
             workspace=engine.config.workspace,
             db=engine.db,
             memory_bridge=engine._memory_bridge,
+            xmemory_bridge=engine._xmemory_bridge,
             config=engine.config,
             skill_manager=engine._skill_manager,
             engine=engine,

--- a/nerve/memory/xmemory_bridge.py
+++ b/nerve/memory/xmemory_bridge.py
@@ -1,0 +1,188 @@
+"""xmemory.ai bridge — optional structured-memory layer alongside memU.
+
+xmemory (https://xmemory.ai) is a schema-backed memory service. Unlike
+memU's free-form semantic store, an xmemory *instance* holds structured
+objects defined by a schema; you ``write`` free text (an LLM extracts it
+into typed objects) and ``read`` in natural language (it answers from the
+knowledge graph).
+
+In Nerve, xmemory runs *next to* memU, never replacing it:
+
+* ``memorize`` tool  → dual-writes: memU (as today) **and** xmemory
+  (async ``write_async``, fire-and-forget).
+* ``memory_recall`` tool → memU returns its N items/breadcrumbs **and**
+  this bridge appends xmemory's single synthesized answer to the query.
+* The memorization *sweep* (session-close, cron) stays memU-only — it
+  never goes through the ``memorize`` tool handler, so it's untouched.
+
+The bridge is inert unless ``config.xmemory.enabled`` (both an API token
+and an ``instance_id`` are set). Every xmemory call is wrapped so a slow
+or failing xmemory can never break memU recall or the memorize tool.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nerve.config import XmemoryConfig
+
+logger = logging.getLogger(__name__)
+
+
+class XmemoryBridge:
+    """Thin async wrapper around the ``xmemory-ai`` SDK.
+
+    Holds a long-lived :class:`AsyncXmemoryClient` bound to a single
+    instance. Constructed cheaply; the network client and instance handle
+    are created in :meth:`initialize`. All public data methods degrade to a
+    no-op (returning ``None`` / ``False``) when the bridge is unavailable.
+    """
+
+    def __init__(self, config: "XmemoryConfig") -> None:
+        self._config = config
+        self._client: Any = None
+        self._instance: Any = None
+        self._available = False
+        # SDK enum/type handles, populated on successful import.
+        self._ReadMode: Any = None
+        self._ExtractionLogic: Any = None
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+    async def initialize(self) -> None:
+        """Construct the async client and bind the instance.
+
+        No-op (stays unavailable) when xmemory is not configured or the
+        ``xmemory-ai`` package is not importable. Never raises.
+        """
+        if not self._config.enabled:
+            logger.debug(
+                "xmemory: not configured (need api_key + instance_id) — disabled",
+            )
+            return
+
+        try:
+            from xmemory import (  # type: ignore[import-not-found]
+                AsyncXmemoryClient,
+                ExtractionLogic,
+                ReadMode,
+            )
+        except ImportError as e:
+            logger.warning(
+                "xmemory: configured but `xmemory-ai` package not installed "
+                "(%s) — disabled. Run `uv pip install xmemory-ai`.",
+                e,
+            )
+            return
+
+        try:
+            self._client = AsyncXmemoryClient(
+                self._config.api_url or None,
+                api_key=self._config.api_key,
+                timeout=self._config.timeout,
+            )
+            # ``.instance()`` returns a bound handle with no network call;
+            # reads/writes hit the API lazily.
+            self._instance = self._client.instance(self._config.instance_id)
+            self._ReadMode = ReadMode
+            self._ExtractionLogic = ExtractionLogic
+            self._available = True
+            logger.info(
+                "xmemory bridge ready (instance=%s, url=%s)",
+                self._config.instance_id,
+                self._config.api_url,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("xmemory: client init failed (%s) — disabled", e)
+            self._client = None
+            self._instance = None
+            self._available = False
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client. Idempotent, never raises."""
+        client = self._client
+        self._available = False
+        self._client = None
+        self._instance = None
+        if client is None:
+            return
+        try:
+            close = getattr(client, "aclose", None) or getattr(client, "close", None)
+            if close is not None:
+                result = close()
+                if hasattr(result, "__await__"):
+                    await result
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("xmemory: error closing client: %s", e)
+
+    @property
+    def available(self) -> bool:
+        """True when xmemory is configured, imported, and bound."""
+        return self._available and self._instance is not None
+
+    # ------------------------------------------------------------------ #
+    # Data ops
+    # ------------------------------------------------------------------ #
+    def _extraction_logic(self) -> Any:
+        """Map the configured ``extraction_logic`` string to the SDK enum."""
+        fast = (self._config.extraction_logic or "deep").strip().lower() == "fast"
+        return self._ExtractionLogic.FAST if fast else self._ExtractionLogic.DEEP
+
+    async def memorize(self, text: str) -> bool:
+        """Async-write ``text`` to xmemory (fire-and-forget).
+
+        Returns True if the write was enqueued, False otherwise. Failures
+        are swallowed (logged) so the memorize tool never fails on xmemory.
+        """
+        if not self.available or not text:
+            return False
+        try:
+            await self._instance.write_async(
+                text, extraction_logic=self._extraction_logic(),
+            )
+            return True
+        except Exception as e:
+            logger.warning("xmemory write_async failed: %s", e)
+            return False
+
+    async def recall_answer(self, query: str) -> str | None:
+        """Query xmemory and return its single synthesized answer.
+
+        Uses ``SINGLE_ANSWER`` read mode — xmemory translates the question
+        to SQL over its knowledge graph and returns a natural-language
+        answer. Returns the answer string, or ``None`` when unavailable,
+        empty, or on any error (so recall always falls back to memU alone).
+        """
+        if not self.available or not query:
+            return None
+        try:
+            result = await self._instance.read(
+                query, read_mode=self._ReadMode.SINGLE_ANSWER,
+            )
+            return _extract_answer(result)
+        except Exception as e:
+            logger.warning("xmemory read failed: %s", e)
+            return None
+
+
+def _extract_answer(result: Any) -> str | None:
+    """Pull the natural-language answer out of an SDK ReadResult.
+
+    SINGLE_ANSWER mode yields ``reader_result == {"answer": "..."}``; we
+    stay defensive about shape (dict, object, or bare string).
+    """
+    reader = getattr(result, "reader_result", result)
+    answer: Any = None
+    if isinstance(reader, dict):
+        answer = reader.get("answer")
+    elif hasattr(reader, "answer"):
+        answer = reader.answer
+    elif isinstance(reader, str):
+        answer = reader
+    if answer is None:
+        return None
+    text = str(answer).strip()
+    return text or None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "memu-py==1.4.0",  # pinned — nerve monkey-patches memU internals (see memu_bridge._patch_sqlite_bugs)
     "watchfiles>=1.0.0",
     "html2text>=2024.2.26",
+    # Optional xmemory.ai structured-memory layer — only active when an
+    # xmemory api_key + instance_id are configured (see XmemoryConfig).
+    "xmemory-ai>=0.5.3",
     # Optional observability stack — only active when langfuse keys are
     # configured. All three are pure-Python wheels.
     "langfuse>=3.0.0",

--- a/tests/test_xmemory_bridge.py
+++ b/tests/test_xmemory_bridge.py
@@ -1,0 +1,337 @@
+"""Tests for the optional xmemory.ai memory layer.
+
+xmemory runs *alongside* memU, never replacing it:
+* ``memorize`` dual-writes (memU + xmemory async), and
+* ``memory_recall`` appends xmemory's synthesized answer to memU's hits.
+
+These tests lock in three contracts: (1) the bridge is inert unless both a
+token and an instance_id are configured, (2) every xmemory failure is
+isolated so memU recall/memorize still works, and (3) the handlers combine
+both sources without regressing the memU-only output shape.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nerve.agent.tools.handlers.memory import (
+    memorize_handler,
+    memory_recall_handler,
+)
+from nerve.agent.tools.registry import ToolContext
+from nerve.config import NerveConfig, XmemoryConfig
+from nerve.memory.xmemory_bridge import XmemoryBridge, _extract_answer
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+
+
+def test_config_enabled_requires_both_keys() -> None:
+    assert XmemoryConfig().enabled is False
+    assert XmemoryConfig(api_key="tok").enabled is False
+    assert XmemoryConfig(instance_id="inst_1").enabled is False
+    assert XmemoryConfig(api_key="tok", instance_id="inst_1").enabled is True
+
+
+def test_config_from_dict_defaults_and_overrides() -> None:
+    c = XmemoryConfig.from_dict({})
+    assert c.api_key == "" and c.instance_id == ""
+    assert c.api_url == "https://api.xmemory.ai"
+    assert c.extraction_logic == "deep"
+    assert c.timeout == 60.0
+
+    c2 = XmemoryConfig.from_dict({
+        "api_key": "tok",
+        "instance_id": "inst_1",
+        "api_url": "https://example.test",
+        "extraction_logic": "fast",
+        "timeout": 30,
+    })
+    assert c2.enabled and c2.api_url == "https://example.test"
+    assert c2.extraction_logic == "fast" and c2.timeout == 30.0
+
+
+def test_nerveconfig_wires_xmemory_block() -> None:
+    nc = NerveConfig.from_dict({"xmemory": {"api_key": "t", "instance_id": "i"}})
+    assert nc.xmemory.enabled is True
+    # Absent block → inert, never None.
+    assert NerveConfig.from_dict({}).xmemory.enabled is False
+
+
+# --------------------------------------------------------------------------- #
+# Pure helper: answer extraction
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_answer_shapes() -> None:
+    assert _extract_answer(SimpleNamespace(reader_result={"answer": "  hi "})) == "hi"
+    assert _extract_answer(SimpleNamespace(reader_result={"answer": ""})) is None
+    assert _extract_answer(SimpleNamespace(reader_result={})) is None
+    assert _extract_answer(SimpleNamespace(reader_result="plain")) == "plain"
+    assert _extract_answer(SimpleNamespace(reader_result=SimpleNamespace(answer="x"))) == "x"
+
+
+# --------------------------------------------------------------------------- #
+# Bridge — disabled / missing-package paths
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_bridge_inert_when_unconfigured() -> None:
+    bridge = XmemoryBridge(XmemoryConfig())
+    await bridge.initialize()
+    assert bridge.available is False
+    assert await bridge.recall_answer("q") is None
+    assert await bridge.memorize("knowledge: x") is False
+    await bridge.aclose()  # idempotent / safe on a never-initialized bridge
+
+
+@pytest.mark.asyncio
+async def test_bridge_disabled_when_package_missing(monkeypatch) -> None:
+    # Simulate `import xmemory` raising ImportError even though it's installed.
+    monkeypatch.setitem(sys.modules, "xmemory", None)
+    bridge = XmemoryBridge(XmemoryConfig(api_key="t", instance_id="i"))
+    await bridge.initialize()
+    assert bridge.available is False
+
+
+# --------------------------------------------------------------------------- #
+# Bridge — enabled path (real client construction, mocked instance handle)
+# --------------------------------------------------------------------------- #
+
+
+async def _enabled_bridge(extraction_logic: str = "deep") -> XmemoryBridge:
+    """Build a bridge bound to a (fake-token) real client, then mock the
+    instance handle so reads/writes never hit the network."""
+    cfg = XmemoryConfig(api_key="tok", instance_id="inst_1", extraction_logic=extraction_logic)
+    bridge = XmemoryBridge(cfg)
+    await bridge.initialize()  # client + .instance() are network-free
+    assert bridge.available
+    bridge._instance = AsyncMock()
+    return bridge
+
+
+@pytest.mark.asyncio
+async def test_recall_answer_returns_single_answer() -> None:
+    bridge = await _enabled_bridge()
+    bridge._instance.read = AsyncMock(
+        return_value=SimpleNamespace(reader_result={"answer": "alice@acme.com"})
+    )
+    ans = await bridge.recall_answer("What is Alice's email?")
+    assert ans == "alice@acme.com"
+    # Uses SINGLE_ANSWER read mode.
+    _, kwargs = bridge._instance.read.call_args
+    assert kwargs["read_mode"] == bridge._ReadMode.SINGLE_ANSWER
+    await bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_recall_answer_isolates_errors() -> None:
+    bridge = await _enabled_bridge()
+    bridge._instance.read = AsyncMock(side_effect=RuntimeError("xmem down"))
+    assert await bridge.recall_answer("q") is None  # never propagates
+    await bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_memorize_writes_async_with_configured_logic() -> None:
+    bridge = await _enabled_bridge(extraction_logic="deep")
+    bridge._instance.write_async = AsyncMock(return_value=SimpleNamespace(write_id="w1"))
+    assert await bridge.memorize("knowledge: the sky is blue") is True
+    args, kwargs = bridge._instance.write_async.call_args
+    assert args[0] == "knowledge: the sky is blue"
+    assert kwargs["extraction_logic"] == bridge._ExtractionLogic.DEEP
+    await bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_memorize_honors_fast_extraction_logic() -> None:
+    bridge = await _enabled_bridge(extraction_logic="fast")
+    bridge._instance.write_async = AsyncMock(return_value=SimpleNamespace(write_id="w1"))
+    await bridge.memorize("event: launched")
+    _, kwargs = bridge._instance.write_async.call_args
+    assert kwargs["extraction_logic"] == bridge._ExtractionLogic.FAST
+    await bridge.aclose()
+
+
+@pytest.mark.asyncio
+async def test_memorize_isolates_errors() -> None:
+    bridge = await _enabled_bridge()
+    bridge._instance.write_async = AsyncMock(side_effect=RuntimeError("boom"))
+    assert await bridge.memorize("knowledge: x") is False
+    await bridge.aclose()
+
+
+# --------------------------------------------------------------------------- #
+# Handlers — dual recall / dual write
+# --------------------------------------------------------------------------- #
+
+
+def _ctx(*, memu, xmem) -> ToolContext:
+    return ToolContext(
+        session_id="s-1",
+        workspace=Path("/tmp/ws"),
+        db=None,
+        memory_bridge=memu,
+        xmemory_bridge=xmem,
+        config=None,
+    )
+
+
+def _memu_recall(items):
+    memu = MagicMock()
+    memu.available = True
+    memu.recall = AsyncMock(return_value=items)
+    return memu
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_combines_memu_and_xmemory() -> None:
+    memu = _memu_recall([
+        {"id": "i1", "type": "profile", "summary": "Alice lives in Metropolis"},
+    ])
+    xmem = MagicMock()
+    xmem.available = True
+    xmem.recall_answer = AsyncMock(return_value="Alice's email is alice@acme.com")
+
+    result = await memory_recall_handler(_ctx(memu=memu, xmem=xmem), {"query": "alice"})
+    text = result.content[0]["text"]
+
+    assert "[memU]" in text
+    assert "Alice lives in Metropolis" in text
+    assert "[xmemory] synthesized answer" in text
+    assert "alice@acme.com" in text
+    xmem.recall_answer.assert_awaited_once_with("alice")
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_xmemory_answer_without_memu_hits() -> None:
+    memu = _memu_recall([])  # memU returns nothing
+    xmem = MagicMock()
+    xmem.available = True
+    xmem.recall_answer = AsyncMock(return_value="Synthesized from the graph.")
+
+    result = await memory_recall_handler(_ctx(memu=memu, xmem=xmem), {"query": "q"})
+    text = result.content[0]["text"]
+    assert "No relevant memories found" in text  # memU part
+    assert "Synthesized from the graph." in text  # xmemory part
+    assert "[xmemory]" in text
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_preserves_memu_only_shape_when_xmemory_disabled() -> None:
+    memu = _memu_recall([
+        {"id": "i1", "type": "profile", "summary": "Alice lives in Metropolis"},
+    ])
+    # xmemory bridge absent entirely.
+    result = await memory_recall_handler(_ctx(memu=memu, xmem=None), {"query": "x"})
+    text = result.content[0]["text"]
+    assert "Recalled 1 memories" in text
+    assert "[memU]" not in text  # original format, no source labels
+    assert "[xmemory]" not in text
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_no_xmemory_section_when_answer_empty() -> None:
+    memu = _memu_recall([
+        {"id": "i1", "type": "profile", "summary": "fact"},
+    ])
+    xmem = MagicMock()
+    xmem.available = True
+    xmem.recall_answer = AsyncMock(return_value=None)  # xmemory found nothing
+    result = await memory_recall_handler(_ctx(memu=memu, xmem=xmem), {"query": "x"})
+    text = result.content[0]["text"]
+    assert "Recalled 1 memories" in text
+    assert "[xmemory]" not in text  # no empty section
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_surfaces_xmemory_when_memu_errors() -> None:
+    memu = MagicMock()
+    memu.available = True
+    memu.recall = AsyncMock(side_effect=RuntimeError("db down"))
+    xmem = MagicMock()
+    xmem.available = True
+    xmem.recall_answer = AsyncMock(return_value="still answerable")
+
+    result = await memory_recall_handler(_ctx(memu=memu, xmem=xmem), {"query": "x"})
+    text = result.content[0]["text"]
+    assert "Memory recall error" in text
+    assert "still answerable" in text
+
+
+@pytest.mark.asyncio
+async def test_recall_handler_skips_xmemory_when_bridge_unavailable() -> None:
+    memu = _memu_recall([{"id": "i1", "type": "profile", "summary": "fact"}])
+    xmem = MagicMock()
+    xmem.available = False  # configured object present but not ready
+    xmem.recall_answer = AsyncMock(return_value="should not be called")
+
+    result = await memory_recall_handler(_ctx(memu=memu, xmem=xmem), {"query": "x"})
+    text = result.content[0]["text"]
+    assert "[xmemory]" not in text
+    xmem.recall_answer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_memorize_handler_dual_writes(monkeypatch, tmp_path) -> None:
+    # Keep the manual-memorize file write inside the test sandbox.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    memu = MagicMock()
+    memu.available = True
+    memu.memorize_file = AsyncMock(return_value=True)
+    xmem = MagicMock()
+    xmem.available = True
+    xmem.memorize = AsyncMock(return_value=True)
+
+    result = await memorize_handler(
+        _ctx(memu=memu, xmem=xmem),
+        {"content": "the sky is blue", "memory_type": "knowledge"},
+    )
+    text = result.content[0]["text"]
+    assert "Memorized: the sky is blue" in text
+    assert "(+ xmemory)" in text
+    xmem.memorize.assert_awaited_once()
+    assert xmem.memorize.call_args.args[0] == "knowledge: the sky is blue"
+
+
+@pytest.mark.asyncio
+async def test_memorize_handler_memu_only_when_xmemory_disabled(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    memu = MagicMock()
+    memu.available = True
+    memu.memorize_file = AsyncMock(return_value=True)
+
+    result = await memorize_handler(
+        _ctx(memu=memu, xmem=None),
+        {"content": "the sky is blue", "memory_type": "knowledge"},
+    )
+    text = result.content[0]["text"]
+    assert text == "Memorized: the sky is blue"  # no xmemory suffix
+
+
+@pytest.mark.asyncio
+async def test_memorize_handler_succeeds_even_if_xmemory_write_fails(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    memu = MagicMock()
+    memu.available = True
+    memu.memorize_file = AsyncMock(return_value=True)
+    xmem = MagicMock()
+    xmem.available = True
+    xmem.memorize = AsyncMock(return_value=False)  # xmemory enqueue failed
+
+    result = await memorize_handler(
+        _ctx(memu=memu, xmem=xmem),
+        {"content": "fact", "memory_type": "knowledge"},
+    )
+    text = result.content[0]["text"]
+    assert "Memorized: fact" in text
+    assert "(+ xmemory)" not in text  # memU still succeeded, xmemory silently skipped


### PR DESCRIPTION
## Summary

Adds an optional [xmemory.ai](https://xmemory.ai) structured-memory layer that runs **alongside** memU — it never replaces it. Completely inert (zero overhead, no SDK calls) unless both `xmemory.api_key` and `xmemory.instance_id` are configured, mirroring the existing Langfuse "keys-activate-it" pattern.

When active:

- **`memorize` dual-writes** — memU exactly as before, **plus** an async `write_async()` to xmemory. The result message shows `(+ xmemory)` when the enqueue succeeded.
- **`memory_recall` adds a synthesized answer** — alongside memU's N items + category breadcrumbs, recall runs xmemory's `SINGLE_ANSWER` read **concurrently** and appends a `[xmemory] synthesized answer` section. xmemory is schema-backed and `read` returns a synthesized answer (not N ranked items), so a single answer is the natural mapping.
- **The memorization sweep stays memU-only** — session-close / cron indexing goes through the bridge directly, not the `memorize` tool handler, so it is unaffected.
- **Failure-isolated** — every xmemory call is wrapped; a slow or failing xmemory can never break memU recall or memorize. When disabled/empty, recall output is byte-for-byte the old memU-only shape.

## Design

- New `XmemoryBridge` (`nerve/memory/xmemory_bridge.py`), constructed in `engine.initialize()` and threaded through `ToolContext.xmemory_bridge` next to `memory_bridge` (all construction sites updated: engine, MCP HTTP server, gateway routes, legacy shim). Closed on engine shutdown.
- New `XmemoryConfig` block (`api_key`, `instance_id`, `api_url`, `extraction_logic`, `timeout`); `enabled` requires both token + instance.
- Backed by the official `xmemory-ai` SDK (`AsyncXmemoryClient`); lazy-imported so a missing package just disables the layer.
- The instance + schema are created out of band on xmemory's side; Nerve only binds to an existing `instance_id`.

## Activation

```yaml
# config.local.yaml
xmemory:
  api_key: "<token>"        # invite-only
  instance_id: "<inst_id>"
  # extraction_logic: deep  # or fast
```

## Notes / scope

- `session_context` (external-agent startup priors) is intentionally left memU-only to keep startup lean — easy to extend later since the bridge method is reusable.
- `conversation_history` / `memory_records_by_date` are memU-specific date queries and remain memU-only.

## Test plan

- [x] `tests/test_xmemory_bridge.py` — 22 new tests: config gating, answer extraction, bridge inert-when-disabled + missing-package, enabled path (mocked instance), failure isolation, and handler-level dual recall / dual write incl. memU-only backward-compat shape.
- [x] Full suite green: `927 passed` (existing) + new tests.
- [ ] End-to-end against a live xmemory instance once a token + instance are provisioned.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*