### PR TITLE
Add support for Claude Fable 5 model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,8 @@ timezone: America/New_York
 # Agent
 agent:
   model: claude-opus-4-8         # Primary model for conversations
+  # Use claude-fable-5 for Anthropic's most capable (Mythos-class) model.
+  # Note: ~2x the cost of Opus 4.8 ($10/$50 per MTok in/out).
   cron_model: claude-sonnet-4-6  # Cheaper model for cron jobs
   title_model: claude-haiku-4-5-20251001  # Session title generation
   max_turns: 50                  # Max agentic turns per request

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1218,6 +1218,7 @@ class AgentEngine:
     # Ordered most-specific to least-specific; first match wins. Mirrors the
     # pattern used by MODEL_PRICING in nerve/db/usage.py.
     _MODEL_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
+        "fable-5":    ("low", "medium", "high", "xhigh", "max"),
         "opus-4-8":   ("low", "medium", "high", "xhigh", "max"),
         "opus-4-7":   ("low", "medium", "high", "xhigh", "max"),
         "opus-4-6":   ("low", "medium", "high", "max"),

--- a/nerve/db/usage.py
+++ b/nerve/db/usage.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 # Key: canonical model short-name substring → (input, output, cache_read,
 # cache_write_5m, cache_write_1h, web_search_per_req)
 MODEL_PRICING: dict[str, tuple[float, float, float, float, float, float]] = {
+    "fable-5":    (10,  50, 1.00, 12.50, 20.00, 0.01),  # Fable 5 (Mythos-class, ~2x Opus 4.8)
     "opus-4-8":   (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 4.8 standard
     "opus-4-7":   (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 4.7 standard
     "opus-4-6":   (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 4.6 standard

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,6 +13,10 @@ from nerve.agent.engine import AgentEngine
 @pytest.mark.parametrize(
     "value, model, expected",
     [
+        # Fable 5 (Mythos-class) supports the full effort ladder
+        ("max",    "claude-fable-5",            "max"),
+        ("xhigh",  "claude-fable-5",            "xhigh"),
+        ("low",    "claude-fable-5",            "low"),
         # Opus 4.8 supports every level (same ladder as 4.7)
         ("max",    "claude-opus-4-8",           "max"),
         ("xhigh",  "claude-opus-4-8",           "xhigh"),

--- a/tests/test_usage_cache_ttl.py
+++ b/tests/test_usage_cache_ttl.py
@@ -181,6 +181,16 @@ class TestPricing:
         assert c5m == 6.25
         assert c1h == 10.00
 
+    def test_fable_5_rates(self):
+        # Anchor: Fable 5 (Mythos-class) — ~2x Opus 4.8. Base $10/MTok input,
+        # $50/MTok output, 5m write = 1.25x = $12.50/MTok, 1h = 2.0x = $20/MTok.
+        from nerve.db.usage import _get_pricing
+        p_in, p_out, _, c5m, c1h, _ = _get_pricing("claude-fable-5")
+        assert p_in == 10
+        assert p_out == 50
+        assert c5m == 12.50
+        assert c1h == 20.00
+
 
 class TestEstimateCost:
     def test_falls_back_to_5m_when_split_absent(self):


### PR DESCRIPTION
## Summary
- Register Claude Fable 5 in the model pricing table (`nerve/db/usage.py`) and the effort-level whitelist (`nerve/agent/engine.py`) so cost tracking and effort capping resolve correctly when the model is configured.
- Fable 5 is Mythos-class, priced at **$10 / $50 per MTok** (input/output) — ~2× Opus 4.8. Cache-write (5m/1h) and `web_search` rates follow the same standard ratios as the other entries; the effort ladder mirrors Opus 4.8 (`low`…`max`).
- Document `claude-fable-5` as an option in `config.example.yaml`. **Defaults are unchanged.**
- New entries go at the top of both substring-matched tables (first-match-wins), per the established model-bump pattern.

No code changes were needed for thinking-style selection (`claude-fable-5` resolves to adaptive thinking, not the legacy 4.5/4.6 budget path) or the diagnostics UI model formatter (already renders "Fable 5").

## Test plan
- [x] `tests/test_usage_cache_ttl.py` — added `test_fable_5_rates` anchoring $10/$50 input/output + 1.25×/2× cache writes
- [x] `tests/test_engine.py` — added Fable 5 effort-ladder cases
- [x] Full suite: **931 passed**

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*