### PR TITLE
Stream autonomous CLI turns to the web UI between runs

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -14,14 +14,18 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
+
+import anyio
 
 from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
     ResultMessage,
+    SystemMessage,
     UserMessage,
     TextBlock,
     ToolUseBlock,
@@ -247,6 +251,30 @@ def _parse_mcp_tool_name(tool_name: str) -> tuple[str, str] | None:
     return None
 
 
+@dataclass
+class _TurnState:
+    """Accumulates one agent turn's worth of streamed content.
+
+    Shared by the user-run path (``_run_inner``) and the autonomous-turn
+    drain (``_drain_pending_messages``) so both produce identical UI
+    broadcasts and DB records.
+    """
+
+    full_response_text: str = ""
+    thinking_text: str = ""
+    tool_calls_log: list[dict] = field(default_factory=list)
+    tool_results_map: dict[str, dict] = field(default_factory=dict)
+    ordered_blocks: list[dict] = field(default_factory=list)
+    last_usage: dict | None = None
+    sdk_session_id: str | None = None
+    # tool_use_id -> monotonic start time of an in-flight sub-agent
+    active_subagents: dict[str, float] = field(default_factory=dict)
+    result_meta: dict | None = None
+    last_model: str | None = None
+    # True once any AssistantMessage was received (gates CLI-crash retry)
+    got_content: bool = False
+
+
 class AgentEngine:
     """Core agent engine wrapping claude-agent-sdk.
 
@@ -270,6 +298,19 @@ class AgentEngine:
         self._skill_manager: SkillManager | None = None
         self._memorize_lock = asyncio.Lock()
         self._session_locks: dict[str, asyncio.Lock] = {}
+        # Idle stream watchers — one per live SDK client. Between run()
+        # calls nothing reads the SDK message stream, but the CLI keeps
+        # producing: background tasks (Bash/Agent run_in_background,
+        # Monitor) settle with task_notification events that trigger FULL
+        # autonomous agent turns inside the subprocess. The watcher drains
+        # those through the normal processing pipeline so they stream to
+        # the UI live instead of buffering invisibly (and then desyncing
+        # the next receive_response()). See _idle_stream_watcher.
+        self._idle_watchers: dict[str, asyncio.Task] = {}
+        # Per-session background-task registry driven by the CLI's
+        # task_started / task_updated / task_notification system messages:
+        # session_id -> task_id -> {task_id, label, tool, status}.
+        self._bg_task_registry: dict[str, dict[str, dict[str, Any]]] = {}
         # Per-session active channel — set on run() entry, cleared on exit.
         # Read by session-scoped tools (send_file) to avoid dispatching via
         # stale router context from a prior inbound channel.
@@ -564,6 +605,9 @@ class AgentEngine:
         No memorization here — the periodic sweep handles that.
         Sessions are marked idle so they can be resumed on next startup.
         """
+        for sid in list(self._idle_watchers):
+            self._stop_idle_watcher(sid)
+
         for sid, client in list(self.sessions._clients.items()):
             try:
                 await self._safe_disconnect(client)
@@ -1321,6 +1365,7 @@ class AgentEngine:
                         "Client process for session %s is dead, recreating",
                         session_id,
                     )
+                    self._stop_idle_watcher(session_id)
                     self.sessions.remove_client(session_id)
                     unregister_handler(session_id)
                     await self._safe_disconnect(client)
@@ -1406,6 +1451,10 @@ class AgentEngine:
             client = ClaudeSDKClient(options=options)
             await client.connect()
             self.sessions.set_client(session_id, client)
+            # Watch the SDK stream between runs so autonomous CLI turns
+            # (background task completions, Monitor events) stream to the
+            # UI instead of buffering invisibly.
+            self._start_idle_watcher(session_id, client, source)
 
             # Record connected_at and the resolved model
             resolved_model = options.model
@@ -1435,6 +1484,7 @@ class AgentEngine:
             clear_resume: If True, clear sdk_session_id (e.g., on error).
                          If False, keep it for future resume (e.g., on stop).
         """
+        self._stop_idle_watcher(session_id)
         await self._memorize_session(session_id)
         client = self.sessions.remove_client(session_id)
 
@@ -1617,6 +1667,349 @@ class AgentEngine:
             if tid and tid in tool_results_map:
                 tc["result"] = tool_results_map[tid]["result"]
                 tc["is_error"] = tool_results_map[tid]["is_error"]
+
+    # ------------------------------------------------------------------ #
+    #  Shared per-message processing (user runs + autonomous turns)        #
+    # ------------------------------------------------------------------ #
+
+    async def _process_sdk_message(
+        self, session_id: str, message: Any, st: _TurnState,
+    ) -> bool:
+        """Process one SDK stream message: broadcast to the UI and
+        accumulate into ``st`` for DB persistence.
+
+        Shared by ``_run_inner`` (user-initiated turns) and
+        ``_drain_pending_messages`` (autonomous CLI turns) so both paths
+        produce identical events and records.
+
+        Returns True when the message is a ResultMessage (turn complete).
+        """
+        # Early-capture sdk_session_id from the first message that carries
+        # it so it survives /stop cancellation (ResultMessage — the normal
+        # source — never arrives when the turn is interrupted).
+        if not st.sdk_session_id:
+            msg_sid = getattr(message, "session_id", None)
+            if msg_sid:
+                st.sdk_session_id = msg_sid
+
+        if isinstance(message, AssistantMessage):
+            st.got_content = True
+            # Capture model from assistant message (more reliable than config)
+            msg_model = getattr(message, "model", None)
+            if msg_model:
+                st.last_model = msg_model
+            # Extract parent_tool_use_id — set when this message comes from
+            # a sub-agent (Task/Agent) rather than the main agent
+            parent_id = getattr(message, "parent_tool_use_id", None)
+
+            for block in message.content:
+                if isinstance(block, TextBlock):
+                    st.full_response_text += block.text
+                    # Track ordered blocks for DB persistence
+                    if st.ordered_blocks and st.ordered_blocks[-1].get("type") == "text":
+                        st.ordered_blocks[-1]["content"] += block.text
+                    else:
+                        st.ordered_blocks.append({"type": "text", "content": block.text})
+                    await broadcaster.broadcast_token(
+                        session_id, block.text,
+                        parent_tool_use_id=parent_id,
+                    )
+
+                elif ThinkingBlock is not None and isinstance(
+                    block, ThinkingBlock,
+                ):
+                    thinking = getattr(block, "thinking", "") or ""
+                    if not thinking:
+                        # Empty thinking block (e.g. Opus 4.7 with
+                        # display="omitted", or simple queries on low
+                        # effort). Nothing visible to render — never fall
+                        # back to str(block) as that leaks the
+                        # ThinkingBlock(...) repr into the UI.
+                        continue
+                    st.thinking_text += thinking
+                    # Track ordered blocks for DB persistence
+                    if st.ordered_blocks and st.ordered_blocks[-1].get("type") == "thinking":
+                        st.ordered_blocks[-1]["content"] += thinking
+                    else:
+                        st.ordered_blocks.append({"type": "thinking", "content": thinking})
+                    await broadcaster.broadcast_thinking(
+                        session_id, thinking,
+                        parent_tool_use_id=parent_id,
+                    )
+
+                elif isinstance(block, ToolUseBlock):
+                    tool_input = getattr(block, "input", {})
+                    tool_name = getattr(block, "name", None) or str(block)
+                    tool_use_id = getattr(block, "id", None)
+                    await broadcaster.broadcast_tool_use(
+                        session_id, tool_name, tool_input,
+                        tool_use_id=tool_use_id,
+                        parent_tool_use_id=parent_id,
+                    )
+                    # Track sub-agent lifecycle.  Claude Code 2.1.x renamed
+                    # the subagent-spawning tool from ``Task`` → ``Agent``
+                    # (and introduced separate ``TaskCreate``/``TaskUpdate``
+                    # /etc. tools for in-session todo tracking).  Match both
+                    # names so old session history still opens panels on
+                    # replay.
+                    if tool_name in ("Task", "Agent") and tool_use_id:
+                        st.active_subagents[tool_use_id] = asyncio.get_event_loop().time()
+                        await broadcaster.broadcast_subagent_start(
+                            session_id,
+                            tool_use_id=tool_use_id,
+                            subagent_type=str(tool_input.get("subagent_type", tool_input.get("model", "agent"))),
+                            description=str(tool_input.get("description", "")),
+                            model=str(tool_input.get("model", "")) or None,
+                        )
+                    st.tool_calls_log.append({
+                        "tool": tool_name,
+                        "input": tool_input,
+                        "tool_use_id": tool_use_id,
+                    })
+                    st.ordered_blocks.append({
+                        "type": "tool_call",
+                        "tool": tool_name,
+                        "input": tool_input,
+                        "tool_use_id": tool_use_id,
+                    })
+
+                elif isinstance(block, ToolResultBlock):
+                    await self._process_tool_result(
+                        block, session_id, parent_id,
+                        st.tool_results_map, st.ordered_blocks,
+                        st.tool_calls_log, st.active_subagents,
+                    )
+
+        elif isinstance(message, UserMessage):
+            parent_id = getattr(message, "parent_tool_use_id", None)
+            content = getattr(message, "content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, ToolResultBlock):
+                        await self._process_tool_result(
+                            block, session_id, parent_id,
+                            st.tool_results_map, st.ordered_blocks,
+                            st.tool_calls_log, st.active_subagents,
+                        )
+
+        elif isinstance(message, SystemMessage):
+            # Task lifecycle events (task_started/task_updated/
+            # task_notification) drive the background-task chips in the UI.
+            # Other subtypes (init, status, ...) are informational only.
+            await self._handle_system_message(session_id, message)
+
+        elif isinstance(message, ResultMessage):
+            if message.usage:
+                st.last_usage = message.usage
+            st.sdk_session_id = message.session_id
+            st.result_meta = {
+                "total_cost_usd": getattr(message, "total_cost_usd", None),
+                "duration_ms": getattr(message, "duration_ms", None),
+                "duration_api_ms": getattr(message, "duration_api_ms", None),
+                "num_turns": getattr(message, "num_turns", None),
+            }
+            return True
+
+        return False
+
+    # CLI task statuses that mean "no longer running".
+    _BG_TERMINAL_STATUSES = frozenset({"completed", "failed", "stopped", "killed"})
+
+    async def _handle_system_message(
+        self, session_id: str, message: Any,
+    ) -> None:
+        """Track CLI background-task lifecycle events and update the UI.
+
+        The CLI emits ``system`` messages for background work (Bash/Agent
+        ``run_in_background``, Monitor watches):
+
+        - ``task_started``  — task spawned (description, task_type)
+        - ``task_progress`` — periodic usage updates
+        - ``task_updated``  — status patches
+        - ``task_notification`` — task settled (completed/failed/stopped)
+
+        These replace the old regex-based output-file watcher: the chips in
+        the UI now reflect what the CLI actually tracks.
+        """
+        subtype = getattr(message, "subtype", "") or ""
+        if subtype not in (
+            "task_started", "task_progress", "task_updated", "task_notification",
+        ):
+            return
+
+        data = getattr(message, "data", None) or {}
+        task_id = data.get("task_id") or getattr(message, "task_id", None)
+        if not task_id:
+            return
+
+        registry = self._bg_task_registry.setdefault(session_id, {})
+        entry = registry.get(task_id)
+        if entry is None:
+            entry = {
+                "task_id": task_id, "label": "", "tool": "Bash",
+                "status": "running",
+            }
+            registry[task_id] = entry
+
+        changed = True
+        if subtype == "task_started":
+            entry["label"] = (
+                data.get("description")
+                or getattr(message, "description", "")
+                or entry["label"] or task_id
+            )
+            task_type = str(data.get("task_type") or "")
+            entry["tool"] = "Agent" if "agent" in task_type else "Bash"
+            entry["status"] = "running"
+        elif subtype == "task_progress":
+            # Only useful for backfilling a label if task_started was missed.
+            desc = data.get("description") or getattr(message, "description", "")
+            if desc and not entry["label"]:
+                entry["label"] = desc
+            else:
+                changed = False
+        elif subtype == "task_updated":
+            patch = data.get("patch") or {}
+            status = str(patch.get("status") or "")
+            if status in self._BG_TERMINAL_STATUSES:
+                entry["status"] = "done" if status in ("completed", "stopped") else "failed"
+            else:
+                changed = False
+        elif subtype == "task_notification":
+            status = str(data.get("status") or getattr(message, "status", "") or "")
+            entry["status"] = (
+                "done" if status in ("completed", "stopped", "") else "failed"
+            )
+            if not entry["label"]:
+                entry["label"] = data.get("summary") or task_id
+
+        if changed:
+            await broadcaster.broadcast(session_id, {
+                "type": "background_tasks_update",
+                "session_id": session_id,
+                "tasks": list(registry.values()),
+            })
+
+    def _prune_bg_tasks(self, session_id: str) -> None:
+        """Drop settled background tasks from the registry.
+
+        Called at the start of a new user turn so stale "done" chips don't
+        accumulate forever. Running tasks are kept.
+        """
+        registry = self._bg_task_registry.get(session_id)
+        if not registry:
+            return
+        for tid in [t for t, e in registry.items() if e.get("status") != "running"]:
+            del registry[tid]
+        if not registry:
+            self._bg_task_registry.pop(session_id, None)
+
+    async def _finalize_turn(
+        self, session_id: str, st: _TurnState, channel: str | None,
+    ) -> None:
+        """Persist a completed turn and emit the terminal ``done`` event.
+
+        Shared by user runs and autonomous turns: stores the assistant
+        message (with interleaved blocks), persists the SDK session id,
+        records usage/cost, broadcasts ``done``, and touches the idle
+        timer.
+        """
+        # Merge tool results into tool_calls_log
+        self._merge_tool_results(st.tool_calls_log, st.tool_results_map)
+
+        # Store assistant message in DB
+        await self.sessions.add_message(
+            session_id, "assistant", st.full_response_text,
+            channel=channel,
+            thinking=st.thinking_text if st.thinking_text else None,
+            blocks=st.ordered_blocks if st.ordered_blocks else None,
+        )
+
+        # Persist SDK session ID and update status
+        if st.sdk_session_id:
+            await self.sessions.mark_active(
+                session_id,
+                sdk_session_id=st.sdk_session_id,
+                connected_at=await self.get_client_connected_at_async(session_id),
+            )
+
+        # Persist usage for context bar on session switch
+        max_context = 1_048_576 if self.config.agent.context_1m else 200_000
+        num_turns = (st.result_meta or {}).get("num_turns") or 1
+        if st.last_usage:
+            usage_data = {
+                **st.last_usage,
+                "max_context_tokens": max_context,
+                "num_turns": num_turns,
+            }
+            session_record = await self.db.get_session(session_id)
+            meta = json.loads(session_record.get("metadata") or "{}") if session_record else {}
+            meta["last_usage"] = usage_data
+
+            # Extract server_tool_use counts
+            server_tool = st.last_usage.get("server_tool_use") or {}
+            web_search = server_tool.get("web_search_requests", 0)
+            web_fetch = server_tool.get("web_fetch_requests", 0)
+
+            # Calculate per-turn cost.
+            # NOTE: The SDK's total_cost_usd is *cumulative* across the
+            # entire SDK session, NOT per-invocation.  We track the last
+            # known cumulative value in session metadata so we can compute
+            # the delta for this turn.
+            from nerve.db.usage import estimate_turn_cost, extract_cache_ttl_split
+            sdk_cost = (st.result_meta or {}).get("total_cost_usd")
+            current_session_cost = (
+                session_record.get("total_cost_usd", 0) if session_record else 0
+            ) or 0
+
+            if sdk_cost is not None:
+                prev_cumulative = meta.get("_sdk_cumulative_cost", 0) or 0
+                turn_cost = max(sdk_cost - prev_cumulative, 0)
+                meta["_sdk_cumulative_cost"] = sdk_cost
+            else:
+                turn_cost = estimate_turn_cost(st.last_usage, model=st.last_model)
+
+            # Save metadata (includes _sdk_cumulative_cost update)
+            await self.db.update_session_metadata(session_id, meta)
+
+            # The Anthropic API splits cache_creation by TTL:
+            #   usage.cache_creation.ephemeral_5m_input_tokens  (1.25x base)
+            #   usage.cache_creation.ephemeral_1h_input_tokens  (2.00x base)
+            # Older API responses omit the split; the aggregate still
+            # lives in cache_creation_input_tokens.
+            cache_5m, cache_1h = extract_cache_ttl_split(st.last_usage)
+
+            # Persist per-turn usage to session_usage table
+            await self.db.record_turn_usage(
+                session_id=session_id,
+                input_tokens=st.last_usage.get("input_tokens", 0),
+                output_tokens=st.last_usage.get("output_tokens", 0),
+                cache_creation=st.last_usage.get("cache_creation_input_tokens", 0),
+                cache_read=st.last_usage.get("cache_read_input_tokens", 0),
+                cache_creation_5m=cache_5m,
+                cache_creation_1h=cache_1h,
+                max_context=max_context,
+                model=st.last_model,
+                cost_usd=turn_cost,
+                duration_ms=(st.result_meta or {}).get("duration_ms"),
+                duration_api_ms=(st.result_meta or {}).get("duration_api_ms"),
+                num_turns=num_turns,
+                web_search_requests=web_search,
+                web_fetch_requests=web_fetch,
+            )
+
+            # Update total_cost_usd on the session
+            await self.db.update_session_fields(session_id, {
+                "total_cost_usd": current_session_cost + turn_cost,
+            })
+
+        await broadcaster.broadcast_done(
+            session_id,
+            usage=st.last_usage,
+            max_context_tokens=max_context,
+            num_turns=num_turns,
+        )
+        self.sessions.touch(session_id)
 
     # ------------------------------------------------------------------ #
     #  Run agent                                                           #
@@ -1813,22 +2206,14 @@ class AgentEngine:
                 blocks=image_refs,
             )
 
-        full_response_text = ""
-        thinking_text = ""
-        tool_calls_log: list[dict] = []
-        tool_results_map: dict[str, dict] = {}
-        ordered_blocks: list[dict] = []  # preserves interleaving for DB
-        last_usage: dict | None = None
-        sdk_session_id: str | None = None
-        active_subagents: dict[str, float] = {}  # tool_use_id -> monotonic start
-        result_meta: dict | None = None  # ResultMessage fields beyond usage
-        last_model: str | None = None  # model from most recent AssistantMessage
+        # Turn accumulator — shared shape with the autonomous-turn drain.
+        st = _TurnState()
 
         # Wakeup turns (fired by the cron-service sweep) carry a leading
         # marker block so the UI shows a "scheduled wakeup" chip. Persisted
         # in ordered_blocks (survives reload) and broadcast live below.
         if source == "wakeup":
-            ordered_blocks.append({"type": "wakeup"})
+            st.ordered_blocks.append({"type": "wakeup"})
 
         try:
             # Get or create persistent client for this session
@@ -1850,6 +2235,36 @@ class AgentEngine:
             if self.sessions.pop_stop_request(session_id):
                 logger.info("Stop requested before agent turn — aborting session %s", session_id)
                 return ""
+
+            # Drain autonomous-turn messages that buffered while no run was
+            # active (background task settled in the race window before the
+            # idle watcher claimed it).  Without this, receive_response()
+            # below would consume the stale turn and terminate on ITS
+            # ResultMessage — answering this message with the previous
+            # turn's output (off-by-one desync).  The short first-content
+            # timeout keeps a just-started autonomous turn from delaying
+            # the user's message for long; if its content arrives later it
+            # interleaves into this turn's stream (still rendered) and the
+            # idle watcher self-heals the remainder.
+            try:
+                await self._drain_pending_messages(
+                    session_id, client, source, channel,
+                    first_content_timeout=3.0,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as drain_err:
+                logger.warning(
+                    "Pre-query drain failed for session %s: %s",
+                    session_id, drain_err,
+                )
+            # The drain's broadcast_done (if it processed a turn) cleared
+            # the open-turn flag set by run(); re-arm it so the synthetic-
+            # done backstop still covers THIS turn.
+            broadcaster.mark_turn_open(session_id)
+
+            # New user turn: settled background-task chips are stale now.
+            self._prune_bg_tasks(session_id)
 
             # Send message — the client preserves conversation history internally
             # Escape slash-prefixed messages so Claude Code CLI doesn't
@@ -1923,7 +2338,6 @@ class AgentEngine:
                 "parent_session_id": session.get("parent_session_id") if session else None,
                 "fork_from": fork_from,
             }
-            _got_response_content = False
             # Live marker so the UI shows the "scheduled wakeup" chip as the
             # turn streams (the persisted block above covers reload).
             if source == "wakeup":
@@ -1953,6 +2367,7 @@ class AgentEngine:
                             "CLI dead for session %s (query phase): %s — retrying",
                             session_id, _qerr,
                         )
+                        self._stop_idle_watcher(session_id)
                         self.sessions.remove_client(session_id)
                         unregister_handler(session_id)
                         await self._safe_disconnect(client)
@@ -1969,128 +2384,14 @@ class AgentEngine:
                             client, session_id,
                             self.config.agent.cli_idle_timeout_seconds,
                         ):
-                            # Early-capture sdk_session_id from first message that
-                            # carries it so it survives /stop cancellation (ResultMessage
-                            # — the normal source — never arrives when the turn is
-                            # interrupted).
-                            if not sdk_session_id:
-                                msg_sid = getattr(message, "session_id", None)
-                                if msg_sid:
-                                    sdk_session_id = msg_sid
-
-                            if isinstance(message, AssistantMessage):
-                                _got_response_content = True
-                                # Capture model from assistant message (more reliable than config)
-                                msg_model = getattr(message, 'model', None)
-                                if msg_model:
-                                    last_model = msg_model
-                                # Extract parent_tool_use_id — set when this message
-                                # comes from a sub-agent (Task) rather than the main agent
-                                parent_id = getattr(message, 'parent_tool_use_id', None)
-
-                                for block in message.content:
-                                    if isinstance(block, TextBlock):
-                                        full_response_text += block.text
-                                        # Track ordered blocks for DB persistence
-                                        if ordered_blocks and ordered_blocks[-1].get("type") == "text":
-                                            ordered_blocks[-1]["content"] += block.text
-                                        else:
-                                            ordered_blocks.append({"type": "text", "content": block.text})
-                                        await broadcaster.broadcast_token(
-                                            session_id, block.text,
-                                            parent_tool_use_id=parent_id,
-                                        )
-
-                                    elif ThinkingBlock is not None and isinstance(
-                                        block, ThinkingBlock,
-                                    ):
-                                        thinking = getattr(block, "thinking", "") or ""
-                                        if not thinking:
-                                            # Empty thinking block (e.g. Opus 4.7 with
-                                            # display="omitted", or simple queries on
-                                            # low effort). Nothing visible to render —
-                                            # never fall back to str(block) as that
-                                            # leaks the ThinkingBlock(...) repr into
-                                            # the UI.
-                                            continue
-                                        thinking_text += thinking
-                                        # Track ordered blocks for DB persistence
-                                        if ordered_blocks and ordered_blocks[-1].get("type") == "thinking":
-                                            ordered_blocks[-1]["content"] += thinking
-                                        else:
-                                            ordered_blocks.append({"type": "thinking", "content": thinking})
-                                        await broadcaster.broadcast_thinking(
-                                            session_id, thinking,
-                                            parent_tool_use_id=parent_id,
-                                        )
-
-                                    elif isinstance(block, ToolUseBlock):
-                                        tool_input = getattr(block, "input", {})
-                                        tool_name = getattr(block, "name", None) or str(block)
-                                        tool_use_id = getattr(block, "id", None)
-                                        await broadcaster.broadcast_tool_use(
-                                            session_id, tool_name, tool_input,
-                                            tool_use_id=tool_use_id,
-                                            parent_tool_use_id=parent_id,
-                                        )
-                                        # Track sub-agent lifecycle.  Claude Code
-                                        # 2.1.x renamed the subagent-spawning
-                                        # tool from ``Task`` → ``Agent`` (and
-                                        # introduced separate ``TaskCreate``/
-                                        # ``TaskUpdate``/etc. tools for in-
-                                        # session todo tracking).  Match both
-                                        # names so old session history still
-                                        # opens panels on replay.
-                                        if tool_name in ("Task", "Agent") and tool_use_id:
-                                            active_subagents[tool_use_id] = asyncio.get_event_loop().time()
-                                            await broadcaster.broadcast_subagent_start(
-                                                session_id,
-                                                tool_use_id=tool_use_id,
-                                                subagent_type=str(tool_input.get("subagent_type", tool_input.get("model", "agent"))),
-                                                description=str(tool_input.get("description", "")),
-                                                model=str(tool_input.get("model", "")) or None,
-                                            )
-                                        tool_calls_log.append({
-                                            "tool": tool_name,
-                                            "input": tool_input,
-                                            "tool_use_id": tool_use_id,
-                                        })
-                                        ordered_blocks.append({
-                                            "type": "tool_call",
-                                            "tool": tool_name,
-                                            "input": tool_input,
-                                            "tool_use_id": tool_use_id,
-                                        })
-
-                                    elif isinstance(block, ToolResultBlock):
-                                        await self._process_tool_result(
-                                            block, session_id, parent_id,
-                                            tool_results_map, ordered_blocks,
-                                            tool_calls_log, active_subagents,
-                                        )
-
-                            elif isinstance(message, UserMessage):
-                                parent_id = getattr(message, 'parent_tool_use_id', None)
-                                content = getattr(message, "content", [])
-                                if isinstance(content, list):
-                                    for block in content:
-                                        if isinstance(block, ToolResultBlock):
-                                            await self._process_tool_result(
-                                                block, session_id, parent_id,
-                                                tool_results_map, ordered_blocks,
-                                                tool_calls_log, active_subagents,
-                                            )
-
-                            elif isinstance(message, ResultMessage):
-                                if message.usage:
-                                    last_usage = message.usage
-                                sdk_session_id = message.session_id
-                                result_meta = {
-                                    "total_cost_usd": getattr(message, "total_cost_usd", None),
-                                    "duration_ms": getattr(message, "duration_ms", None),
-                                    "duration_api_ms": getattr(message, "duration_api_ms", None),
-                                    "num_turns": getattr(message, "num_turns", None),
-                                }
+                            done = await self._process_sdk_message(
+                                session_id, message, st,
+                            )
+                            if done:
+                                # receive_response() also stops after the
+                                # ResultMessage; the explicit break keeps
+                                # the invariant local.
+                                break
 
                     except asyncio.CancelledError:
                         raise  # propagate to outer handler
@@ -2098,13 +2399,14 @@ class AgentEngine:
                         # CLI crashed during response reading.
                         # Retry only if we haven't received any content yet
                         # (otherwise we'd produce duplicate/garbled output).
-                        if _got_response_content or _attempt > 0:
+                        if st.got_content or _attempt > 0:
                             raise
                         logger.warning(
                             "CLI crashed for session %s during response "
                             "(no content yet): %s — retrying with fresh client",
                             session_id, _recv_err,
                         )
+                        self._stop_idle_watcher(session_id)
                         self.sessions.remove_client(session_id)
                         unregister_handler(session_id)
                         await self._safe_disconnect(client)
@@ -2116,9 +2418,9 @@ class AgentEngine:
 
         except asyncio.CancelledError:
             logger.info("Session %s cancelled by user", session_id)
-            partial = full_response_text + (
+            partial = st.full_response_text + (
                 "\n\n[Stopped by user]"
-                if full_response_text
+                if st.full_response_text
                 else "[Stopped by user]"
             )
 
@@ -2126,11 +2428,12 @@ class AgentEngine:
             # Persist sdk_session_id so the session can be resumed later.
             # For new sessions the DB still has NULL because mark_active()
             # was called before the SDK emitted any messages.
-            if sdk_session_id:
+            if st.sdk_session_id:
                 await self.db.update_session_fields(
-                    session_id, {"sdk_session_id": sdk_session_id},
+                    session_id, {"sdk_session_id": st.sdk_session_id},
                 )
             await self.sessions.mark_stopped(session_id)
+            self._stop_idle_watcher(session_id)
             unregister_handler(session_id)
             client = self.sessions.remove_client(session_id)
             if client:
@@ -2138,12 +2441,12 @@ class AgentEngine:
 
             # --- Non-critical: save message, broadcast, memorize -----------
             try:
-                self._merge_tool_results(tool_calls_log, tool_results_map)
+                self._merge_tool_results(st.tool_calls_log, st.tool_results_map)
                 await self.sessions.add_message(
                     session_id, "assistant", partial,
                     channel=channel,
-                    thinking=thinking_text if thinking_text else None,
-                    blocks=ordered_blocks if ordered_blocks else None,
+                    thinking=st.thinking_text if st.thinking_text else None,
+                    blocks=st.ordered_blocks if st.ordered_blocks else None,
                 )
                 await broadcaster.broadcast(session_id, {
                     "type": "stopped", "session_id": session_id,
@@ -2195,286 +2498,420 @@ class AgentEngine:
             # Memorize before discarding client
             await self._memorize_session(session_id)
             # Clear resume — CLI state may be corrupted after error
+            self._stop_idle_watcher(session_id)
             unregister_handler(session_id)
             client = self.sessions.remove_client(session_id)
             await self.sessions.mark_error(session_id, error_msg)
             if client:
                 await self._safe_disconnect(client)
-            full_response_text = error_msg
+            st.full_response_text = error_msg
 
-        # Merge tool results into tool_calls_log
-        self._merge_tool_results(tool_calls_log, tool_results_map)
+        # Persist the turn (assistant message + usage) and broadcast done.
+        # Background-task continuation is handled by the CLI itself: when a
+        # run_in_background task settles, the CLI runs an autonomous turn
+        # which the idle stream watcher drains to the UI — no Nerve-side
+        # output-file polling needed (the old regex watcher lived here).
+        await self._finalize_turn(session_id, st, channel)
 
-        # Detect background tasks for auto-resume after turn ends.
-        # When Bash/Task runs with run_in_background, the result is only
-        # picked up on the NEXT engine.run() call.  We spawn a watcher that
-        # polls the output file and auto-triggers a new run when it's ready.
-        # NOTE: must run AFTER _merge_tool_results so tc["result"] is populated.
-        bg_tasks: list[dict] = []  # {output_file, tool, description, command, task_id}
-        for tc in tool_calls_log:
-            inp = tc.get("input") or {}
-            if not inp.get("run_in_background"):
-                continue
-            result_text = tc.get("result", "")
-            # Extract output file from result text
-            m = re.search(r"output_file:\s*(\S+)|Output is being written to:\s*(\S+)", result_text)
-            if not m:
-                logger.warning("Background task detected but no output file: %.200s", result_text)
-                continue
-            output_file = m.group(1) or m.group(2)
-            # Extract task ID
-            m_id = re.search(r"(?:ID|agentId):\s*(\S+)", result_text)
-            task_id = m_id.group(1).rstrip(".") if m_id else os.path.basename(output_file).replace(".output", "")
-            tool_name = tc.get("tool", "Bash")
-            description = inp.get("description", "")
-            command = inp.get("command", "")
-            # Truncate long commands for display
-            label = description or (command[:60] + "..." if len(command) > 60 else command) or tool_name
-            bg_tasks.append({
-                "output_file": output_file,
-                "task_id": task_id,
-                "tool": tool_name,
-                "label": label,
-            })
-            logger.info("Tracking background task %s: %s", task_id, label)
+        return st.full_response_text
 
-        # Store assistant message in DB
-        await self.sessions.add_message(
-            session_id, "assistant", full_response_text,
-            channel=channel,
-            thinking=thinking_text if thinking_text else None,
-            blocks=ordered_blocks if ordered_blocks else None,
-        )
+    # ------------------------------------------------------------------ #
+    #  Autonomous turns — CLI activity between run() calls                 #
+    # ------------------------------------------------------------------ #
+    #
+    # The CLI continues sessions on its own: when a background task
+    # (Bash/Agent run_in_background, Monitor watch) settles, it emits
+    # task_notification system messages and then runs a FULL agent turn
+    # (model call + tool use + result) inside the subprocess.  Nothing
+    # reads the SDK stream between run() calls, so historically those
+    # turns piled up invisibly in the SDK's in-memory buffer (capacity
+    # 100 — beyond that the SDK reader stalls and the control protocol
+    # wedges with it) and the buffered ResultMessage then terminated the
+    # NEXT receive_response() immediately, answering the next user
+    # message with the previous turn's output (off-by-one desync).
+    #
+    # The idle stream watcher fixes both: it probes the buffer between
+    # runs and drains autonomous turns through the same processing
+    # pipeline as user turns — streamed live to the UI, persisted to the
+    # DB, usage recorded.
 
-        # Persist SDK session ID and update status
-        if sdk_session_id:
-            await self.sessions.mark_active(
-                session_id,
-                sdk_session_id=sdk_session_id,
-                connected_at=await self.get_client_connected_at_async(session_id),
-            )
+    # How often the idle watcher probes the SDK buffer (seconds).
+    _IDLE_STREAM_POLL_SECONDS = 0.5
 
-        # Persist usage for context bar on session switch
-        max_context = 1_048_576 if self.config.agent.context_1m else 200_000
-        num_turns = (result_meta or {}).get("num_turns") or 1
-        if last_usage:
-            usage_data = {
-                **last_usage,
-                "max_context_tokens": max_context,
-                "num_turns": num_turns,
-            }
-            session_record = await self.db.get_session(session_id)
-            meta = json.loads(session_record.get("metadata") or "{}") if session_record else {}
-            meta["last_usage"] = usage_data
+    @staticmethod
+    def _sdk_message_stream(client: Any) -> Any | None:
+        """Return the SDK client's internal message receive stream.
 
-            # Extract server_tool_use counts
-            server_tool = last_usage.get("server_tool_use") or {}
-            web_search = server_tool.get("web_search_requests", 0)
-            web_fetch = server_tool.get("web_fetch_requests", 0)
+        Private-API access (``client._query._message_receive``), pinned to
+        the bundled SDK version. Callers degrade gracefully (drain and
+        watcher become no-ops) when the attribute shape changes.
+        """
+        return getattr(getattr(client, "_query", None), "_message_receive", None)
 
-            # Calculate per-turn cost.
-            # NOTE: The SDK's total_cost_usd is *cumulative* across the
-            # entire SDK session, NOT per-invocation.  We track the last
-            # known cumulative value in session metadata so we can compute
-            # the delta for this turn.
-            from nerve.db.usage import estimate_turn_cost, extract_cache_ttl_split
-            sdk_cost = (result_meta or {}).get("total_cost_usd")
-            current_session_cost = (
-                session_record.get("total_cost_usd", 0) if session_record else 0
-            ) or 0
+    @classmethod
+    def _sdk_buffer_used(cls, client: Any) -> int:
+        """Number of unread messages in the SDK client's buffer (0 on error)."""
+        stream = cls._sdk_message_stream(client)
+        if stream is None:
+            return 0
+        try:
+            return int(stream.statistics().current_buffer_used)
+        except Exception:
+            return 0
 
-            if sdk_cost is not None:
-                prev_cumulative = meta.get("_sdk_cumulative_cost", 0) or 0
-                turn_cost = max(sdk_cost - prev_cumulative, 0)
-                meta["_sdk_cumulative_cost"] = sdk_cost
-            else:
-                turn_cost = estimate_turn_cost(last_usage, model=last_model)
-
-            # Save metadata (includes _sdk_cumulative_cost update)
-            await self.db.update_session_metadata(session_id, meta)
-
-            # The Anthropic API splits cache_creation by TTL:
-            #   usage.cache_creation.ephemeral_5m_input_tokens  (1.25x base)
-            #   usage.cache_creation.ephemeral_1h_input_tokens  (2.00x base)
-            # Older API responses omit the split; the aggregate still
-            # lives in cache_creation_input_tokens.
-            cache_5m, cache_1h = extract_cache_ttl_split(last_usage)
-
-            # Persist per-turn usage to session_usage table
-            await self.db.record_turn_usage(
-                session_id=session_id,
-                input_tokens=last_usage.get("input_tokens", 0),
-                output_tokens=last_usage.get("output_tokens", 0),
-                cache_creation=last_usage.get("cache_creation_input_tokens", 0),
-                cache_read=last_usage.get("cache_read_input_tokens", 0),
-                cache_creation_5m=cache_5m,
-                cache_creation_1h=cache_1h,
-                max_context=max_context,
-                model=last_model,
-                cost_usd=turn_cost,
-                duration_ms=(result_meta or {}).get("duration_ms"),
-                duration_api_ms=(result_meta or {}).get("duration_api_ms"),
-                num_turns=num_turns,
-                web_search_requests=web_search,
-                web_fetch_requests=web_fetch,
-            )
-
-            # Update total_cost_usd on the session
-            await self.db.update_session_fields(session_id, {
-                "total_cost_usd": current_session_cost + turn_cost,
-            })
-
-        await broadcaster.broadcast_done(
-            session_id,
-            usage=last_usage,
-            max_context_tokens=max_context,
-            num_turns=num_turns,
-        )
-        self.sessions.touch(session_id)
-
-        # Spawn background task watcher if needed
-        if bg_tasks:
-            # Notify UI about running background tasks
-            await broadcaster.broadcast(session_id, {
-                "type": "background_tasks_update",
-                "session_id": session_id,
-                "tasks": [
-                    {"task_id": t["task_id"], "label": t["label"], "tool": t["tool"], "status": "running"}
-                    for t in bg_tasks
-                ],
-            })
-            asyncio.create_task(
-                self._watch_background_tasks(
-                    session_id, bg_tasks, source, channel,
-                )
-            )
-
-        return full_response_text
-
-    async def _watch_background_tasks(
+    async def _drain_pending_messages(
         self,
         session_id: str,
-        bg_tasks: list[dict],
+        client: Any,
+        source: str,
+        channel: str | None,
+        manage_framing: bool = False,
+        first_content_timeout: float = 30.0,
+    ) -> int:
+        """Drain SDK messages that arrived outside an active ``run()``.
+
+        Autonomous CLI turns are routed through the same pipeline as user
+        turns: blocks broadcast live, assistant message persisted with a
+        leading ``{"type": "auto"}`` marker, usage recorded, ``done``
+        emitted.  Standalone task lifecycle events update the background-
+        task chips without opening a turn.
+
+        Never parks while no turn is open (only consumes what's already
+        buffered), so the pre-query call inside ``run()`` cannot hang on
+        an idle CLI.  The CLI emits a ``system/init`` message when it
+        starts processing a turn, so an ``init`` in the buffer means
+        content IS coming (the model call is in flight) — the drain opens
+        the turn and waits up to ``first_content_timeout`` for the first
+        content message (model latency can be several seconds).  If
+        nothing arrives the empty turn is dropped without persisting and
+        the watcher's next poll picks the content up instead.  Once
+        content flows, the wait uses the same idle timeout as a normal
+        run; on that timeout the partial turn is persisted and
+        ``asyncio.TimeoutError`` propagates so the caller can apply
+        hung-CLI treatment.
+
+        Caller must hold the per-session run lock.  ``manage_framing``
+        controls session-level run framing (mark_running/session_running/
+        buffering): the idle watcher passes True; ``run()`` passes False
+        because its own framing is already open.
+
+        Returns the number of completed autonomous turns processed.
+        """
+        stream = self._sdk_message_stream(client)
+        if stream is None:
+            return 0
+
+        from claude_agent_sdk._errors import MessageParseError
+        from claude_agent_sdk._internal.message_parser import parse_message
+
+        idle_timeout = self.config.agent.cli_idle_timeout_seconds
+        turns = 0
+        st: _TurnState | None = None
+        session_framing = False
+
+        async def _open_turn() -> None:
+            nonlocal st, session_framing
+            if st is not None:
+                return
+            st = _TurnState()
+            # Leading marker block → "background continuation" chip in the
+            # UI, both live (auto_turn event) and after reload (persisted).
+            st.ordered_blocks.append({"type": "auto"})
+            if manage_framing and not session_framing:
+                session_framing = True
+                if not broadcaster.is_buffering(session_id):
+                    broadcaster.start_buffering(session_id)
+                self.sessions.mark_running(session_id)
+                await broadcaster.broadcast("__global__", {
+                    "type": "session_running",
+                    "session_id": session_id,
+                    "is_running": True,
+                })
+            broadcaster.mark_turn_open(session_id)
+            await broadcaster.broadcast(session_id, {
+                "type": "auto_turn", "session_id": session_id,
+            })
+
+        def _turn_has_content() -> bool:
+            return st is not None and (
+                st.got_content
+                or bool(st.full_response_text)
+                or len(st.ordered_blocks) > 1  # beyond the auto marker
+                or st.last_usage is not None
+            )
+
+        async def _close_turn() -> None:
+            nonlocal st, turns
+            if st is None:
+                return
+            if _turn_has_content():
+                await self._finalize_turn(session_id, st, channel)
+                turns += 1
+            # Empty turn (init arrived but content never did) — drop it;
+            # the finally backstop ships a synthetic done if framing opened.
+            st = None
+
+        try:
+            while True:
+                if st is None:
+                    # No turn open — only consume what's already buffered.
+                    try:
+                        data = stream.receive_nowait()
+                    except anyio.WouldBlock:
+                        break
+                    except (anyio.EndOfStream, anyio.ClosedResourceError):
+                        break
+                else:
+                    # Turn in flight — the CLI is producing; park for the
+                    # next message.  Before the first content message the
+                    # wait is capped by first_content_timeout (init arrives
+                    # seconds before the model's first output); after that
+                    # it matches a normal run's idle timeout.  NOTE: a
+                    # timeout cancels the parked receive, which can in
+                    # theory drop one in-flight message — acceptable on
+                    # both timeout paths (empty turn → watcher re-drains;
+                    # hung CLI → client discarded).
+                    waiting_first_content = not st.got_content
+                    if waiting_first_content:
+                        park_timeout: float | None = first_content_timeout
+                    else:
+                        park_timeout = (
+                            idle_timeout
+                            if idle_timeout and idle_timeout > 0
+                            else None
+                        )
+                    try:
+                        data = await asyncio.wait_for(
+                            stream.receive(), timeout=park_timeout,
+                        )
+                    except asyncio.TimeoutError:
+                        if waiting_first_content:
+                            logger.info(
+                                "Autonomous turn for session %s produced no "
+                                "content within %.0fs — deferring to the "
+                                "next drain",
+                                session_id, first_content_timeout,
+                            )
+                            await _close_turn()  # empty — dropped
+                            break
+                        logger.warning(
+                            "Autonomous turn idle timeout (%ss) for session %s "
+                            "— persisting partial turn and flagging CLI as hung",
+                            idle_timeout, session_id,
+                        )
+                        st.full_response_text += (
+                            "\n\n[Background turn interrupted: CLI went silent]"
+                            if st.full_response_text
+                            else "[Background turn interrupted: CLI went silent]"
+                        )
+                        await _close_turn()
+                        raise
+                    except (anyio.EndOfStream, anyio.ClosedResourceError):
+                        logger.warning(
+                            "SDK stream ended mid-autonomous-turn for session %s",
+                            session_id,
+                        )
+                        await _close_turn()
+                        break
+
+                mtype = data.get("type") if isinstance(data, dict) else None
+                if mtype == "end":
+                    # Reader sentinel — stream is closed.
+                    await _close_turn()
+                    break
+                if mtype == "error":
+                    logger.error(
+                        "SDK stream error during autonomous drain for %s: %s",
+                        session_id, data.get("error"),
+                    )
+                    await _close_turn()
+                    break
+
+                try:
+                    message = parse_message(data)
+                except MessageParseError as pe:
+                    logger.warning(
+                        "Unparseable SDK message during drain for %s: %s",
+                        session_id, pe,
+                    )
+                    continue
+                if message is None:
+                    continue
+
+                if isinstance(message, SystemMessage) and st is None:
+                    if getattr(message, "subtype", "") == "init":
+                        # The CLI emits ``init`` when it starts processing
+                        # a turn — an autonomous continuation is underway;
+                        # open the turn and park for its content.
+                        await _open_turn()
+                    else:
+                        # Task lifecycle events between turns — chips only.
+                        await self._handle_system_message(session_id, message)
+                    continue
+
+                if isinstance(message, (AssistantMessage, UserMessage)):
+                    await _open_turn()
+                elif isinstance(message, ResultMessage) and st is None:
+                    # Stray result with no preceding content (e.g. a prior
+                    # drain timed out mid-turn).  Consume it so it can't
+                    # desync the next receive_response(); nothing to render.
+                    logger.info(
+                        "Consumed stray ResultMessage during drain for %s",
+                        session_id,
+                    )
+                    continue
+
+                if st is not None:
+                    turn_done = await self._process_sdk_message(
+                        session_id, message, st,
+                    )
+                    if turn_done:
+                        await _close_turn()
+
+        except asyncio.CancelledError:
+            # /stop (or teardown) cancelled the drain mid-turn — persist
+            # what we have so the partial turn isn't lost.
+            if st is not None and _turn_has_content():
+                st.full_response_text += (
+                    "\n\n[Stopped by user]"
+                    if st.full_response_text
+                    else "[Stopped by user]"
+                )
+                with contextlib.suppress(Exception):
+                    self._merge_tool_results(st.tool_calls_log, st.tool_results_map)
+                    await self.sessions.add_message(
+                        session_id, "assistant", st.full_response_text,
+                        channel=channel,
+                        thinking=st.thinking_text or None,
+                        blocks=st.ordered_blocks or None,
+                    )
+                    await broadcaster.broadcast(session_id, {
+                        "type": "stopped", "session_id": session_id,
+                    })
+            raise
+        finally:
+            if manage_framing and session_framing:
+                self.sessions.mark_not_running(session_id)
+                # Backstop: ship a synthetic done if no terminal event was
+                # broadcast (mirrors run()'s finally).
+                if broadcaster.is_turn_open(session_id):
+                    with contextlib.suppress(Exception):
+                        await broadcaster.broadcast_done(session_id)
+                    broadcaster.clear_turn_open(session_id)
+                broadcaster.stop_buffering(session_id)
+                with contextlib.suppress(Exception):
+                    await broadcaster.broadcast("__global__", {
+                        "type": "session_running",
+                        "session_id": session_id,
+                        "is_running": False,
+                    })
+
+        return turns
+
+    def _start_idle_watcher(
+        self, session_id: str, client: Any, source: str,
+    ) -> None:
+        """Spawn the idle stream watcher for a freshly connected client."""
+        self._stop_idle_watcher(session_id)
+        channel = self._active_channel.get(session_id)
+        self._idle_watchers[session_id] = asyncio.create_task(
+            self._idle_stream_watcher(session_id, client, source, channel),
+            name=f"idle-watcher:{session_id}",
+        )
+
+    def _stop_idle_watcher(self, session_id: str) -> None:
+        """Cancel a session's idle watcher (no-op from within the watcher)."""
+        task = self._idle_watchers.pop(session_id, None)
+        if task is None or task.done():
+            return
+        # The watcher may itself trigger client teardown (_discard_client);
+        # never cancel the current task from within itself.
+        if task is asyncio.current_task():
+            return
+        task.cancel()
+
+    async def _idle_stream_watcher(
+        self,
+        session_id: str,
+        client: Any,
         source: str,
         channel: str | None,
     ) -> None:
-        """Poll background task output files and auto-trigger engine.run().
+        """Drain autonomous CLI turns to the UI while no run() is active.
 
-        When tools run with run_in_background, the SDK subprocess exits after
-        the main turn.  The background process writes to an output file.
-        This watcher polls until the file is ready, then triggers a new
-        engine.run() so the model processes the result immediately instead
-        of waiting for the next user message.
+        Probes the SDK message buffer (non-destructively, via stream
+        statistics) every ``_IDLE_STREAM_POLL_SECONDS``.  When messages
+        appear and no run is active, takes the per-session run lock and
+        drains them as autonomous turns.  Exits when the client is
+        replaced, discarded, or its subprocess dies.
         """
-        poll_interval = 2  # seconds
-        max_wait = 600  # 10 minutes max
-        completed_ids: set[str] = set()
-
         try:
-            elapsed = 0
-            while elapsed < max_wait:
-                await asyncio.sleep(poll_interval)
-                elapsed += poll_interval
+            while True:
+                await asyncio.sleep(self._IDLE_STREAM_POLL_SECONDS)
 
-                all_done = True
-                newly_completed = False
-                for task in bg_tasks:
-                    if task["task_id"] in completed_ids:
-                        continue
-                    path = task["output_file"]
-                    if not os.path.exists(path):
-                        all_done = False
-                        continue
+                if self.sessions.get_client(session_id) is not client:
+                    return  # replaced/discarded — new client gets a new watcher
+                if self.sessions.is_running(session_id):
+                    continue  # run() owns the stream right now
+                if self._sdk_buffer_used(client) <= 0:
+                    if self._is_client_dead(client):
+                        return
+                    continue
+
+                lock = self._session_locks.setdefault(session_id, asyncio.Lock())
+                if lock.locked():
+                    continue  # a run is starting; its pre-query drain covers this
+
+                async with lock:
+                    if self.sessions.get_client(session_id) is not client:
+                        return
+
+                    drain = asyncio.create_task(
+                        self._drain_pending_messages(
+                            session_id, client, source, channel,
+                            manage_framing=True,
+                        ),
+                        name=f"auto-drain:{session_id}",
+                    )
+                    # Register so /stop reaches the drain: interrupt ends the
+                    # CLI turn gracefully (drain finalizes on ResultMessage);
+                    # the hard-cancel fallback cancels the drain task.
+                    self.sessions.register_task(session_id, drain)
                     try:
-                        size = os.path.getsize(path)
-                        if size == 0:
-                            all_done = False
-                            continue
-                        # Check if file is still being written (modified in last 2s)
-                        mtime = os.path.getmtime(path)
-                        if (time.time() - mtime) < 2:
-                            all_done = False
-                            continue
-                        # This task is done
-                        completed_ids.add(task["task_id"])
-                        newly_completed = True
-                    except OSError:
-                        all_done = False
-                        continue
+                        await drain
+                    except asyncio.TimeoutError:
+                        # Hung CLI mid-autonomous-turn — same treatment as a
+                        # hung run(): kill the client, next message recreates.
+                        logger.warning(
+                            "Discarding hung client for session %s "
+                            "(autonomous turn stalled)", session_id,
+                        )
+                        await self._discard_client(session_id)
+                        return
+                    except asyncio.CancelledError:
+                        current = asyncio.current_task()
+                        being_cancelled = bool(
+                            current and current.cancelling()
+                        )
+                        if drain.cancelled() and not being_cancelled:
+                            # /stop hard-cancelled the drain. Mid-turn CLI
+                            # state is inconsistent — discard, mirroring
+                            # run()'s cancel path.
+                            await self.sessions.mark_stopped(session_id)
+                            await self._discard_client(session_id)
+                            return
+                        if not drain.done():
+                            drain.cancel()
+                            with contextlib.suppress(BaseException):
+                                await drain
+                        raise
 
-                # Broadcast progress to UI on any change
-                if newly_completed:
-                    await broadcaster.broadcast(session_id, {
-                        "type": "background_tasks_update",
-                        "session_id": session_id,
-                        "tasks": [
-                            {
-                                "task_id": t["task_id"],
-                                "label": t["label"],
-                                "tool": t["tool"],
-                                "status": "done" if t["task_id"] in completed_ids else "running",
-                            }
-                            for t in bg_tasks
-                        ],
-                    })
-
-                if all_done:
-                    break
-
-            if elapsed >= max_wait:
-                logger.warning(
-                    "Background task watcher timed out for session %s",
-                    session_id,
-                )
-                # Broadcast timeout status
-                await broadcaster.broadcast(session_id, {
-                    "type": "background_tasks_update",
-                    "session_id": session_id,
-                    "tasks": [
-                        {
-                            "task_id": t["task_id"],
-                            "label": t["label"],
-                            "tool": t["tool"],
-                            "status": "done" if t["task_id"] in completed_ids else "timeout",
-                        }
-                        for t in bg_tasks
-                    ],
-                })
-                return
-
-            # All background tasks done — auto-resume the session
-            logger.info(
-                "Background tasks completed for session %s, auto-resuming",
-                session_id,
-            )
-
-            if self.sessions.is_running(session_id):
-                logger.info(
-                    "Session %s already running, skipping auto-resume",
-                    session_id,
-                )
-                return
-
-            # Trigger a new engine.run() so the model picks up the
-            # background task notifications from the SDK
-            task = asyncio.create_task(
-                self.run(
-                    session_id=session_id,
-                    user_message=(
-                        "[Background tasks completed. "
-                        "Check the results with TaskOutput and report to the user.]"
-                    ),
-                    source=source,
-                    channel=channel,
-                    internal=True,
-                )
-            )
-            self.register_task(session_id, task)
-
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.error(
-                "Background task watcher failed for session %s: %s",
-                session_id, e,
+                "Idle stream watcher for session %s crashed: %s",
+                session_id, e, exc_info=True,
             )
 
     # ------------------------------------------------------------------ #

--- a/tests/test_autonomous_turns.py
+++ b/tests/test_autonomous_turns.py
@@ -1,0 +1,489 @@
+"""Tests for autonomous-turn draining — nerve.agent.engine.
+
+The CLI continues sessions on its own (background task settles →
+task_notification → full agent turn inside the subprocess).  These tests
+cover the engine pieces that surface that activity:
+
+- ``_handle_system_message`` — task lifecycle → background-task chips
+- ``_drain_pending_messages`` — buffered autonomous turns → UI + DB
+- ``_sdk_buffer_used`` — non-destructive buffer probe
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import anyio
+import pytest
+
+from claude_agent_sdk import ResultMessage, SystemMessage
+
+from nerve.agent.engine import AgentEngine, _TurnState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engine() -> AgentEngine:
+    """Minimal AgentEngine stub for drain/system-message tests."""
+    engine = AgentEngine.__new__(AgentEngine)
+    engine.config = SimpleNamespace(
+        workspace="/tmp",
+        agent=SimpleNamespace(
+            cli_idle_timeout_seconds=2,
+            context_1m=False,
+        ),
+    )
+    engine._bg_task_registry = {}
+    engine._idle_watchers = {}
+    engine._session_locks = {}
+    return engine
+
+
+class _FakeStream:
+    """Stand-in for the SDK's MemoryObjectReceiveStream."""
+
+    def __init__(self, items: list[dict]):
+        self._send, self._recv = anyio.create_memory_object_stream(
+            max_buffer_size=100,
+        )
+        for item in items:
+            self._send.send_nowait(item)
+
+    def receive_nowait(self):
+        return self._recv.receive_nowait()
+
+    async def receive(self):
+        return await self._recv.receive()
+
+    def statistics(self):
+        return self._recv.statistics()
+
+    def push(self, item: dict) -> None:
+        self._send.send_nowait(item)
+
+
+def _fake_client(stream: _FakeStream):
+    return SimpleNamespace(_query=SimpleNamespace(_message_receive=stream))
+
+
+def _sys_msg(subtype: str, **data) -> dict:
+    return {"type": "system", "subtype": subtype, "session_id": "sdk-1",
+            "uuid": "u-1", **data}
+
+
+def _assistant_text(text: str) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "model": "claude-test",
+            "content": [{"type": "text", "text": text}],
+        },
+        "session_id": "sdk-1",
+    }
+
+
+def _result_msg() -> dict:
+    return {
+        "type": "result",
+        "subtype": "success",
+        "duration_ms": 10,
+        "duration_api_ms": 8,
+        "is_error": False,
+        "num_turns": 1,
+        "session_id": "sdk-1",
+        "total_cost_usd": 0.01,
+        "usage": {"input_tokens": 5, "output_tokens": 7},
+    }
+
+
+# ---------------------------------------------------------------------------
+# _sdk_buffer_used
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_buffer_used_counts_pending():
+    stream = _FakeStream([_sys_msg("task_updated", task_id="t1", patch={})])
+    client = _fake_client(stream)
+    assert AgentEngine._sdk_buffer_used(client) == 1
+    stream.receive_nowait()
+    assert AgentEngine._sdk_buffer_used(client) == 0
+
+
+def test_sdk_buffer_used_handles_missing_internals():
+    assert AgentEngine._sdk_buffer_used(SimpleNamespace()) == 0
+    assert AgentEngine._sdk_buffer_used(SimpleNamespace(_query=None)) == 0
+
+
+# ---------------------------------------------------------------------------
+# _handle_system_message → background-task chips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_lifecycle_updates_registry_and_broadcasts():
+    engine = _make_engine()
+
+    events = []
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock(
+            side_effect=lambda sid, msg: events.append(msg),
+        )
+
+        started = SystemMessage(
+            subtype="task_started",
+            data=_sys_msg(
+                "task_started", task_id="t1",
+                description="run tests", task_type="local_bash",
+            ),
+        )
+        await engine._handle_system_message("s1", started)
+
+        reg = engine._bg_task_registry["s1"]
+        assert reg["t1"]["status"] == "running"
+        assert reg["t1"]["label"] == "run tests"
+        assert reg["t1"]["tool"] == "Bash"
+
+        notified = SystemMessage(
+            subtype="task_notification",
+            data=_sys_msg(
+                "task_notification", task_id="t1", status="completed",
+            ),
+        )
+        await engine._handle_system_message("s1", notified)
+        assert reg["t1"]["status"] == "done"
+
+    assert len(events) == 2
+    assert all(e["type"] == "background_tasks_update" for e in events)
+    assert events[-1]["tasks"][0]["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_task_failed_maps_to_failed_status():
+    engine = _make_engine()
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        msg = SystemMessage(
+            subtype="task_notification",
+            data=_sys_msg("task_notification", task_id="t9", status="failed"),
+        )
+        await engine._handle_system_message("s1", msg)
+    assert engine._bg_task_registry["s1"]["t9"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_agent_task_type_uses_agent_tool():
+    engine = _make_engine()
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        msg = SystemMessage(
+            subtype="task_started",
+            data=_sys_msg(
+                "task_started", task_id="t2",
+                description="explore repo", task_type="local_agent",
+            ),
+        )
+        await engine._handle_system_message("s1", msg)
+    assert engine._bg_task_registry["s1"]["t2"]["tool"] == "Agent"
+
+
+@pytest.mark.asyncio
+async def test_non_task_subtypes_ignored():
+    engine = _make_engine()
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await engine._handle_system_message(
+            "s1", SystemMessage(subtype="init", data={"type": "system"}),
+        )
+        bc.broadcast.assert_not_called()
+    assert "s1" not in engine._bg_task_registry
+
+
+def test_prune_bg_tasks_drops_settled():
+    engine = _make_engine()
+    engine._bg_task_registry["s1"] = {
+        "t1": {"task_id": "t1", "label": "a", "tool": "Bash", "status": "done"},
+        "t2": {"task_id": "t2", "label": "b", "tool": "Bash", "status": "running"},
+    }
+    engine._prune_bg_tasks("s1")
+    assert list(engine._bg_task_registry["s1"]) == ["t2"]
+
+    engine._bg_task_registry["s2"] = {
+        "t3": {"task_id": "t3", "label": "c", "tool": "Bash", "status": "failed"},
+    }
+    engine._prune_bg_tasks("s2")
+    assert "s2" not in engine._bg_task_registry
+
+
+# ---------------------------------------------------------------------------
+# _drain_pending_messages
+# ---------------------------------------------------------------------------
+
+
+def _patch_finalize(engine: AgentEngine):
+    """Replace _finalize_turn with a recorder (avoids DB plumbing)."""
+    finalized: list[_TurnState] = []
+
+    async def _record(session_id, st, channel):
+        finalized.append(st)
+
+    engine._finalize_turn = _record  # type: ignore[method-assign]
+    return finalized
+
+
+@pytest.mark.asyncio
+async def test_drain_empty_buffer_returns_immediately():
+    engine = _make_engine()
+    stream = _FakeStream([])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        turns = await engine._drain_pending_messages("s1", client, "web", None)
+
+    assert turns == 0
+    assert finalized == []
+
+
+@pytest.mark.asyncio
+async def test_drain_processes_full_autonomous_turn():
+    """task events + init + assistant + result → one finalized turn."""
+    engine = _make_engine()
+    stream = _FakeStream([
+        _sys_msg("task_updated", task_id="t1",
+                 patch={"status": "completed"}),
+        _sys_msg("task_notification", task_id="t1", status="completed",
+                 output_file="/tmp/x", summary="done"),
+        _sys_msg("init", cwd="/tmp"),
+        _assistant_text("Background job finished."),
+        _result_msg(),
+    ])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    events = []
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock(side_effect=lambda sid, m: events.append(m))
+        bc.broadcast_token = AsyncMock()
+        bc.is_buffering = lambda sid: False
+        bc.start_buffering = lambda sid: None
+        bc.stop_buffering = lambda sid: []
+        bc.mark_turn_open = lambda sid: None
+        bc.is_turn_open = lambda sid: False
+        engine.sessions = SimpleNamespace(
+            mark_running=lambda sid: None,
+            mark_not_running=lambda sid: None,
+        )
+        turns = await engine._drain_pending_messages(
+            "s1", client, "web", None, manage_framing=True,
+        )
+
+    assert turns == 1
+    assert len(finalized) == 1
+    st = finalized[0]
+    assert st.full_response_text == "Background job finished."
+    # Leading marker block for the "background continuation" chip
+    assert st.ordered_blocks[0] == {"type": "auto"}
+    # Chips updated + auto_turn marker + session_running framing
+    types = [e.get("type") for e in events]
+    assert "background_tasks_update" in types
+    assert "auto_turn" in types
+    assert {"type": "session_running", "session_id": "s1",
+            "is_running": True} in events
+    assert {"type": "session_running", "session_id": "s1",
+            "is_running": False} in events
+    # Buffer fully consumed — nothing left to desync the next turn
+    assert AgentEngine._sdk_buffer_used(client) == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_standalone_task_events_do_not_open_turn():
+    """Task events with no following turn: chips update, no turn framing."""
+    engine = _make_engine()
+    stream = _FakeStream([
+        _sys_msg("task_started", task_id="t1", description="bg job",
+                 task_type="local_bash"),
+    ])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    events = []
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock(side_effect=lambda sid, m: events.append(m))
+        turns = await engine._drain_pending_messages(
+            "s1", client, "web", None, manage_framing=True,
+        )
+
+    assert turns == 0
+    assert finalized == []
+    types = [e.get("type") for e in events]
+    assert types == ["background_tasks_update"]  # no session_running/auto_turn
+
+
+@pytest.mark.asyncio
+async def test_drain_consumes_stray_result_without_turn():
+    """A buffered ResultMessage with no content is consumed, not rendered."""
+    engine = _make_engine()
+    stream = _FakeStream([_result_msg()])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        turns = await engine._drain_pending_messages("s1", client, "web", None)
+
+    assert turns == 0
+    assert finalized == []
+    assert AgentEngine._sdk_buffer_used(client) == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_parks_mid_turn_until_result():
+    """Mid-turn drain waits for late messages instead of exiting early."""
+    engine = _make_engine()
+    stream = _FakeStream([_assistant_text("working...")])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    async def _push_later():
+        await asyncio.sleep(0.1)
+        stream.push(_result_msg())
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        bc.broadcast_token = AsyncMock()
+        pusher = asyncio.create_task(_push_later())
+        turns = await engine._drain_pending_messages("s1", client, "web", None)
+        await pusher
+
+    assert turns == 1
+    assert finalized[0].full_response_text == "working..."
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_persists_partial_and_raises():
+    """Hung CLI mid-turn: partial turn persisted, TimeoutError propagates."""
+    engine = _make_engine()
+    engine.config.agent.cli_idle_timeout_seconds = 0.1
+    stream = _FakeStream([_assistant_text("partial output")])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        bc.broadcast_token = AsyncMock()
+        with pytest.raises(asyncio.TimeoutError):
+            await engine._drain_pending_messages("s1", client, "web", None)
+
+    assert len(finalized) == 1
+    assert "partial output" in finalized[0].full_response_text
+    assert "interrupted" in finalized[0].full_response_text
+
+
+@pytest.mark.asyncio
+async def test_drain_parks_on_init_until_content_arrives():
+    """``init`` means a turn is in flight — drain waits for its content
+    (model latency) and completes the whole turn in one call."""
+    engine = _make_engine()
+    stream = _FakeStream([_sys_msg("init", cwd="/tmp")])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    async def _push_later():
+        await asyncio.sleep(0.1)
+        stream.push(_assistant_text("late content"))
+        stream.push(_result_msg())
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        bc.broadcast_token = AsyncMock()
+        pusher = asyncio.create_task(_push_later())
+        turns = await engine._drain_pending_messages(
+            "s1", client, "web", None, first_content_timeout=5.0,
+        )
+        await pusher
+
+    assert turns == 1
+    assert finalized[0].full_response_text == "late content"
+
+
+@pytest.mark.asyncio
+async def test_drain_drops_empty_turn_on_first_content_timeout():
+    """``init`` with no content within first_content_timeout: the empty
+    turn is dropped (no persist, no exception) — the watcher's next poll
+    picks the content up instead."""
+    engine = _make_engine()
+    stream = _FakeStream([_sys_msg("init", cwd="/tmp")])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        turns = await engine._drain_pending_messages(
+            "s1", client, "web", None, first_content_timeout=0.05,
+        )
+
+    assert turns == 0
+    assert finalized == []
+
+
+@pytest.mark.asyncio
+async def test_drain_handles_end_sentinel():
+    """Reader 'end' sentinel closes the drain cleanly."""
+    engine = _make_engine()
+    stream = _FakeStream([{"type": "end"}])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        turns = await engine._drain_pending_messages("s1", client, "web", None)
+
+    assert turns == 0
+    assert finalized == []
+
+
+@pytest.mark.asyncio
+async def test_drain_multiple_turns_in_one_call():
+    """Two buffered autonomous turns finalize as two assistant messages."""
+    engine = _make_engine()
+    stream = _FakeStream([
+        _assistant_text("turn one"),
+        _result_msg(),
+        _assistant_text("turn two"),
+        _result_msg(),
+    ])
+    client = _fake_client(stream)
+    finalized = _patch_finalize(engine)
+
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        bc.broadcast_token = AsyncMock()
+        turns = await engine._drain_pending_messages("s1", client, "web", None)
+
+    assert turns == 2
+    assert [st.full_response_text for st in finalized] == ["turn one", "turn two"]
+
+
+# ---------------------------------------------------------------------------
+# _process_sdk_message — ResultMessage handling via shared path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_sdk_message_returns_true_on_result():
+    engine = _make_engine()
+    st = _TurnState()
+    result = ResultMessage(
+        subtype="success", duration_ms=1, duration_api_ms=1,
+        is_error=False, num_turns=1, session_id="sdk-9",
+        total_cost_usd=0.5, usage={"input_tokens": 1},
+    )
+    done = await engine._process_sdk_message("s1", result, st)
+    assert done is True
+    assert st.sdk_session_id == "sdk-9"
+    assert st.last_usage == {"input_tokens": 1}
+    assert st.result_meta["total_cost_usd"] == 0.5

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -24,9 +24,10 @@ export type WSMessage =
   | { type: 'answer_injected'; session_id: string; notification_id: string; title: string; answer: string; answered_by: string; content: string }
   | { type: 'session_running'; session_id: string; is_running: boolean }
   | { type: 'session_awaiting_input'; session_id: string; awaiting: boolean }
-  | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'timeout' }[] }
+  | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'failed' | 'timeout' }[] }
   | { type: 'hoa_progress'; session_id: string; event: Record<string, unknown> }
   | { type: 'wakeup'; session_id: string }
+  | { type: 'auto_turn'; session_id: string }
   | { type: 'pong' };
 
 type MessageHandler = (msg: WSMessage) => void;

--- a/web/src/components/Chat/BackgroundJobs.tsx
+++ b/web/src/components/Chat/BackgroundJobs.tsx
@@ -20,6 +20,7 @@ function toolIcon(tool: string) {
 const STATUS_COLORS = {
   running: 'text-hue-emerald',
   done: 'text-text-faint',
+  failed: 'text-hue-red',
   timeout: 'text-hue-amber',
 } as const;
 

--- a/web/src/components/Chat/BlockRenderer.tsx
+++ b/web/src/components/Chat/BlockRenderer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Download, FileText, Clock } from 'lucide-react';
+import { Download, FileText, Clock, RefreshCw } from 'lucide-react';
 import type { MessageBlock } from '../../types/chat';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolCallBlock } from './ToolCallBlock';
@@ -39,6 +39,17 @@ export function BlockRenderer({
                 <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border border-border bg-surface">
                   <Clock size={11} />
                   Scheduled wakeup
+                </span>
+                <span className="h-px flex-1 bg-border" />
+              </div>
+            );
+          case 'auto':
+            return (
+              <div key={i} className="flex items-center gap-1.5 my-1.5 text-xs text-text-muted">
+                <span className="h-px flex-1 bg-border" />
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full border border-border bg-surface">
+                  <RefreshCw size={11} />
+                  Background continuation
                 </span>
                 <span className="h-px flex-1 bg-border" />
               </div>

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -8,7 +8,7 @@ import { hydrateMessage } from '../utils/hydrateMessage';
 import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './helpers/blockHelpers';
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
 // Handlers
-import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError, handleWakeup } from './handlers/streamingHandlers';
+import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError, handleWakeup, handleAutoTurn } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected } from './handlers/sessionHandlers';
 import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress } from './handlers/panelHandlers';
 import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
@@ -103,7 +103,7 @@ interface ChatState {
   modifiedFilesCount: number;
 
   // Background tasks (run_in_background)
-  backgroundTasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'timeout'; startedAt: number }[];
+  backgroundTasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'failed' | 'timeout'; startedAt: number }[];
 
   // Session search
   searchQuery: string;
@@ -513,6 +513,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       case 'tool_result':  return handleToolResult(msg, get, set);
       case 'done':         return handleDone(msg, get, set);
       case 'wakeup':       return handleWakeup(msg, get, set);
+      case 'auto_turn':    return handleAutoTurn(msg, get, set);
       case 'stopped':      return handleStopped(msg, get, set);
       case 'error':        return handleError(msg, get, set);
       // Sessions

--- a/web/src/stores/handlers/streamingHandlers.ts
+++ b/web/src/stores/handlers/streamingHandlers.ts
@@ -91,6 +91,21 @@ export function handleWakeup(
   set({ streamingBlocks: blocks, isStreaming: true });
 }
 
+export function handleAutoTurn(
+  _msg: Extract<WSMessage, { type: 'auto_turn' }>,
+  get: Get,
+  set: Set,
+): void {
+  // The CLI started an autonomous turn (e.g. a background task settled
+  // and the agent is reporting the result) — prepend a marker so the
+  // turn renders with a "background continuation" chip.
+  const blocks = [...get().streamingBlocks];
+  if (!blocks.some((b) => b.type === 'auto')) {
+    blocks.unshift({ type: 'auto' });
+  }
+  set({ streamingBlocks: blocks, isStreaming: true, agentStatus: { state: 'thinking' } });
+}
+
 export function handleToolUse(
   msg: Extract<WSMessage, { type: 'tool_use' }>,
   get: Get,

--- a/web/src/stores/helpers/bufferReplay.ts
+++ b/web/src/stores/helpers/bufferReplay.ts
@@ -69,6 +69,18 @@ export function applyStreamEvent(blocks: MessageBlock[], event: WSMessage): Mess
       }
       break;
     }
+    case 'wakeup': {
+      if (!result.some((b) => b.type === 'wakeup')) {
+        result.unshift({ type: 'wakeup' });
+      }
+      break;
+    }
+    case 'auto_turn': {
+      if (!result.some((b) => b.type === 'auto')) {
+        result.unshift({ type: 'auto' });
+      }
+      break;
+    }
   }
   return result;
 }

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -39,7 +39,13 @@ export interface WakeupBlockData {
   type: 'wakeup';
 }
 
-export type MessageBlock = ThinkingBlockData | TextBlockData | ToolCallBlockData | ImageBlockData | FileBlockData | WakeupBlockData;
+/** Leading marker on an autonomous turn the CLI ran on its own (e.g. after
+ *  a background task settled) — no user message preceded it. */
+export interface AutoTurnBlockData {
+  type: 'auto';
+}
+
+export type MessageBlock = ThinkingBlockData | TextBlockData | ToolCallBlockData | ImageBlockData | FileBlockData | WakeupBlockData | AutoTurnBlockData;
 
 export interface ChatMessage {
   id?: number;

--- a/web/src/utils/hydrateMessage.ts
+++ b/web/src/utils/hydrateMessage.ts
@@ -50,6 +50,9 @@ export function hydrateMessage(raw: any): ChatMessage {
     if (b.type === 'wakeup') {
       return { type: 'wakeup' as const };
     }
+    if (b.type === 'auto') {
+      return { type: 'auto' as const };
+    }
     // Default: text
     return { type: 'text' as const, content: b.content || '' };
   });


### PR DESCRIPTION
## Problem

When the agent runs background work (Bash/Agent `run_in_background`, Monitor) and the turn ends, the CLI later **continues the session autonomously**: it emits `task_notification` events and runs a full agent turn (model call + output) inside the subprocess. Nerve only read the SDK stream during an active `run()`, so:

1. The autonomous turn buffered invisibly — **nothing appeared in the web UI** until the user sent a message (hence the "send dots to see progress" workaround).
2. The SDK buffer caps at 100 messages; beyond that the SDK reader stalls and the control protocol (hooks, can_use_tool) wedges with it.
3. Worse: the buffered `ResultMessage` terminated the **next** `receive_response()` immediately — the next user message got answered with the *previous* turn's output (permanent off-by-one desync).

Verified live: a `sleep 20`-in-background turn ends; 15s later the buffer receives `task_updated`, `task_notification`, `init`, `AssistantMessage`, `ResultMessage` — a complete invisible turn.

## Fix

- **Shared turn pipeline** — extract `_TurnState` + `_process_sdk_message` + `_finalize_turn` from `_run_inner`, so user turns and autonomous turns produce identical broadcasts and DB records.
- **Idle stream watcher** (per live client) — probes the SDK buffer between runs (non-destructive `statistics()` poll, 0.5s) and drains autonomous turns under the per-session run lock: `session_running` framing, live token/tool streaming, DB persistence, usage/cost accounting, `done`. The CLI emits `system/init` when a turn starts, so the drain parks for in-flight content (bounded by a first-content timeout; full `cli_idle_timeout` once content flows).
- **Pre-query drain in `run()`** — consumes any stale buffered turn before sending the query, eliminating the off-by-one desync (verified live: follow-up after an autonomous turn now gets its own response).
- **Real background-task chips** — driven by the CLI's `task_started` / `task_updated` / `task_notification` events (including failures), replacing the regex output-file watcher. The old watcher's `[Background tasks completed...]` re-injection is gone too — the CLI's own continuation covers it, so no more duplicate reporting.
- **"Background continuation" chip** — autonomous turns persist a leading `{"type": "auto"}` block and broadcast an `auto_turn` event, so it's clear why the assistant spoke unprompted (live, on reconnect replay, and after reload).

## Notes

- The drain accesses SDK internals (`client._query._message_receive`) behind defensive helpers; on SDK shape changes it degrades to the old behavior instead of crashing.
- Known narrow race: a user message landing while an autonomous turn is mid-flight can interleave into that turn's stream — content still renders, and the watcher self-heals attribution on the next poll.
- Telegram delivery of autonomous turns is a possible follow-up: they persist to history and stream to the web UI, but no push goes to chat channels (same as before).

## Test plan

- [x] 18 new unit tests (`tests/test_autonomous_turns.py`): drain semantics, park-on-init, first-content timeout, stray results, task-event registry, buffer probing
- [x] Full suite: 949 passed
- [x] `npm run build` clean
- [x] Live integration vs real CLI: autonomous turn drained → chips + `auto_turn` + streamed text + empty buffer; follow-up query returns the correct fresh response
- [x] Restart Nerve and verify in the web UI with a real background job

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*