### PR TITLE
Fix Langfuse cost overcount for cached agent tokens

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -95,6 +95,31 @@ via a hardcoded `MODEL_PRICING` dict and the SDK's
 they're independent calculations. Treat Langfuse as a second source of
 truth for catching local cost-tracking bugs.
 
+### Prompt-cache pricing (usage rewriter)
+
+The LangSmith `claude-agent-sdk` integration reports usage in
+LangSmith's canonical format: `input_tokens` *includes* prompt-cache
+reads and writes, with the breakdown only in `input_token_details`.
+Langfuse's OTEL ingestion doesn't read that detail field, so without
+correction it prices every cached token at the full uncached input rate
+— a ~5-10x cost overcount on agent sessions, which are typically >95%
+cache reads billed at 10% of the input price.
+
+Nerve fixes this at export time: `init_langfuse` wraps the Langfuse
+OTLP exporter with `nerve/observability/usage_rewrite.py`, which
+rewrites each agent span's `gen_ai.usage.*` attributes from the
+accurate `langsmith.metadata.usage_metadata` payload into the same
+shape `opentelemetry-instrumentation-anthropic` emits (uncached input +
+explicit cache-read / cache-creation counts). Langfuse then applies its
+managed per-model cache prices.
+
+The diagnostics status block reports this as `usage_rewriter: true`.
+If it's `false` while `enabled` is `true`, the SDK layout probably
+changed underneath the installer — agent costs in Langfuse will be
+inflated until it's fixed. Known approximation: 1-hour cache writes are
+priced at the 5-minute rate (Langfuse's OTEL mapping has no separate 1h
+key).
+
 ## Troubleshooting
 
 - **Spans aren't appearing.** Check `/api/observability/status` —

--- a/nerve/observability/langfuse.py
+++ b/nerve/observability/langfuse.py
@@ -47,6 +47,7 @@ _host: str = ""
 _redact_patterns: list[re.Pattern[str]] = []
 _last_flush_at: str | None = None
 _auth_ok: bool = False
+_usage_rewriter: bool = False
 
 
 def is_enabled() -> bool:
@@ -61,6 +62,7 @@ def get_status() -> dict[str, Any]:
         "host": _host or None,
         "auth_ok": _auth_ok,
         "last_flush_at": _last_flush_at,
+        "usage_rewriter": _usage_rewriter,
     }
 
 
@@ -71,7 +73,7 @@ def init_langfuse(config: Any) -> bool:
     packages, or auth failure). Never raises — observability must not be
     able to take down the gateway.
     """
-    global _enabled, _host, _redact_patterns, _auth_ok
+    global _enabled, _host, _redact_patterns, _auth_ok, _usage_rewriter
 
     lf = getattr(config, "langfuse", None)
     if lf is None:
@@ -117,6 +119,29 @@ def init_langfuse(config: Any) -> bool:
             "Langfuse: auth_check raised (%s) — observability disabled", e,
         )
         return False
+
+    # Wrap the Langfuse OTLP exporter so LangSmith agent spans get
+    # cache-aware usage attributes. Without this, Langfuse prices every
+    # cached input token at the full uncached rate (~5-10x overcount on
+    # agent sessions). See nerve/observability/usage_rewrite.py.
+    try:
+        from nerve.observability.usage_rewrite import install_usage_rewriter
+        _usage_rewriter = install_usage_rewriter(client)
+        if _usage_rewriter:
+            logger.info("Langfuse: cache-aware usage rewriter installed")
+        else:
+            logger.warning(
+                "Langfuse: usage rewriter not installed (SDK layout "
+                "mismatch?) — agent-loop costs in Langfuse will overcount "
+                "cached input tokens"
+            )
+    except Exception as e:
+        _usage_rewriter = False
+        logger.warning(
+            "Langfuse: usage rewriter installation failed (%s) — "
+            "agent-loop costs in Langfuse will overcount cached input "
+            "tokens", e,
+        )
 
     # Wrap Claude Agent SDK. Failure here disables agent tracing but doesn't
     # disable the rest — direct Anthropic instrumentation can still cover

--- a/nerve/observability/usage_rewrite.py
+++ b/nerve/observability/usage_rewrite.py
@@ -1,0 +1,266 @@
+"""Cache-aware usage rewriting for LangSmith agent spans exported to Langfuse.
+
+Why this exists
+---------------
+The LangSmith ``claude-agent-sdk`` integration reports token usage in
+LangSmith's canonical format: ``input_tokens`` is the **sum** of uncached
+input plus prompt-cache reads and writes, with the breakdown kept in
+``input_token_details``. LangSmith's own backend understands that format
+and applies cache discounts from the details.
+
+Langfuse does not. Its OTEL ingestion reads the flat
+``gen_ai.usage.input_tokens`` attribute, ignores
+``input_token_details`` (which the LangSmith exporter also stringifies
+as a Python repr rather than JSON), and prices every input token at the
+model's uncached input rate. Agent sessions are typically >95%
+cache-read tokens billed at 10% of the input price, so Langfuse
+overstates agent costs by roughly 5-10x.
+
+What this module does
+---------------------
+A delegating :class:`opentelemetry.sdk.trace.export.SpanExporter` that
+sits in front of Langfuse's OTLP exporter. For every span that carries a
+``langsmith.metadata.usage_metadata`` attribute (the accurate,
+transcript-reconciled per-message usage), it rewrites the
+``gen_ai.usage.*`` attributes into the same shape that
+``opentelemetry-instrumentation-anthropic`` emits — uncached input plus
+explicit ``gen_ai.usage.cache_read.input_tokens`` /
+``gen_ai.usage.cache_creation.input_tokens`` — which Langfuse maps to
+its ``input_cached_tokens`` / ``input_cache_creation`` usage keys and
+prices with the cache rates from its managed model definitions.
+
+Known approximation: 1-hour cache writes are folded into the single
+``cache_creation`` attribute and priced at the 5-minute rate (Langfuse's
+OTEL mapping has no separate 1h key). The 1h share of agent traffic is
+small; the error is a few percent of the cache-write component.
+
+Failure mode
+------------
+Best-effort, like the rest of the observability package. Any error while
+rewriting a span exports the original span unchanged; any error while
+installing leaves the exporter unwrapped. Tracing must never take down
+or distort the host beyond what it already does.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Mapping, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# LangSmith attribute carrying the canonical usage metadata JSON. This is
+# set by the claude-agent-sdk integration from live AssistantMessages and
+# later overwritten with accurate counts reconciled from the JSONL
+# transcripts.
+USAGE_METADATA_ATTR = "langsmith.metadata.usage_metadata"
+
+# OTEL GenAI attributes Langfuse maps into usage_details. The cache keys
+# follow the opentelemetry-instrumentation-anthropic (traceloop)
+# convention, which Langfuse maps to ``input_cached_tokens`` and
+# ``input_cache_creation`` — both priced in Langfuse-managed Anthropic
+# model definitions.
+GEN_AI_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+GEN_AI_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+GEN_AI_TOTAL_TOKENS = "gen_ai.usage.total_tokens"
+GEN_AI_CACHE_READ_TOKENS = "gen_ai.usage.cache_read.input_tokens"
+GEN_AI_CACHE_CREATION_TOKENS = "gen_ai.usage.cache_creation.input_tokens"
+
+
+def _to_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def rewrite_usage_attributes(
+    attributes: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    """Compute corrected ``gen_ai.usage.*`` attributes for a span.
+
+    Returns a dict of attribute updates, or ``None`` when the span has no
+    parseable LangSmith usage metadata (in which case it must be exported
+    unchanged).
+    """
+    raw = attributes.get(USAGE_METADATA_ATTR)
+    if not raw or not isinstance(raw, str):
+        return None
+
+    try:
+        meta = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+
+    # LangSmith canonical: input_tokens already includes cache tokens.
+    input_total = _to_int(meta.get("input_tokens"))
+    output_tokens = _to_int(meta.get("output_tokens"))
+
+    details = meta.get("input_token_details")
+    if not isinstance(details, dict):
+        details = {}
+
+    cache_read = _to_int(details.get("cache_read"))
+    cache_creation = _to_int(
+        details.get("ephemeral_5m_input_tokens")
+    ) + _to_int(
+        # The integration writes "1hr"; tolerate "1h" too.
+        details.get("ephemeral_1hr_input_tokens")
+        or details.get("ephemeral_1h_input_tokens")
+    )
+
+    uncached_input = max(input_total - cache_read - cache_creation, 0)
+
+    updates: dict[str, Any] = {
+        GEN_AI_INPUT_TOKENS: uncached_input,
+        GEN_AI_OUTPUT_TOKENS: output_tokens,
+        GEN_AI_TOTAL_TOKENS: input_total + output_tokens,
+    }
+    if cache_read:
+        updates[GEN_AI_CACHE_READ_TOKENS] = cache_read
+    if cache_creation:
+        updates[GEN_AI_CACHE_CREATION_TOKENS] = cache_creation
+    return updates
+
+
+class UsageRewritingSpanExporter:
+    """SpanExporter decorator that fixes LangSmith usage before export.
+
+    Implements the ``SpanExporter`` interface by delegation so it can wrap
+    whatever exporter Langfuse configured (OTLP by default, anything in
+    tests). Spans without LangSmith usage metadata pass through untouched
+    — including ``opentelemetry-instrumentation-anthropic`` generations,
+    which already report cache usage correctly.
+    """
+
+    def __init__(self, delegate: Any) -> None:
+        self._delegate = delegate
+
+    def export(self, spans: Sequence[Any]) -> Any:
+        try:
+            spans = [self._rewrite(span) for span in spans]
+        except Exception:
+            # Never lose a batch to rewriting problems.
+            logger.debug("Usage rewrite failed for batch", exc_info=True)
+        return self._delegate.export(spans)
+
+    def shutdown(self) -> None:
+        return self._delegate.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        force_flush = getattr(self._delegate, "force_flush", None)
+        if force_flush is None:
+            return True
+        return force_flush(timeout_millis)
+
+    # -- internals ----------------------------------------------------
+
+    def _rewrite(self, span: Any) -> Any:
+        try:
+            attributes = span.attributes or {}
+            updates = rewrite_usage_attributes(attributes)
+            if not updates:
+                return span
+            merged = dict(attributes)
+            merged.update(updates)
+            return self._clone_with_attributes(span, merged)
+        except Exception:
+            logger.debug(
+                "Usage rewrite failed for span %r — exporting unchanged",
+                getattr(span, "name", "?"),
+                exc_info=True,
+            )
+            return span
+
+    @staticmethod
+    def _clone_with_attributes(span: Any, attributes: dict[str, Any]) -> Any:
+        """Build a copy of a ReadableSpan with replaced attributes.
+
+        Ended spans are immutable, so the only clean way to adjust
+        attributes at export time is to construct a new ReadableSpan that
+        shares every other field.
+        """
+        from opentelemetry.sdk.trace import ReadableSpan
+
+        context = getattr(span, "context", None) or span.get_span_context()
+        return ReadableSpan(
+            name=span.name,
+            context=context,
+            parent=span.parent,
+            resource=span.resource,
+            attributes=attributes,
+            events=span.events,
+            links=span.links,
+            kind=span.kind,
+            instrumentation_scope=span.instrumentation_scope,
+            status=span.status,
+            start_time=span.start_time,
+            end_time=span.end_time,
+        )
+
+
+def install_usage_rewriter(client: Any) -> bool:
+    """Wrap the Langfuse span processors' exporters on a live client.
+
+    Walks ``client._resources.tracer_provider`` for
+    ``LangfuseSpanProcessor`` instances and wraps each underlying span
+    exporter in :class:`UsageRewritingSpanExporter`. Idempotent — already
+    wrapped exporters are left alone.
+
+    Returns True when at least one exporter is wrapped (or was already
+    wrapped), False when the structure doesn't match (SDK layout change,
+    tracing disabled, etc.).
+    """
+    try:
+        from langfuse._client.span_processor import LangfuseSpanProcessor
+    except ImportError:
+        return False
+
+    resources = getattr(client, "_resources", None)
+    provider = getattr(resources, "tracer_provider", None)
+    if provider is None:
+        return False
+
+    multi = getattr(provider, "_active_span_processor", None)
+    processors = getattr(multi, "_span_processors", None) or ()
+
+    installed = False
+    for processor in processors:
+        if not isinstance(processor, LangfuseSpanProcessor):
+            continue
+        if _wrap_processor_exporter(processor):
+            installed = True
+    return installed
+
+
+def _wrap_processor_exporter(processor: Any) -> bool:
+    """Replace a BatchSpanProcessor's exporter with the rewriting wrapper.
+
+    Handles both OTEL SDK layouts:
+    - >= 1.39: ``processor._batch_processor._exporter``
+    - older:   ``processor.span_exporter``
+    """
+    holders = []
+    batch_processor = getattr(processor, "_batch_processor", None)
+    if batch_processor is not None and hasattr(batch_processor, "_exporter"):
+        holders.append((batch_processor, "_exporter"))
+    if hasattr(processor, "span_exporter"):
+        holders.append((processor, "span_exporter"))
+
+    for holder, attr in holders:
+        current = getattr(holder, attr, None)
+        if current is None:
+            continue
+        if isinstance(current, UsageRewritingSpanExporter):
+            return True  # already installed
+        try:
+            setattr(holder, attr, UsageRewritingSpanExporter(current))
+            return True
+        except AttributeError:
+            # Read-only property (e.g. a delegating accessor) — try the
+            # next holder.
+            continue
+    return False

--- a/tests/test_observability_langfuse.py
+++ b/tests/test_observability_langfuse.py
@@ -27,6 +27,7 @@ def _reset_lf_state(monkeypatch):
     lf._redact_patterns = []
     lf._last_flush_at = None
     lf._auth_ok = False
+    lf._usage_rewriter = False
     for var in (
         "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_HOST",
         "LANGSMITH_OTEL_ENABLED", "LANGSMITH_OTEL_ONLY", "LANGSMITH_TRACING",

--- a/tests/test_usage_rewrite.py
+++ b/tests/test_usage_rewrite.py
@@ -1,0 +1,356 @@
+"""Tests for nerve.observability.usage_rewrite.
+
+Covers the pure attribute-rewrite logic, the delegating span exporter
+(including pass-through of non-LangSmith spans), and installation onto a
+real OTEL TracerProvider + LangfuseSpanProcessor pipeline.
+
+The OTEL SDK is a hard dependency of the langfuse extra; tests that need
+it are skipped when it isn't installed so the suite still passes on
+minimal environments.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nerve.observability.usage_rewrite import (
+    GEN_AI_CACHE_CREATION_TOKENS,
+    GEN_AI_CACHE_READ_TOKENS,
+    GEN_AI_INPUT_TOKENS,
+    GEN_AI_OUTPUT_TOKENS,
+    GEN_AI_TOTAL_TOKENS,
+    USAGE_METADATA_ATTR,
+    UsageRewritingSpanExporter,
+    install_usage_rewriter,
+    rewrite_usage_attributes,
+)
+
+otel_sdk = pytest.importorskip("opentelemetry.sdk.trace", reason="OTEL SDK not installed")
+
+
+def _usage_attr(
+    input_tokens: int,
+    output_tokens: int,
+    cache_read: int = 0,
+    ephemeral_5m: int = 0,
+    ephemeral_1h: int = 0,
+) -> str:
+    """Build a LangSmith-canonical usage_metadata JSON string.
+
+    Mirrors langsmith's ``extract_usage_metadata``: ``input_tokens``
+    already includes the cache tokens.
+    """
+    details = {}
+    if cache_read:
+        details["cache_read"] = cache_read
+    if ephemeral_5m:
+        details["ephemeral_5m_input_tokens"] = ephemeral_5m
+    if ephemeral_1h:
+        details["ephemeral_1hr_input_tokens"] = ephemeral_1h
+    meta = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    if details:
+        meta["input_token_details"] = details
+    return json.dumps(meta)
+
+
+# ---------------------------------------------------------------------------
+# rewrite_usage_attributes — pure logic
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteUsageAttributes:
+    def test_cache_heavy_turn_is_split(self):
+        # Shape observed on a real agent span: 237,073 "input" tokens of
+        # which 236,384 were cache reads and 687 cache writes.
+        attrs = {
+            USAGE_METADATA_ATTR: _usage_attr(
+                input_tokens=237_073,
+                output_tokens=5,
+                cache_read=236_384,
+                ephemeral_5m=687,
+            )
+        }
+        updates = rewrite_usage_attributes(attrs)
+        assert updates == {
+            GEN_AI_INPUT_TOKENS: 2,
+            GEN_AI_OUTPUT_TOKENS: 5,
+            GEN_AI_TOTAL_TOKENS: 237_078,
+            GEN_AI_CACHE_READ_TOKENS: 236_384,
+            GEN_AI_CACHE_CREATION_TOKENS: 687,
+        }
+
+    def test_uncached_call_keeps_input(self):
+        attrs = {USAGE_METADATA_ATTR: _usage_attr(811, 146)}
+        updates = rewrite_usage_attributes(attrs)
+        assert updates == {
+            GEN_AI_INPUT_TOKENS: 811,
+            GEN_AI_OUTPUT_TOKENS: 146,
+            GEN_AI_TOTAL_TOKENS: 957,
+        }
+
+    def test_one_hour_cache_writes_counted(self):
+        attrs = {
+            USAGE_METADATA_ATTR: _usage_attr(
+                input_tokens=1_000, output_tokens=10,
+                cache_read=500, ephemeral_5m=100, ephemeral_1h=300,
+            )
+        }
+        updates = rewrite_usage_attributes(attrs)
+        assert updates[GEN_AI_INPUT_TOKENS] == 100
+        assert updates[GEN_AI_CACHE_READ_TOKENS] == 500
+        assert updates[GEN_AI_CACHE_CREATION_TOKENS] == 400
+
+    def test_inconsistent_details_clamped_to_zero(self):
+        # Cache details larger than input_tokens must not go negative.
+        attrs = {
+            USAGE_METADATA_ATTR: json.dumps(
+                {
+                    "input_tokens": 100,
+                    "output_tokens": 1,
+                    "input_token_details": {"cache_read": 500},
+                }
+            )
+        }
+        updates = rewrite_usage_attributes(attrs)
+        assert updates[GEN_AI_INPUT_TOKENS] == 0
+        assert updates[GEN_AI_CACHE_READ_TOKENS] == 500
+
+    def test_missing_attribute_returns_none(self):
+        assert rewrite_usage_attributes({}) is None
+        assert rewrite_usage_attributes({"other": "x"}) is None
+
+    def test_malformed_json_returns_none(self):
+        assert rewrite_usage_attributes({USAGE_METADATA_ATTR: "{not json"}) is None
+        assert rewrite_usage_attributes({USAGE_METADATA_ATTR: "[1, 2]"}) is None
+
+    def test_non_string_attribute_returns_none(self):
+        assert rewrite_usage_attributes({USAGE_METADATA_ATTR: 42}) is None
+
+    def test_garbage_token_values_coerced(self):
+        attrs = {
+            USAGE_METADATA_ATTR: json.dumps(
+                {"input_tokens": "abc", "output_tokens": None}
+            )
+        }
+        updates = rewrite_usage_attributes(attrs)
+        assert updates == {
+            GEN_AI_INPUT_TOKENS: 0,
+            GEN_AI_OUTPUT_TOKENS: 0,
+            GEN_AI_TOTAL_TOKENS: 0,
+        }
+
+
+# ---------------------------------------------------------------------------
+# UsageRewritingSpanExporter — delegation + span rebuild
+# ---------------------------------------------------------------------------
+
+
+class FakeExporter:
+    def __init__(self):
+        self.batches = []
+        self.shutdown_called = False
+        self.flushed = False
+
+    def export(self, spans):
+        self.batches.append(list(spans))
+        return "exported"
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+    def force_flush(self, timeout_millis=30_000):
+        self.flushed = True
+        return True
+
+
+def _make_spans(tracer_attrs_pairs):
+    """End real SDK spans with given attributes and return ReadableSpans."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    collected = []
+
+    class Collector:
+        def export(self, spans):
+            collected.extend(spans)
+            return None
+
+        def shutdown(self):
+            return None
+
+        def force_flush(self, timeout_millis=30_000):
+            return True
+
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(Collector()))
+    tracer = provider.get_tracer("langsmith")
+    for name, attrs in tracer_attrs_pairs:
+        with tracer.start_as_current_span(name) as span:
+            for key, value in attrs.items():
+                span.set_attribute(key, value)
+    provider.shutdown()
+    return collected
+
+
+class TestUsageRewritingSpanExporter:
+    def test_rewrites_langsmith_span_and_keeps_others(self):
+        usage_json = _usage_attr(
+            input_tokens=237_073, output_tokens=5,
+            cache_read=236_384, ephemeral_5m=687,
+        )
+        spans = _make_spans(
+            [
+                (
+                    "claude.assistant.turn",
+                    {
+                        USAGE_METADATA_ATTR: usage_json,
+                        GEN_AI_INPUT_TOKENS: 956_331,  # inflated
+                        GEN_AI_OUTPUT_TOKENS: 572,
+                        "langsmith.span.kind": "llm",
+                    },
+                ),
+                (
+                    "anthropic.chat",
+                    {GEN_AI_INPUT_TOKENS: 811, GEN_AI_OUTPUT_TOKENS: 146},
+                ),
+            ]
+        )
+        delegate = FakeExporter()
+        exporter = UsageRewritingSpanExporter(delegate)
+
+        result = exporter.export(spans)
+        assert result == "exported"
+        assert len(delegate.batches) == 1
+        exported = {s.name: s for s in delegate.batches[0]}
+
+        turn = exported["claude.assistant.turn"]
+        assert turn.attributes[GEN_AI_INPUT_TOKENS] == 2
+        assert turn.attributes[GEN_AI_OUTPUT_TOKENS] == 5
+        assert turn.attributes[GEN_AI_CACHE_READ_TOKENS] == 236_384
+        assert turn.attributes[GEN_AI_CACHE_CREATION_TOKENS] == 687
+        # Original metadata preserved for debugging.
+        assert turn.attributes[USAGE_METADATA_ATTR] == usage_json
+        assert turn.attributes["langsmith.span.kind"] == "llm"
+
+        # Non-LangSmith span passes through as the same object, untouched.
+        chat = exported["anthropic.chat"]
+        assert chat is spans[1]
+        assert chat.attributes[GEN_AI_INPUT_TOKENS] == 811
+
+    def test_clone_preserves_span_identity_fields(self):
+        spans = _make_spans(
+            [
+                (
+                    "claude.assistant.turn",
+                    {USAGE_METADATA_ATTR: _usage_attr(100, 10, cache_read=90)},
+                )
+            ]
+        )
+        original = spans[0]
+        delegate = FakeExporter()
+        UsageRewritingSpanExporter(delegate).export(spans)
+        clone = delegate.batches[0][0]
+
+        assert clone is not original
+        assert clone.context.span_id == original.context.span_id
+        assert clone.context.trace_id == original.context.trace_id
+        assert clone.start_time == original.start_time
+        assert clone.end_time == original.end_time
+        assert clone.instrumentation_scope == original.instrumentation_scope
+        assert clone.resource is original.resource
+
+    def test_broken_span_exported_unchanged(self):
+        class BrokenSpan:
+            name = "broken"
+
+            @property
+            def attributes(self):
+                raise RuntimeError("boom")
+
+        delegate = FakeExporter()
+        exporter = UsageRewritingSpanExporter(delegate)
+        broken = BrokenSpan()
+        exporter.export([broken])
+        assert delegate.batches == [[broken]]
+
+    def test_shutdown_and_flush_delegate(self):
+        delegate = FakeExporter()
+        exporter = UsageRewritingSpanExporter(delegate)
+        exporter.shutdown()
+        assert delegate.shutdown_called
+        assert exporter.force_flush() is True
+        assert delegate.flushed
+
+
+# ---------------------------------------------------------------------------
+# install_usage_rewriter — wiring onto a live provider
+# ---------------------------------------------------------------------------
+
+
+class TestInstallUsageRewriter:
+    def test_installs_on_langfuse_processor(self):
+        langfuse_sp = pytest.importorskip(
+            "langfuse._client.span_processor",
+            reason="langfuse package not installed",
+        )
+        from types import SimpleNamespace
+
+        from opentelemetry.sdk.trace import TracerProvider
+
+        delegate = FakeExporter()
+        processor = langfuse_sp.LangfuseSpanProcessor(
+            public_key="pk-test",
+            secret_key="sk-test",
+            base_url="http://localhost:9",
+            span_exporter=delegate,
+        )
+        provider = TracerProvider()
+        provider.add_span_processor(processor)
+        client = SimpleNamespace(
+            _resources=SimpleNamespace(tracer_provider=provider)
+        )
+
+        try:
+            assert install_usage_rewriter(client) is True
+            # Idempotent on second call.
+            assert install_usage_rewriter(client) is True
+
+            # End a span through the real pipeline and verify the
+            # delegate receives rewritten attributes.
+            tracer = provider.get_tracer("langsmith")
+            with tracer.start_as_current_span("claude.assistant.turn") as span:
+                span.set_attribute(
+                    USAGE_METADATA_ATTR,
+                    _usage_attr(1_000, 7, cache_read=900, ephemeral_5m=50),
+                )
+                span.set_attribute(GEN_AI_INPUT_TOKENS, 1_000)
+            processor.force_flush()
+
+            assert delegate.batches, "span never reached the delegate"
+            exported = delegate.batches[0][0]
+            assert exported.attributes[GEN_AI_INPUT_TOKENS] == 50
+            assert exported.attributes[GEN_AI_CACHE_READ_TOKENS] == 900
+            assert exported.attributes[GEN_AI_CACHE_CREATION_TOKENS] == 50
+        finally:
+            provider.shutdown()
+
+    def test_returns_false_without_resources(self):
+        from types import SimpleNamespace
+
+        pytest.importorskip(
+            "langfuse._client.span_processor",
+            reason="langfuse package not installed",
+        )
+        assert install_usage_rewriter(SimpleNamespace()) is False
+        assert (
+            install_usage_rewriter(
+                SimpleNamespace(_resources=SimpleNamespace(tracer_provider=None))
+            )
+            is False
+        )


### PR DESCRIPTION
## Problem

Langfuse showed agent-session costs ~5-10x higher than actual consumption (one partial day: **$6,467 shown vs ~$914 actual**).

Root cause: the LangSmith `claude-agent-sdk` integration reports usage in LangSmith's canonical format — `input_tokens` *includes* prompt-cache reads/writes, with the breakdown only in `input_token_details`. The LangSmith OTEL exporter ships the flattened `gen_ai.usage.input_tokens` and stringifies the details as a Python repr that Langfuse ignores. Langfuse then prices **every** input token at the uncached rate, while agent sessions are typically >95% cache reads billed at 10% of it.

(Generations traced via `opentelemetry-instrumentation-anthropic` were unaffected — that instrumentor emits explicit cache attributes Langfuse prices correctly. That asymmetry confirmed the diagnosis.)

## Fix

New `nerve/observability/usage_rewrite.py`:

- `rewrite_usage_attributes()` — parses the accurate, transcript-reconciled `langsmith.metadata.usage_metadata` span attribute and recomputes `gen_ai.usage.*`: uncached input, plus explicit `gen_ai.usage.cache_read.input_tokens` / `gen_ai.usage.cache_creation.input_tokens` (the convention Langfuse already maps to its priced `input_cached_tokens` / `input_cache_creation` keys).
- `UsageRewritingSpanExporter` — delegating `SpanExporter` that rebuilds matching `ReadableSpan`s with corrected attributes at export time; all other spans pass through untouched.
- `install_usage_rewriter()` — wraps the `LangfuseSpanProcessor`'s underlying exporter on the live client (handles both old and ≥1.39 OTEL SDK `BatchSpanProcessor` layouts). Idempotent.

`init_langfuse` installs the wrapper right after auth check; the diagnostics status block now reports `usage_rewriter`. Everything is best-effort: any failure logs a warning and exports spans unchanged — observability can never take down or distort the host.

Known approximation (documented): 1-hour cache writes are priced at the 5-minute rate — Langfuse's OTEL mapping has no separate 1h key.

## Test plan

- [x] Unit tests for the rewrite math, including a captured production span shape (237,073 flattened input → 2 uncached + 236,384 cache-read + 687 cache-write), 1h+5m writes, clamping, malformed JSON
- [x] Exporter tests: rewrite + pass-through, span identity preserved on clone, broken spans exported unchanged, shutdown/flush delegation
- [x] End-to-end through a real `TracerProvider` + `LangfuseSpanProcessor` with an injected fake exporter
- [x] Full suite: 945 passed
- [x] Deploy to a worker instance and compare Langfuse daily cost vs local `session_usage` for one day

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*