### PR TITLE
Cron: file-based prompts, chat deep-links, run-log fixes

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -45,7 +45,32 @@ jobs:
     prompt: "Check for overdue tasks..."
     target: telegram
     enabled: true
+
+  - id: repo-watch-nerve
+    schedule: "1h"
+    prompt_file: prompts/repo-watch.md   # Relative to this YAML's directory
+    enabled: true
+
+  - id: repo-watch-other
+    schedule: "1h"
+    prompt_file: prompts/repo-watch.md   # Same prompt, shared between jobs
+    enabled: true
 ```
+
+### Prompt Files
+
+Instead of an inline `prompt`, a job can point at a file with `prompt_file`.
+This keeps long prompts out of the YAML and lets multiple jobs share one
+prompt definition.
+
+- Relative paths resolve against the directory of the YAML file the job was
+  loaded from (e.g. `prompts/repo-watch.md` next to `jobs.yaml` →
+  `~/.nerve/cron/prompts/repo-watch.md`). Absolute paths and `~` work too.
+- The file is read fresh on **every run** — edits take effect on the next
+  trigger without a restart.
+- If both `prompt` and `prompt_file` are set, the file wins; the inline
+  prompt is used as a fallback when the file can't be read.
+- A job must define at least one of `prompt` / `prompt_file`.
 
 ## Job Fields
 
@@ -53,7 +78,8 @@ jobs:
 |-------|------|----------|-------------|
 | `id` | string | yes | Unique job identifier |
 | `schedule` | string | yes | Crontab expression or interval (`2h`, `30m`) |
-| `prompt` | string | yes | Message sent to the agent |
+| `prompt` | string | yes* | Message sent to the agent |
+| `prompt_file` | string | yes* | Path to a file containing the prompt (relative to the YAML's directory). Read fresh each run; shareable between jobs. *One of `prompt`/`prompt_file` is required |
 | `description` | string | no | Human-readable description |
 | `model` | string | no | Override model (default: `agent.cron_model`) |
 | `target` | string | no | Delivery channel (default: `telegram`) |

--- a/nerve/cron/jobs.py
+++ b/nerve/cron/jobs.py
@@ -23,7 +23,14 @@ class CronJob:
     """A cron job definition."""
     id: str
     schedule: str  # crontab expression or interval (e.g., "*/30 * * * *", "2h")
-    prompt: str  # The message/instruction sent to the agent
+    prompt: str = ""  # The message/instruction sent to the agent (inline)
+    # Path to a file containing the prompt. Relative paths resolve against
+    # the directory of the YAML file the job was loaded from. When set, the
+    # file is read fresh on every run (edits apply without a restart) and
+    # multiple jobs may share the same prompt file. Takes precedence over
+    # the inline prompt; the inline prompt acts as a fallback if the file
+    # is unreadable.
+    prompt_file: str = ""
     description: str = ""
     model: str = ""  # Override model; empty = use config default
     session_mode: str = "isolated"  # "isolated" (new session per run) or "persistent" (reuse context)
@@ -47,9 +54,45 @@ class CronJob:
     gates: list["CronGate"] = field(
         default_factory=list, init=False, repr=False, compare=False,
     )
+    # Resolved absolute path for prompt_file (set by from_dict/load_jobs).
+    # Not serialized; excluded from equality/repr.
+    prompt_path: Path | None = field(
+        default=None, init=False, repr=False, compare=False,
+    )
 
     def __post_init__(self) -> None:
         self.gates = self._build_gates()
+        if not self.prompt and not self.prompt_file:
+            raise ValueError(
+                f"Cron job {self.id!r} needs a 'prompt' or 'prompt_file'"
+            )
+        if self.prompt_file and self.prompt_path is None:
+            # Direct construction (tests, programmatic) — resolve against cwd.
+            self.prompt_path = Path(self.prompt_file).expanduser()
+
+    def resolve_prompt(self) -> str:
+        """Return the effective prompt for a run.
+
+        Reads prompt_file fresh on every call so edits apply without a
+        restart. Falls back to the inline prompt if the file is unreadable;
+        raises if neither is usable.
+        """
+        if self.prompt_path is not None:
+            try:
+                return self.prompt_path.read_text(encoding="utf-8")
+            except OSError as e:
+                if self.prompt:
+                    logger.error(
+                        "Cron job %s: cannot read prompt_file %s (%s) — "
+                        "falling back to inline prompt",
+                        self.id, self.prompt_path, e,
+                    )
+                    return self.prompt
+                raise RuntimeError(
+                    f"Cron job {self.id!r}: cannot read prompt_file "
+                    f"{self.prompt_path} and no inline prompt fallback: {e}"
+                ) from e
+        return self.prompt
 
     def _build_gates(self) -> list["CronGate"]:
         """Construct gate objects from run_if plus the legacy shorthand."""
@@ -67,11 +110,12 @@ class CronJob:
         return build_gates(specs)
 
     @classmethod
-    def from_dict(cls, d: dict) -> CronJob:
-        return cls(
+    def from_dict(cls, d: dict, base_dir: Path | None = None) -> CronJob:
+        job = cls(
             id=d["id"],
             schedule=d["schedule"],
-            prompt=d["prompt"],
+            prompt=d.get("prompt", ""),
+            prompt_file=d.get("prompt_file", ""),
             description=d.get("description", ""),
             model=d.get("model", ""),
             session_mode=d.get("session_mode", "isolated"),
@@ -87,6 +131,12 @@ class CronJob:
             show_session_label=d.get("show_session_label", True),
             metadata=d.get("metadata", {}),
         )
+        if job.prompt_file:
+            p = Path(job.prompt_file).expanduser()
+            if not p.is_absolute() and base_dir is not None:
+                p = (base_dir / p).resolve()
+            job.prompt_path = p
+        return job
 
 
 def load_jobs(jobs_file: Path) -> list[CronJob]:
@@ -109,8 +159,8 @@ def load_jobs(jobs_file: Path) -> list[CronJob]:
     jobs = []
     for item in jobs_data:
         try:
-            jobs.append(CronJob.from_dict(item))
-        except (KeyError, TypeError) as e:
+            jobs.append(CronJob.from_dict(item, base_dir=jobs_file.parent))
+        except (KeyError, TypeError, ValueError) as e:
             logger.warning("Invalid cron job definition: %s — %s", item, e)
 
     logger.info("Loaded %d cron jobs from %s", len(jobs), jobs_file)
@@ -126,6 +176,7 @@ def save_jobs(jobs: list[CronJob], jobs_file: Path) -> None:
             "id": job.id,
             "schedule": job.schedule,
             "prompt": job.prompt,
+            "prompt_file": job.prompt_file,
             "description": job.description,
             "model": job.model,
             "session_mode": job.session_mode,

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -383,23 +383,26 @@ class CronService:
 
         log_id = await self.db.log_cron_start(job.id)
         logger.info("Running cron job: %s (mode=%s)", job.id, job.session_mode)
+        session_id: str | None = None
 
         try:
             model = job.model or self.config.agent.cron_model
             rotated = False
+            base_prompt = job.resolve_prompt()
 
             if job.session_mode == "persistent":
+                session_id = f"cron:{job.id}"
                 # Persistent mode: reuse SDK context across runs
                 if job.context_rotate_at or job.context_rotate_hours > 0:
                     rotated = await self._maybe_rotate_context(
-                        f"cron:{job.id}", job.context_rotate_hours,
+                        session_id, job.context_rotate_hours,
                         rotate_at=job.context_rotate_at,
                     )
 
                 # Determine prompt: full on first run, short reminder on subsequent
-                prompt = job.prompt
+                prompt = base_prompt
                 if job.reminder_mode:
-                    session = await self.db.get_session(f"cron:{job.id}")
+                    session = await self.db.get_session(session_id)
                     is_resume = (
                         session
                         and session.get("sdk_session_id")
@@ -411,7 +414,7 @@ class CronService:
                             "task as before."
                         )
                     else:
-                        prompt = job.prompt.rstrip() + (
+                        prompt = base_prompt.rstrip() + (
                             "\n\n---\n"
                             "NOTE: This is a persistent cron with reminder "
                             "mode. On subsequent triggers you will receive "
@@ -425,28 +428,34 @@ class CronService:
                     model=model,
                 )
             else:
-                # Isolated mode: per-run session (existing behaviour)
-                run_id = (
-                    datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-                    if self.config.sessions.cron_session_mode == "per_run"
-                    else None
-                )
+                # Isolated mode: per-run session. The run_id is generated
+                # here (the engine would otherwise generate an identical
+                # timestamp-based one) so the session id is known for the
+                # run log.
+                run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+                session_id = f"cron:{job.id}:{run_id}"
                 response = await self.engine.run_cron(
                     job_id=job.id,
-                    prompt=job.prompt,
+                    prompt=base_prompt,
                     model=model,
                     run_id=run_id,
                 )
 
-            output = response[:2000]
+            # Keep the tail of the response — for multi-message runs the
+            # final summary lives at the end, not the beginning.
+            output = response if len(response) <= 2000 else "…" + response[-2000:]
             if rotated:
                 output = "[context rotated] " + output
-            await self.db.log_cron_finish(log_id, "success", output=output)
+            await self.db.log_cron_finish(
+                log_id, "success", output=output, session_id=session_id,
+            )
             logger.info("Cron job %s completed (%d chars)", job.id, len(response))
 
         except Exception as e:
             logger.error("Cron job %s failed: %s", job.id, e, exc_info=True)
-            await self.db.log_cron_finish(log_id, "error", error=str(e))
+            await self.db.log_cron_finish(
+                log_id, "error", error=str(e), session_id=session_id,
+            )
 
     async def _run_source_wrapper(self, runner: SourceRunner) -> None:
         """Wrapper to run a source ingestion with cron and source logging."""
@@ -618,23 +627,29 @@ class CronService:
             "session_age_hours": session_age_hours,
         }
 
-    def list_jobs(self) -> list[dict]:
+    async def list_jobs(self) -> list[dict]:
         """List all registered jobs (cron + sources) with their next run times."""
         result = []
         for job in self._jobs:
             sched_job = self.scheduler.get_job(job.id)
             next_run = sched_job.next_run_time if sched_job else None
+            try:
+                last_session_id = await self.db.get_latest_cron_session_id(job.id)
+            except Exception:
+                last_session_id = None
             result.append({
                 "id": job.id,
                 "type": "cron",
                 "source": job.metadata.get("_source", "unknown"),
                 "schedule": job.schedule,
                 "description": job.description,
+                "prompt_file": job.prompt_file,
                 "enabled": job.enabled,
                 "session_mode": job.session_mode,
                 "lock": job.lock,
                 "gates": [gate.describe() for gate in job.gates],
                 "next_run": next_run.isoformat() if next_run else None,
+                "last_session_id": last_session_id,
             })
 
         # Include source runners
@@ -652,6 +667,7 @@ class CronService:
                 "description": f"Source: {source_name} (ingestor)",
                 "enabled": True,
                 "next_run": next_run.isoformat() if next_run else None,
+                "last_session_id": None,
             })
 
         return result

--- a/nerve/db/cron.py
+++ b/nerve/db/cron.py
@@ -17,12 +17,18 @@ class CronStore:
         return log_id
 
     async def log_cron_finish(
-        self, log_id: int, status: str, output: str | None = None, error: str | None = None
+        self,
+        log_id: int,
+        status: str,
+        output: str | None = None,
+        error: str | None = None,
+        session_id: str | None = None,
     ) -> None:
         now = utc_now_iso()
         await self.db.execute(
-            "UPDATE cron_logs SET finished_at = ?, status = ?, output = ?, error = ? WHERE id = ?",
-            (now, status, output, error, log_id),
+            "UPDATE cron_logs SET finished_at = ?, status = ?, output = ?, error = ?, "
+            "session_id = COALESCE(?, session_id) WHERE id = ?",
+            (now, status, output, error, session_id, log_id),
         )
         await self.db.commit()
 
@@ -44,6 +50,25 @@ class CronStore:
         ) as cursor:
             row = await cursor.fetchone()
             return dict(row) if row else None
+
+    async def get_latest_cron_session_id(self, job_id: str) -> str | None:
+        """Return the most recently active session id for a cron job.
+
+        Matches both the persistent form (``cron:<job>``) and per-run
+        isolated sessions (``cron:<job>:<run>``).
+        """
+        escaped = (
+            job_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        async with self.db.execute(
+            """SELECT id FROM sessions
+               WHERE id = ? OR id LIKE ? ESCAPE '\\'
+               ORDER BY COALESCE(last_activity_at, updated_at, created_at) DESC
+               LIMIT 1""",
+            (f"cron:{job_id}", f"cron:{escaped}:%"),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row["id"] if row else None
 
     async def get_recent_cron_runs(self, hours: int = 6) -> list[dict]:
         """Get all successful cron runs within the last N hours."""

--- a/nerve/db/migrations/v033_cron_log_session.py
+++ b/nerve/db/migrations/v033_cron_log_session.py
@@ -1,0 +1,16 @@
+"""V33: Link cron run logs to their agent sessions.
+
+Adds ``cron_logs.session_id`` so each run can be traced to the session it
+executed in (``cron:<job>`` for persistent jobs, ``cron:<job>:<run>`` for
+isolated per-run sessions). The web UI uses this to deep-link from a cron
+run row to its chat page. Source-runner logs keep NULL — they have no
+agent session.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute("ALTER TABLE cron_logs ADD COLUMN session_id TEXT")

--- a/nerve/gateway/routes/cron.py
+++ b/nerve/gateway/routes/cron.py
@@ -18,7 +18,7 @@ async def list_cron_jobs(user: dict = Depends(require_auth)):
     if not _cron_service:
         return {"jobs": []}
 
-    jobs = _cron_service.list_jobs()
+    jobs = await _cron_service.list_jobs()
     return {"jobs": jobs}
 
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -511,3 +511,194 @@ class TestRunGates:
         await cron_service._run_job_inner(job)
 
         cron_service.engine.run_cron.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Prompt files (prompt_file)
+# ---------------------------------------------------------------------------
+
+class TestPromptFile:
+    def test_requires_prompt_or_prompt_file(self):
+        with pytest.raises(ValueError):
+            CronJob(id="x", schedule="1h")
+
+    def test_inline_prompt_resolves(self):
+        job = _make_job()
+        assert job.resolve_prompt() == "do stuff"
+
+    def test_prompt_file_resolves(self, tmp_path):
+        pf = tmp_path / "prompt.md"
+        pf.write_text("from file", encoding="utf-8")
+        job = CronJob(id="x", schedule="1h", prompt_file=str(pf))
+        assert job.resolve_prompt() == "from file"
+
+    def test_prompt_file_wins_over_inline(self, tmp_path):
+        pf = tmp_path / "prompt.md"
+        pf.write_text("file wins", encoding="utf-8")
+        job = CronJob(id="x", schedule="1h", prompt="inline", prompt_file=str(pf))
+        assert job.resolve_prompt() == "file wins"
+
+    def test_prompt_file_read_fresh_each_run(self, tmp_path):
+        pf = tmp_path / "prompt.md"
+        pf.write_text("v1", encoding="utf-8")
+        job = CronJob(id="x", schedule="1h", prompt_file=str(pf))
+        assert job.resolve_prompt() == "v1"
+        pf.write_text("v2", encoding="utf-8")
+        assert job.resolve_prompt() == "v2"
+
+    def test_missing_file_falls_back_to_inline(self, tmp_path):
+        job = CronJob(
+            id="x", schedule="1h",
+            prompt="fallback", prompt_file=str(tmp_path / "nope.md"),
+        )
+        assert job.resolve_prompt() == "fallback"
+
+    def test_missing_file_no_fallback_raises(self, tmp_path):
+        job = CronJob(
+            id="x", schedule="1h", prompt_file=str(tmp_path / "nope.md"),
+        )
+        with pytest.raises(RuntimeError):
+            job.resolve_prompt()
+
+    def test_from_dict_relative_to_base_dir(self, tmp_path):
+        (tmp_path / "prompts").mkdir()
+        (tmp_path / "prompts" / "shared.md").write_text("shared!", encoding="utf-8")
+        job = CronJob.from_dict(
+            {"id": "x", "schedule": "1h", "prompt_file": "prompts/shared.md"},
+            base_dir=tmp_path,
+        )
+        assert job.resolve_prompt() == "shared!"
+
+    def test_load_jobs_shared_prompt_file(self, tmp_path):
+        from nerve.cron.jobs import load_jobs
+
+        (tmp_path / "prompts").mkdir()
+        (tmp_path / "prompts" / "shared.md").write_text("same prompt", encoding="utf-8")
+        yaml_file = tmp_path / "jobs.yaml"
+        yaml_file.write_text(
+            "jobs:\n"
+            "  - id: a\n"
+            "    schedule: 1h\n"
+            "    prompt_file: prompts/shared.md\n"
+            "  - id: b\n"
+            "    schedule: 2h\n"
+            "    prompt_file: prompts/shared.md\n",
+            encoding="utf-8",
+        )
+        jobs = load_jobs(yaml_file)
+        assert len(jobs) == 2
+        assert jobs[0].resolve_prompt() == "same prompt"
+        assert jobs[1].resolve_prompt() == "same prompt"
+
+    def test_load_jobs_skips_job_without_any_prompt(self, tmp_path):
+        from nerve.cron.jobs import load_jobs
+
+        yaml_file = tmp_path / "jobs.yaml"
+        yaml_file.write_text(
+            "jobs:\n"
+            "  - id: bad\n"
+            "    schedule: 1h\n"
+            "  - id: good\n"
+            "    schedule: 1h\n"
+            "    prompt: hi\n",
+            encoding="utf-8",
+        )
+        jobs = load_jobs(yaml_file)
+        assert [j.id for j in jobs] == ["good"]
+
+    def test_save_jobs_round_trips_prompt_file(self, tmp_path):
+        from nerve.cron.jobs import load_jobs, save_jobs
+
+        (tmp_path / "p.md").write_text("x", encoding="utf-8")
+        job = CronJob.from_dict(
+            {"id": "x", "schedule": "1h", "prompt_file": "p.md"},
+            base_dir=tmp_path,
+        )
+        out = tmp_path / "out.yaml"
+        save_jobs([job], out)
+        loaded = load_jobs(out)
+        assert loaded[0].prompt_file == "p.md"
+        assert loaded[0].resolve_prompt() == "x"
+
+    @pytest.mark.asyncio
+    async def test_run_uses_prompt_file_content(self, cron_service, tmp_path):
+        pf = tmp_path / "prompt.md"
+        pf.write_text("file instructions", encoding="utf-8")
+        job = CronJob(id="filed", schedule="1h", prompt_file=str(pf))
+
+        await cron_service._run_job_inner(job)
+
+        kwargs = cron_service.engine.run_cron.call_args.kwargs
+        assert kwargs["prompt"] == "file instructions"
+
+    @pytest.mark.asyncio
+    async def test_run_unreadable_prompt_file_logs_error(self, cron_service, tmp_path):
+        job = CronJob(id="filed", schedule="1h", prompt_file=str(tmp_path / "nope.md"))
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.engine.run_cron.assert_not_called()
+        args, kwargs = cron_service.db.log_cron_finish.call_args
+        assert args[1] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Run log output + session linking
+# ---------------------------------------------------------------------------
+
+class TestRunLogOutput:
+    @pytest.mark.asyncio
+    async def test_stores_tail_of_long_response(self, cron_service):
+        long = "begin " + ("x" * 3000) + " THE END"
+        cron_service.engine.run_cron = AsyncMock(return_value=long)
+        job = _make_job()
+
+        await cron_service._run_job_inner(job)
+
+        kwargs = cron_service.db.log_cron_finish.call_args.kwargs
+        output = kwargs["output"]
+        assert output.endswith("THE END")
+        assert output.startswith("…")
+        assert len(output) <= 2001  # tail + ellipsis
+
+    @pytest.mark.asyncio
+    async def test_stores_short_response_verbatim(self, cron_service):
+        cron_service.engine.run_cron = AsyncMock(return_value="all done")
+        job = _make_job()
+
+        await cron_service._run_job_inner(job)
+
+        kwargs = cron_service.db.log_cron_finish.call_args.kwargs
+        assert kwargs["output"] == "all done"
+
+    @pytest.mark.asyncio
+    async def test_isolated_run_links_session_id(self, cron_service):
+        job = _make_job(id="iso-job")
+
+        await cron_service._run_job_inner(job)
+
+        run_id = cron_service.engine.run_cron.call_args.kwargs["run_id"]
+        assert run_id  # service always generates one
+        kwargs = cron_service.db.log_cron_finish.call_args.kwargs
+        assert kwargs["session_id"] == f"cron:iso-job:{run_id}"
+
+    @pytest.mark.asyncio
+    async def test_persistent_run_links_session_id(self, cron_service):
+        cron_service.db.get_session = AsyncMock(return_value=None)
+        job = _make_job(id="pers-job", session_mode="persistent", context_rotate_hours=0)
+
+        await cron_service._run_job_inner(job)
+
+        kwargs = cron_service.db.log_cron_finish.call_args.kwargs
+        assert kwargs["session_id"] == "cron:pers-job"
+
+    @pytest.mark.asyncio
+    async def test_error_run_still_links_session_id(self, cron_service):
+        cron_service.engine.run_cron = AsyncMock(side_effect=RuntimeError("boom"))
+        job = _make_job(id="err-job")
+
+        await cron_service._run_job_inner(job)
+
+        args, kwargs = cron_service.db.log_cron_finish.call_args
+        assert args[1] == "error"
+        assert kwargs["session_id"].startswith("cron:err-job:")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1280,3 +1280,67 @@ class TestConsumerCursors:
         cursors = await db.list_consumer_cursors()
         assert len(cursors) == 1
         assert cursors[0]["consumer"] == "active"
+
+
+class TestCronLogSessions:
+    """cron_logs.session_id linking (v33) + latest-session lookup."""
+
+    @pytest.mark.asyncio
+    async def test_log_cron_finish_stores_session_id(self, db: Database):
+        log_id = await db.log_cron_start("job-a")
+        await db.log_cron_finish(
+            log_id, "success", output="ok", session_id="cron:job-a:20260101-000000",
+        )
+        logs = await db.get_cron_logs(job_id="job-a")
+        assert logs[0]["session_id"] == "cron:job-a:20260101-000000"
+
+    @pytest.mark.asyncio
+    async def test_log_cron_finish_without_session_id(self, db: Database):
+        log_id = await db.log_cron_start("source:gmail")
+        await db.log_cron_finish(log_id, "success", output="3 ingested")
+        logs = await db.get_cron_logs(job_id="source:gmail")
+        assert logs[0]["session_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_latest_cron_session_per_run(self, db: Database):
+        await db.create_session("cron:job-a:20260101-000000", source="cron")
+        await db.create_session("cron:job-a:20260102-000000", source="cron")
+        await db.db.execute(
+            "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+            ("2026-01-01T00:00:10+00:00", "cron:job-a:20260101-000000"),
+        )
+        await db.db.execute(
+            "UPDATE sessions SET last_activity_at = ? WHERE id = ?",
+            ("2026-01-02T00:00:10+00:00", "cron:job-a:20260102-000000"),
+        )
+        await db.db.commit()
+
+        latest = await db.get_latest_cron_session_id("job-a")
+        assert latest == "cron:job-a:20260102-000000"
+
+    @pytest.mark.asyncio
+    async def test_latest_cron_session_persistent(self, db: Database):
+        await db.create_session("cron:job-b", source="cron")
+        latest = await db.get_latest_cron_session_id("job-b")
+        assert latest == "cron:job-b"
+
+    @pytest.mark.asyncio
+    async def test_latest_cron_session_no_prefix_bleed(self, db: Database):
+        """job-a must not match job-a-extended's sessions."""
+        await db.create_session("cron:job-a-extended:20260101-000000", source="cron")
+        assert await db.get_latest_cron_session_id("job-a") is None
+
+    @pytest.mark.asyncio
+    async def test_latest_cron_session_missing(self, db: Database):
+        assert await db.get_latest_cron_session_id("ghost") is None
+
+    @pytest.mark.asyncio
+    async def test_latest_cron_session_underscore_not_wildcard(self, db: Database):
+        """LIKE special chars in job ids must be escaped."""
+        await db.create_session("cron:jobXa:20260101-000000", source="cron")
+        assert await db.get_latest_cron_session_id("job_a") is None
+        await db.create_session("cron:job_a:20260102-000000", source="cron")
+        assert (
+            await db.get_latest_cron_session_id("job_a")
+            == "cron:job_a:20260102-000000"
+        )

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   RefreshCw, RotateCw, Play, Loader2, Clock, Inbox,
-  CheckCircle2, XCircle, Timer, Filter,
+  CheckCircle2, XCircle, Timer, Filter, MessageSquare, FileText,
 } from 'lucide-react';
 import { useCronStore, type CronJob, type CronLog } from '../stores/cronStore';
+
+/** Chat-page path for a session id. */
+function chatPath(sessionId: string): string {
+  return `/chat/${encodeURIComponent(sessionId)}`;
+}
 
 // --- Helpers ---
 
@@ -84,13 +90,10 @@ function jobTypeBadge(type: string) {
   );
 }
 
+/** Sidebar label: always the job name (id) — descriptions go in the tooltip. */
 function jobLabel(job: CronJob): string {
-  if (job.description) {
-    // Truncate long descriptions for sidebar
-    const desc = job.description.split('—')[0].split('–')[0].trim();
-    return desc.length > 24 ? desc.slice(0, 22) + '..' : desc;
-  }
-  return job.id;
+  // Source runner ids are prefixed (e.g. "source:gmail:user@x") — strip it.
+  return job.type === 'source' ? job.id.replace(/^source:/, '') : job.id;
 }
 
 // --- Trigger Button ---
@@ -107,6 +110,7 @@ function TriggerButton({ jobId, small = false }: { jobId: string; small?: boolea
 
   return (
     <button onClick={handleClick} disabled={isTriggering}
+      onAuxClick={(e) => e.stopPropagation()}
       className={`flex items-center gap-1 rounded transition-colors cursor-pointer shrink-0
         ${isTriggering ? 'text-text-faint cursor-not-allowed' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}
         ${small ? 'p-1' : 'px-2 py-1.5 text-[12px]'}`}
@@ -114,6 +118,25 @@ function TriggerButton({ jobId, small = false }: { jobId: string; small?: boolea
       {isTriggering ? <Loader2 size={small ? 12 : 14} className="animate-spin" /> : <Play size={small ? 12 : 14} />}
       {!small && !isTriggering && <span>Run</span>}
     </button>
+  );
+}
+
+// --- Chat Link ---
+
+/** Link to a cron's chat session. Renders an anchor so cmd/ctrl+click and
+ *  middle-click open a new tab natively. */
+function ChatLink({ sessionId, small = false, label }: { sessionId: string; small?: boolean; label?: string }) {
+  return (
+    <Link to={chatPath(sessionId)}
+      onClick={(e) => e.stopPropagation()}
+      onAuxClick={(e) => e.stopPropagation()}
+      className={`flex items-center gap-1 rounded transition-colors cursor-pointer shrink-0
+        text-text-muted hover:text-text-secondary hover:bg-surface-raised
+        ${small ? 'p-1' : 'px-2 py-1.5 text-[12px]'}`}
+      title="Open chat">
+      <MessageSquare size={small ? 12 : 14} />
+      {!small && <span>{label || 'Chat'}</span>}
+    </Link>
   );
 }
 
@@ -158,7 +181,22 @@ function CronSidebar() {
 
         {jobs.map(job => (
           <div key={job.id} className={`group ${!job.enabled ? 'opacity-50' : ''}`}>
-            <button onClick={() => selectJob(job.id)}
+            <button title={job.description || job.id}
+              onClick={(e) => {
+                // Cmd/ctrl+click opens the cron's chat in a new tab;
+                // plain click keeps the in-page select behaviour.
+                if ((e.metaKey || e.ctrlKey) && job.last_session_id) {
+                  window.open(chatPath(job.last_session_id), '_blank', 'noopener');
+                  return;
+                }
+                selectJob(job.id);
+              }}
+              onAuxClick={(e) => {
+                // Middle-click → new tab, like a link.
+                if (e.button === 1 && job.last_session_id) {
+                  window.open(chatPath(job.last_session_id), '_blank', 'noopener');
+                }
+              }}
               className={`w-full flex items-center justify-between px-2 py-1.5 rounded text-[13px] transition-colors cursor-pointer
                 ${selectedJobId === job.id ? 'bg-accent/15 text-accent' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}>
               <span className="flex items-center gap-2 min-w-0 truncate">
@@ -166,6 +204,11 @@ function CronSidebar() {
                 <span className="truncate">{jobLabel(job)}</span>
               </span>
               <span className="flex items-center gap-1 shrink-0">
+                {job.last_session_id && (
+                  <span className="opacity-0 group-hover:opacity-100 transition-opacity">
+                    <ChatLink sessionId={job.last_session_id} small />
+                  </span>
+                )}
                 {job.enabled && (
                   <span className="opacity-0 group-hover:opacity-100 transition-opacity">
                     <TriggerButton jobId={job.id} small />
@@ -215,13 +258,17 @@ function JobInfoCard({ job }: { job: CronJob }) {
           {job.description && (
             <div className="text-[13px] text-text-muted mt-1">{job.description}</div>
           )}
+          {job.prompt_file && (
+            <div className="text-[11px] text-text-dim mt-1 flex items-center gap-1 font-mono">
+              <FileText size={11} /> {job.prompt_file}
+            </div>
+          )}
         </div>
-        {job.enabled && (
-          <div className="flex items-center gap-1">
-            {job.session_mode === 'persistent' && <RotateButton jobId={job.id} />}
-            <TriggerButton jobId={job.id} />
-          </div>
-        )}
+        <div className="flex items-center gap-1">
+          {job.last_session_id && <ChatLink sessionId={job.last_session_id} label="Open Chat" />}
+          {job.enabled && job.session_mode === 'persistent' && <RotateButton jobId={job.id} />}
+          {job.enabled && <TriggerButton jobId={job.id} />}
+        </div>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
@@ -294,6 +341,7 @@ function LogsTable({ showJobColumn }: { showJobColumn: boolean }) {
             <th className="text-left px-3 py-2 font-medium">Duration</th>
             <th className="text-left px-3 py-2 font-medium">Status</th>
             <th className="text-left px-3 py-2 font-medium">Output</th>
+            <th className="w-8" aria-label="Chat" />
           </tr>
         </thead>
         <tbody>
@@ -349,10 +397,13 @@ function LogRow({ log, showJobColumn }: { log: CronLog; showJobColumn: boolean }
             {preview}{isLong && !expanded ? '…' : ''}
           </span>
         </td>
+        <td className="px-1 py-2">
+          {log.session_id && <ChatLink sessionId={log.session_id} small />}
+        </td>
       </tr>
       {expanded && hasOutput && (
         <tr className="bg-surface">
-          <td colSpan={showJobColumn ? 5 : 4} className="px-3 py-2">
+          <td colSpan={showJobColumn ? 6 : 5} className="px-3 py-2">
             <pre className="text-[12px] text-text-muted whitespace-pre-wrap break-words max-h-[200px] overflow-y-auto font-mono">
               {log.error ? `Error: ${log.error}` : log.output}
             </pre>

--- a/web/src/stores/cronStore.ts
+++ b/web/src/stores/cronStore.ts
@@ -6,11 +6,15 @@ export interface CronJob {
   type: 'cron' | 'source';
   schedule: string;
   description: string;
+  /** Prompt file path when the job's prompt is file-based. */
+  prompt_file?: string;
   enabled: boolean;
   session_mode?: string;
   /** Human-readable run-gate conditions; job runs only if all are satisfied. */
   gates?: string[];
   next_run: string | null;
+  /** Most recently active chat session for this job (cron:{id}[:{run}]). */
+  last_session_id?: string | null;
 }
 
 export interface CronLog {
@@ -21,6 +25,8 @@ export interface CronLog {
   status: string | null;
   output: string | null;
   error: string | null;
+  /** Session the run executed in — deep-links to the chat page. */
+  session_id?: string | null;
 }
 
 interface CronState {


### PR DESCRIPTION
## Summary

**1. `prompt_file` for cron jobs**
- Jobs can now point at a prompt file instead of (or alongside) an inline `prompt` — multiple crons can share one prompt definition.
- Relative paths resolve against the YAML's directory (e.g. `prompts/shared.md` next to `jobs.yaml`); `~` and absolute paths work.
- The file is read fresh on every run, so edits apply without a restart. Inline `prompt` acts as a fallback if the file is unreadable; a job must define at least one of the two.

**2. Cron page UX**
- Left panel now shows job **names** (ids) instead of truncated descriptions; the description moved to the tooltip. Source-runner ids drop the `source:` prefix.
- Run logs now store the **tail** of the agent response instead of the head — for multi-message runs the final summary lives at the end (`…` prefix marks truncation).
- **Chat deep-links**: added `cron_logs.session_id` (migration v33) + `last_session_id` in the jobs API. In the UI:
  - sidebar rows: chat icon on hover, cmd/ctrl+click or middle-click anywhere on the row opens the cron's chat in a new tab
  - job info card: "Open Chat" button
  - each log row: links to that specific run's session
- The isolated-mode `run_id` is now always generated by the service (the engine previously generated an identical timestamp-based one when it was omitted) so the session id is known for logging. This leaves `sessions.cron_session_mode` unreferenced — it was already effectively dead; left in config for compat.

Follow-up (per-run backfill, jobs overview, paginated history) continues in #107.

## Test plan
- [x] `pytest tests/` — 988 passed
- [x] `npm run build` + eslint clean

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*