### PR TITLE
Link cron run logs to their session at run start

### DIFF
--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -390,8 +390,28 @@ class CronService:
             rotated = False
             base_prompt = job.resolve_prompt()
 
+            # Determine the session id up front and link the run log to it
+            # immediately, so the UI can open the chat of a *running* cron
+            # instead of waiting for the run to finish.
+            run_id: str | None = None
             if job.session_mode == "persistent":
                 session_id = f"cron:{job.id}"
+            else:
+                # Isolated mode: per-run session. The run_id is generated
+                # here (the engine would otherwise generate an identical
+                # timestamp-based one) so the session id is known for the
+                # run log.
+                run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+                session_id = f"cron:{job.id}:{run_id}"
+            try:
+                await self.db.set_cron_log_session(log_id, session_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to link cron log %s to session %s: %s",
+                    log_id, session_id, e,
+                )
+
+            if job.session_mode == "persistent":
                 # Persistent mode: reuse SDK context across runs
                 if job.context_rotate_at or job.context_rotate_hours > 0:
                     rotated = await self._maybe_rotate_context(
@@ -428,12 +448,6 @@ class CronService:
                     model=model,
                 )
             else:
-                # Isolated mode: per-run session. The run_id is generated
-                # here (the engine would otherwise generate an identical
-                # timestamp-based one) so the session id is known for the
-                # run log.
-                run_id = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-                session_id = f"cron:{job.id}:{run_id}"
                 response = await self.engine.run_cron(
                     job_id=job.id,
                     prompt=base_prompt,

--- a/nerve/db/cron.py
+++ b/nerve/db/cron.py
@@ -16,6 +16,18 @@ class CronStore:
         await self.db.commit()
         return log_id
 
+    async def set_cron_log_session(self, log_id: int, session_id: str) -> None:
+        """Link a run log to its session while the run is still in flight.
+
+        Written at run start so the UI can open the chat of a running cron;
+        log_cron_finish keeps it as a fallback for older code paths.
+        """
+        await self.db.execute(
+            "UPDATE cron_logs SET session_id = ? WHERE id = ?",
+            (session_id, log_id),
+        )
+        await self.db.commit()
+
     async def log_cron_finish(
         self,
         log_id: int,

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -702,3 +702,69 @@ class TestRunLogOutput:
         args, kwargs = cron_service.db.log_cron_finish.call_args
         assert args[1] == "error"
         assert kwargs["session_id"].startswith("cron:err-job:")
+
+
+# ---------------------------------------------------------------------------
+# Live session linking (chat available while a run is in flight)
+# ---------------------------------------------------------------------------
+
+class TestLiveSessionLink:
+    @pytest.mark.asyncio
+    async def test_isolated_links_session_before_run(self, cron_service):
+        order: list[str] = []
+        cron_service.db.set_cron_log_session = AsyncMock(
+            side_effect=lambda *a, **k: order.append("link"),
+        )
+
+        async def _run(**kwargs):
+            order.append("run")
+            return "ok"
+
+        cron_service.engine.run_cron = AsyncMock(side_effect=_run)
+        job = _make_job(id="live-job")
+
+        await cron_service._run_job_inner(job)
+
+        assert order == ["link", "run"]
+        log_id, session_id = cron_service.db.set_cron_log_session.call_args.args
+        assert log_id == 1
+        assert session_id.startswith("cron:live-job:")
+        # Same session id must be used for the engine run
+        assert (
+            f"cron:live-job:{cron_service.engine.run_cron.call_args.kwargs['run_id']}"
+            == session_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_persistent_links_session_before_run(self, cron_service):
+        cron_service.db.get_session = AsyncMock(return_value=None)
+        job = _make_job(
+            id="pers-live", session_mode="persistent", context_rotate_hours=0,
+        )
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.db.set_cron_log_session.assert_awaited_once_with(
+            1, "cron:pers-live",
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_link_when_prompt_unresolvable(self, cron_service, tmp_path):
+        job = CronJob(id="bad", schedule="1h", prompt_file=str(tmp_path / "nope.md"))
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.db.set_cron_log_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_link_failure_does_not_break_run(self, cron_service):
+        cron_service.db.set_cron_log_session = AsyncMock(
+            side_effect=RuntimeError("db locked"),
+        )
+        job = _make_job(id="resilient")
+
+        await cron_service._run_job_inner(job)
+
+        cron_service.engine.run_cron.assert_called_once()
+        args, kwargs = cron_service.db.log_cron_finish.call_args
+        assert args[1] == "success"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1443,3 +1443,26 @@ class TestCronLogSessionBackfill:
 
         logs = await db.get_cron_logs(job_id="multi")
         assert logs[0]["session_id"] == "cron:multi:20260110-120130"
+
+
+class TestSetCronLogSession:
+    """Linking a run log to its session while the run is in flight."""
+
+    @pytest.mark.asyncio
+    async def test_set_cron_log_session_links_running_row(self, db: Database):
+        log_id = await db.log_cron_start("job-live")
+        await db.set_cron_log_session(log_id, "cron:job-live:20260610-120000")
+
+        logs = await db.get_cron_logs(job_id="job-live")
+        assert logs[0]["session_id"] == "cron:job-live:20260610-120000"
+        assert logs[0]["finished_at"] is None  # still running, already linked
+
+    @pytest.mark.asyncio
+    async def test_finish_keeps_start_link(self, db: Database):
+        """log_cron_finish must not clobber the link set at start."""
+        log_id = await db.log_cron_start("job-live2")
+        await db.set_cron_log_session(log_id, "cron:job-live2:20260610-130000")
+        await db.log_cron_finish(log_id, "success", output="done")
+
+        logs = await db.get_cron_logs(job_id="job-live2")
+        assert logs[0]["session_id"] == "cron:job-live2:20260610-130000"


### PR DESCRIPTION
## Summary

Follow-up to #107: the chat deep-link on a run row only appeared after the run **finished**, because `session_id` was written by `log_cron_finish`. For long-running crons that's exactly backwards — the in-flight run is the one you want to open and watch live.

- New `set_cron_log_session(log_id, session_id)`: the service computes the session id (persistent `cron:<job>` / isolated `cron:<job>:<run>`) right after prompt resolution and links the log row **before** starting the engine run. Link failures are logged and never break the run.
- `log_cron_finish` keeps its `COALESCE` write as a fallback and never clobbers the start-time link.
- If the prompt can't be resolved (run fails before a session would exist), no link is written — no dead links on early-error rows.

No frontend changes needed — the logs table already renders the chat icon whenever `session_id` is present; now it's present while the run is still going.

## Test plan
- [x] `pytest tests/` — 998 passed (new: link written before `run_cron`/`run_persistent_cron` with the same session id the engine uses; no link on unresolvable prompt; link failure doesn't break the run; finish doesn't clobber the start link)
- [ ] Live check: trigger a long cron, confirm the chat icon shows on the running row and opens the streaming session

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*