### PR TITLE
Don't block cron run lifecycle on memorization

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -297,6 +297,10 @@ class AgentEngine:
         self._xmemory_bridge = None
         self._skill_manager: SkillManager | None = None
         self._memorize_lock = asyncio.Lock()
+        # Background memorization tasks (see schedule_memorize) — strong
+        # refs so the tasks aren't GC'd mid-flight; pruned by their
+        # done-callbacks and flushed in shutdown().
+        self._memorize_bg_tasks: set[asyncio.Task] = set()
         self._session_locks: dict[str, asyncio.Lock] = {}
         # Idle stream watchers — one per live SDK client. Between run()
         # calls nothing reads the SDK message stream, but the CLI keeps
@@ -623,6 +627,17 @@ class AgentEngine:
         self.sessions._clients.clear()
         self.sessions._client_locks.clear()
 
+        # Cancel queued background memorizations — the periodic sweep
+        # re-indexes anything they would have covered (the watermark is
+        # only advanced after a successful pass).
+        for task in list(self._memorize_bg_tasks):
+            task.cancel()
+        if self._memorize_bg_tasks:
+            await asyncio.gather(
+                *self._memorize_bg_tasks, return_exceptions=True,
+            )
+        self._memorize_bg_tasks.clear()
+
         # Close the optional xmemory HTTP client (no-op when disabled).
         if self._xmemory_bridge is not None:
             try:
@@ -660,32 +675,50 @@ class AgentEngine:
     #  Memory bridge                                                       #
     # ------------------------------------------------------------------ #
 
-    async def _memorize_session(self, session_id: str) -> None:
+    async def _memorize_session(
+        self, session_id: str, connected_at_override: str | None = None,
+    ) -> None:
         """Index un-memorized messages from a session into memU.
 
         Uses the more recent of ``connected_at`` and ``last_memorized_at`` as
         the lower bound so already-indexed messages are never re-sent to memU.
+
+        ``connected_at_override`` replaces the live ``connected_at`` column as
+        the fallback lower bound.  Background memorizations (scheduled via
+        ``schedule_memorize``) pass the value frozen at scheduling time: by
+        the time the task acquires the global lock, the live column may have
+        been cleared (``mark_error``, context rotation) or reset by a newer
+        client — either of which would silently skip or shrink the window of
+        messages this memorization is meant to cover.
         """
         if not self._memory_bridge or not self._memory_bridge.available:
             return
 
-        session = await self.db.get_session(session_id)
-        connected_at = session.get("connected_at") if session else None
-        if not connected_at:
-            return
-
-        watermark = _normalize_ts(session.get("last_memorized_at") or "")
-        connected = _normalize_ts(connected_at)
-
-        # Pick effective lower bound: watermark wins when it's more recent
-        if watermark and watermark >= connected:
-            lower_bound = watermark
-            inclusive = False  # strict >: watermark message already indexed
-        else:
-            lower_bound = connected
-            inclusive = True   # >=: include messages from connection time
-
         async with self._memorize_lock:
+            # Session state (notably the last_memorized_at watermark) is
+            # read inside the lock: queued memorizations for the same
+            # session must each see the watermark advanced by the previous
+            # one, or they would re-index the same window and regress it.
+            session = await self.db.get_session(session_id)
+            connected_at = connected_at_override or (
+                session.get("connected_at") if session else None
+            )
+            if not connected_at:
+                return
+
+            watermark = _normalize_ts(
+                (session or {}).get("last_memorized_at") or "",
+            )
+            connected = _normalize_ts(connected_at)
+
+            # Pick effective lower bound: watermark wins when more recent
+            if watermark and watermark >= connected:
+                lower_bound = watermark
+                inclusive = False  # strict >: watermark msg already indexed
+            else:
+                lower_bound = connected
+                inclusive = True   # >=: include messages from connect time
+
             try:
                 messages = await self.db.get_messages(session_id, limit=10000)
 
@@ -721,6 +754,48 @@ class AgentEngine:
 
             except Exception as e:
                 logger.error("Failed to memorize session %s: %s", session_id, e)
+
+    async def schedule_memorize(self, session_id: str) -> None:
+        """Schedule memorization of ``session_id`` as a background task.
+
+        Memorization serialises on a single global lock and one pass can
+        take minutes (LLM-based indexing inside memU), so under load the
+        queue wait reaches tens of minutes.  Latency-sensitive callers —
+        cron-run teardown, error recovery, idle sweeps — must not block on
+        it: the messages are already persisted in the DB, so indexing can
+        happen whenever the queue drains.  If the process exits first, the
+        periodic memorization sweep re-indexes anything still uncovered
+        (the watermark is only advanced after a successful pass).
+
+        The session's current ``connected_at`` is frozen here and handed to
+        the task so the covered message window stays stable however the
+        session mutates while the task is queued (see
+        ``_memorize_session``).
+        """
+        if not self._memory_bridge or not self._memory_bridge.available:
+            return
+
+        session = await self.db.get_session(session_id)
+        connected_at = session.get("connected_at") if session else None
+        if not connected_at:
+            return
+
+        task = asyncio.create_task(
+            self._memorize_session(
+                session_id, connected_at_override=connected_at,
+            ),
+        )
+        self._memorize_bg_tasks.add(task)
+
+        def _done(t: asyncio.Task) -> None:
+            self._memorize_bg_tasks.discard(t)
+            if not t.cancelled() and t.exception() is not None:
+                logger.error(
+                    "Background memorization failed for session %s: %s",
+                    session_id, t.exception(),
+                )
+
+        task.add_done_callback(_done)
 
     async def _memorize_incremental(self, session_id: str) -> int:
         """Index only messages newer than last_memorized_at into memU.
@@ -1477,15 +1552,25 @@ class AgentEngine:
 
     async def _discard_client(
         self, session_id: str, clear_resume: bool = False,
+        background_memorize: bool = False,
     ) -> None:
         """Disconnect and remove a client.
 
         Args:
             clear_resume: If True, clear sdk_session_id (e.g., on error).
                          If False, keep it for future resume (e.g., on stop).
+            background_memorize: If True, schedule memorization as a
+                background task instead of awaiting it inline.
+                Memorization queues on a global lock, so awaiting it here
+                blocks the caller for the whole queue wait — for cron runs
+                that kept the run log "running" (and APScheduler skipping
+                subsequent fires) long after the agent turn had finished.
         """
         self._stop_idle_watcher(session_id)
-        await self._memorize_session(session_id)
+        if background_memorize:
+            await self.schedule_memorize(session_id)
+        else:
+            await self._memorize_session(session_id)
         client = self.sessions.remove_client(session_id)
 
         if clear_resume:
@@ -2457,7 +2542,7 @@ class AgentEngine:
                     session_id, cleanup_err,
                 )
             # Memorize in background — don't block the stop path
-            asyncio.create_task(self._memorize_session(session_id))
+            await self.schedule_memorize(session_id)
             return partial
 
         except Exception as e:
@@ -2495,8 +2580,11 @@ class AgentEngine:
                 )
 
             await broadcaster.broadcast_error(session_id, error_msg)
-            # Memorize before discarding client
-            await self._memorize_session(session_id)
+            # Schedule memorization BEFORE mark_error clears connected_at —
+            # the frozen bound keeps coverage intact.  Scheduled, not
+            # awaited: an inline memorize would hold the session lock for
+            # the whole memorize-queue wait, stalling queued user messages.
+            await self.schedule_memorize(session_id)
             # Clear resume — CLI state may be corrupted after error
             self._stop_idle_watcher(session_id)
             unregister_handler(session_id)
@@ -2886,7 +2974,9 @@ class AgentEngine:
                             "Discarding hung client for session %s "
                             "(autonomous turn stalled)", session_id,
                         )
-                        await self._discard_client(session_id)
+                        await self._discard_client(
+                            session_id, background_memorize=True,
+                        )
                         return
                     except asyncio.CancelledError:
                         current = asyncio.current_task()
@@ -2898,7 +2988,9 @@ class AgentEngine:
                             # state is inconsistent — discard, mirroring
                             # run()'s cancel path.
                             await self.sessions.mark_stopped(session_id)
-                            await self._discard_client(session_id)
+                            await self._discard_client(
+                                session_id, background_memorize=True,
+                            )
                             return
                         if not drain.done():
                             drain.cancel()
@@ -2942,7 +3034,10 @@ class AgentEngine:
                 model=model or self.config.agent.cron_model,
             )
         finally:
-            await self._discard_client(session_id)
+            # background_memorize: returning promptly closes the cron run
+            # log and frees APScheduler to fire the next run — memorization
+            # queues on a global lock and must not gate the run lifecycle.
+            await self._discard_client(session_id, background_memorize=True)
 
     async def run_persistent_cron(
         self,
@@ -2969,7 +3064,8 @@ class AgentEngine:
                 model=model or self.config.agent.cron_model,
             )
         finally:
-            await self._discard_client(session_id)
+            # See run_cron: memorization must not gate the run lifecycle.
+            await self._discard_client(session_id, background_memorize=True)
 
     async def run_hook(
         self,
@@ -2992,7 +3088,8 @@ class AgentEngine:
                 model=model or self.config.agent.cron_model,
             )
         finally:
-            await self._discard_client(session_id)
+            # See run_cron: memorization must not gate the run lifecycle.
+            await self._discard_client(session_id, background_memorize=True)
 
     # ------------------------------------------------------------------ #
     #  Idle client sweep                                                   #
@@ -3013,7 +3110,9 @@ class AgentEngine:
         idle_ids = self.sessions.get_idle_client_ids(timeout_minutes * 60)
         for sid in idle_ids:
             logger.info("Auto-closing idle client for session %s", sid)
-            await self._discard_client(sid)
+            # background_memorize: free the claude subprocess now; indexing
+            # follows whenever the memorize queue drains.
+            await self._discard_client(sid, background_memorize=True)
 
         if idle_ids:
             logger.info(

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -300,9 +300,13 @@ class CronService:
         if not should_rotate:
             return False
 
-        # Memorize current context before rotation (safety net)
+        # Schedule memorization of the pre-rotation context (safety net).
+        # Scheduled, not awaited: memorization queues on a global lock and
+        # awaiting it would delay the run start by the whole queue wait.
+        # The lower bound is frozen at scheduling time, so clearing
+        # connected_at below cannot shrink the covered window.
         try:
-            await self.engine._memorize_session(session_id)
+            await self.engine.schedule_memorize(session_id)
         except Exception as e:
             logger.warning("Pre-rotation memorize failed for %s: %s", session_id, e)
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -444,6 +444,43 @@ class TestJobLock:
 
 
 # ---------------------------------------------------------------------------
+# Context rotation — memorization must not block the run lifecycle
+# ---------------------------------------------------------------------------
+
+class TestRotationMemorize:
+    @pytest.mark.asyncio
+    async def test_rotation_schedules_background_memorize(self, cron_service):
+        """Rotation schedules memorization instead of awaiting it inline."""
+        cron_service.db.get_session = AsyncMock(return_value={
+            "connected_at": _hours_ago(30),
+        })
+
+        rotated = await cron_service._maybe_rotate_context(
+            "cron:pers", rotate_hours=24,
+        )
+
+        assert rotated is True
+        cron_service.engine.schedule_memorize.assert_awaited_once_with(
+            "cron:pers",
+        )
+        cron_service.engine._memorize_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_rotation_no_memorize(self, cron_service):
+        """A session younger than the rotation window is left alone."""
+        cron_service.db.get_session = AsyncMock(return_value={
+            "connected_at": _hours_ago(1),
+        })
+
+        rotated = await cron_service._maybe_rotate_context(
+            "cron:pers", rotate_hours=24,
+        )
+
+        assert rotated is False
+        cron_service.engine.schedule_memorize.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Run gates — service-level skip/run behaviour
 # ---------------------------------------------------------------------------
 

--- a/tests/test_memorize_background.py
+++ b/tests/test_memorize_background.py
@@ -1,0 +1,306 @@
+"""Tests for background memorization scheduling (engine.schedule_memorize).
+
+Memorization serialises on a single global lock and can take minutes per
+session.  Cron runs used to await it inline during client teardown, which
+kept the cron run log "running" (and APScheduler skipping subsequent
+fires) long after the agent turn had finished.  These tests pin the
+non-blocking behaviour and the frozen-``connected_at`` window semantics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nerve.agent.engine import AgentEngine
+
+_CONNECTED_AT = "2026-01-01T00:00:00+00:00"
+
+
+def _make_engine() -> AgentEngine:
+    """AgentEngine with mocked config/db — no initialize(), no IO."""
+    config = MagicMock()
+    config.sessions.sticky_period_minutes = 5
+    config.agent.max_concurrent = 3
+    config.mcp_servers = []
+    db = AsyncMock()
+    return AgentEngine(config, db)
+
+
+def _engine_with_bridge() -> AgentEngine:
+    engine = _make_engine()
+    engine._memory_bridge = MagicMock(available=True)
+    engine.db.get_session = AsyncMock(
+        return_value={"connected_at": _CONNECTED_AT},
+    )
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# schedule_memorize
+# ---------------------------------------------------------------------------
+
+class TestScheduleMemorize:
+    @pytest.mark.asyncio
+    async def test_passes_frozen_connected_at(self):
+        """The connected_at captured at scheduling time is handed to the task."""
+        engine = _engine_with_bridge()
+        engine._memorize_session = AsyncMock()
+
+        await engine.schedule_memorize("s1")
+        # Live session mutates after scheduling (e.g. mark_error clears it)
+        engine.db.get_session = AsyncMock(return_value={"connected_at": None})
+
+        await asyncio.gather(*engine._memorize_bg_tasks)
+        engine._memorize_session.assert_awaited_once_with(
+            "s1", connected_at_override=_CONNECTED_AT,
+        )
+
+    @pytest.mark.asyncio
+    async def test_noop_without_connected_at(self):
+        """Sessions that never connected have nothing to memorize."""
+        engine = _engine_with_bridge()
+        engine.db.get_session = AsyncMock(return_value={"connected_at": None})
+
+        await engine.schedule_memorize("s1")
+
+        assert not engine._memorize_bg_tasks
+
+    @pytest.mark.asyncio
+    async def test_noop_without_bridge(self):
+        engine = _make_engine()
+        engine._memory_bridge = None
+
+        await engine.schedule_memorize("s1")
+
+        assert not engine._memorize_bg_tasks
+        engine.db.get_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_task_pruned_after_completion(self):
+        """Done-callbacks remove finished tasks from the registry."""
+        engine = _engine_with_bridge()
+        engine._memorize_session = AsyncMock()
+
+        await engine.schedule_memorize("s1")
+        await asyncio.gather(*engine._memorize_bg_tasks)
+        await asyncio.sleep(0)  # let done-callbacks run
+
+        assert not engine._memorize_bg_tasks
+
+    @pytest.mark.asyncio
+    async def test_failed_task_pruned_and_logged(self):
+        """A failing memorization neither lingers nor raises into the caller."""
+        engine = _engine_with_bridge()
+        engine._memorize_session = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await engine.schedule_memorize("s1")
+        await asyncio.gather(*engine._memorize_bg_tasks, return_exceptions=True)
+        await asyncio.sleep(0)
+
+        assert not engine._memorize_bg_tasks
+
+
+# ---------------------------------------------------------------------------
+# _memorize_session — connected_at override semantics
+# ---------------------------------------------------------------------------
+
+class TestMemorizeSessionOverride:
+    @pytest.mark.asyncio
+    async def test_override_covers_window_after_connected_at_cleared(self):
+        """Frozen bound still indexes messages after the live column is gone."""
+        engine = _make_engine()
+        bridge = MagicMock(available=True)
+        bridge.memorize_conversation = AsyncMock()
+        engine._memory_bridge = bridge
+        # Live column already cleared (e.g. mark_error / rotation ran first)
+        engine.db.get_session = AsyncMock(return_value={
+            "connected_at": None, "last_memorized_at": None,
+        })
+        engine.db.get_messages = AsyncMock(return_value=[
+            {"created_at": "2026-01-01 00:05:00", "role": "user", "content": "hi"},
+        ])
+
+        await engine._memorize_session(
+            "s1", connected_at_override=_CONNECTED_AT,
+        )
+
+        bridge.memorize_conversation.assert_awaited_once()
+        sid, msgs = bridge.memorize_conversation.call_args.args
+        assert sid == "s1"
+        assert len(msgs) == 1
+        engine.db.update_session_fields.assert_awaited_once_with(
+            "s1", {"last_memorized_at": "2026-01-01 00:05:00"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_override_and_no_connected_at_skips(self):
+        engine = _make_engine()
+        bridge = MagicMock(available=True)
+        bridge.memorize_conversation = AsyncMock()
+        engine._memory_bridge = bridge
+        engine.db.get_session = AsyncMock(return_value={"connected_at": None})
+
+        await engine._memorize_session("s1")
+
+        bridge.memorize_conversation.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_watermark_read_after_lock(self):
+        """A queued memorize sees the watermark advanced by the previous one.
+
+        The session row is read inside the global lock — a second queued
+        task for the same session must not re-index the window the first
+        one covered (which would also regress the watermark).
+        """
+        engine = _make_engine()
+        bridge = MagicMock(available=True)
+        bridge.memorize_conversation = AsyncMock()
+        engine._memory_bridge = bridge
+
+        watermark = {"value": None}
+
+        async def get_session(_sid):
+            return {
+                "connected_at": _CONNECTED_AT,
+                "last_memorized_at": watermark["value"],
+            }
+
+        async def update_fields(_sid, fields):
+            watermark["value"] = fields["last_memorized_at"]
+
+        engine.db.get_session = AsyncMock(side_effect=get_session)
+        engine.db.update_session_fields = AsyncMock(side_effect=update_fields)
+        engine.db.get_messages = AsyncMock(return_value=[
+            {"created_at": "2026-01-01 00:05:00", "role": "user", "content": "hi"},
+            {"created_at": "2026-01-01 00:06:00", "role": "assistant", "content": "yo"},
+        ])
+
+        await asyncio.gather(
+            engine._memorize_session("s1", connected_at_override=_CONNECTED_AT),
+            engine._memorize_session("s1", connected_at_override=_CONNECTED_AT),
+        )
+
+        # First pass indexes both messages; second sees the watermark and
+        # finds nothing new.
+        bridge.memorize_conversation.assert_awaited_once()
+        assert watermark["value"] == "2026-01-01 00:06:00"
+
+
+# ---------------------------------------------------------------------------
+# _discard_client — background vs inline memorization
+# ---------------------------------------------------------------------------
+
+class TestDiscardClientMemorize:
+    @pytest.mark.asyncio
+    async def test_background_does_not_wait_for_memorize(self):
+        """Discard returns while the memorization is still queued/running."""
+        engine = _engine_with_bridge()
+        release = asyncio.Event()
+
+        async def slow_memorize(session_id, connected_at_override=None):
+            await release.wait()
+
+        engine._memorize_session = slow_memorize
+
+        await asyncio.wait_for(
+            engine._discard_client("s1", background_memorize=True),
+            timeout=1.0,
+        )
+
+        assert len(engine._memorize_bg_tasks) == 1
+        assert not next(iter(engine._memorize_bg_tasks)).done()
+
+        release.set()
+        await asyncio.gather(*engine._memorize_bg_tasks)
+
+    @pytest.mark.asyncio
+    async def test_inline_awaits_memorize(self):
+        """Default discard keeps the old synchronous behaviour."""
+        engine = _engine_with_bridge()
+        done: list[str] = []
+
+        async def memorize(session_id, connected_at_override=None):
+            done.append(session_id)
+
+        engine._memorize_session = memorize
+
+        await engine._discard_client("s1")
+
+        assert done == ["s1"]
+        assert not engine._memorize_bg_tasks
+
+
+# ---------------------------------------------------------------------------
+# Cron / hook teardown contract
+# ---------------------------------------------------------------------------
+
+class TestCronRunDiscard:
+    @pytest.mark.asyncio
+    async def test_run_cron_discards_with_background_memorize(self):
+        engine = _make_engine()
+        engine.sessions.create_cron_session = AsyncMock(
+            return_value={"id": "cron:job:1"},
+        )
+        engine.run = AsyncMock(return_value="done")
+        engine._discard_client = AsyncMock()
+
+        result = await engine.run_cron("job", "prompt")
+
+        assert result == "done"
+        engine._discard_client.assert_awaited_once_with(
+            "cron:job:1", background_memorize=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_persistent_cron_discards_with_background_memorize(self):
+        engine = _make_engine()
+        engine.sessions.get_or_create = AsyncMock(return_value={"id": "cron:job"})
+        engine.run = AsyncMock(return_value="done")
+        engine._discard_client = AsyncMock()
+
+        result = await engine.run_persistent_cron("job", "prompt")
+
+        assert result == "done"
+        engine._discard_client.assert_awaited_once_with(
+            "cron:job", background_memorize=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_cron_discards_even_on_error(self):
+        engine = _make_engine()
+        engine.sessions.create_cron_session = AsyncMock(
+            return_value={"id": "cron:job:1"},
+        )
+        engine.run = AsyncMock(side_effect=RuntimeError("boom"))
+        engine._discard_client = AsyncMock()
+
+        with pytest.raises(RuntimeError):
+            await engine.run_cron("job", "prompt")
+
+        engine._discard_client.assert_awaited_once_with(
+            "cron:job:1", background_memorize=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# shutdown — pending background memorizations are flushed
+# ---------------------------------------------------------------------------
+
+class TestShutdownFlush:
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_pending_memorize_tasks(self):
+        engine = _engine_with_bridge()
+
+        async def hang(session_id, connected_at_override=None):
+            await asyncio.Event().wait()
+
+        engine._memorize_session = hang
+        await engine.schedule_memorize("s1")
+        assert engine._memorize_bg_tasks
+
+        await engine.shutdown()
+
+        assert not engine._memorize_bg_tasks


### PR DESCRIPTION
## Problem

Cron jobs were stuck showing "running" long after their agent turn had finished — and the next scheduled runs silently never started.

Root cause: `run_cron` / `run_persistent_cron` / `run_hook` tear the client down in a `finally` via `_discard_client()`, whose first await is `_memorize_session()`. Memorization serialises on a single global lock (`_memorize_lock`), and one memU indexing pass takes 30–280s (LLM calls). On a deployment with many concurrent cron jobs the queue wait reaches tens of minutes. While a run waits in that queue:

- `log_cron_finish` hasn't run → the run-log row stays unfinished → UI shows "running" even though the claude CLI subprocess already exited;
- APScheduler's default `max_instances=1` sees the job callable still executing → subsequent fires are silently skipped ("maximum number of running instances reached").

Observed in production: a 30-min cron whose turn ended at 19:52:40 only "completed" at 20:15:54 — the memorize started the exact second the previous session's memorize released the lock — and the 19:30/20:00 ticks never fired.

## Fix

- New `engine.schedule_memorize(session_id)`: spawns memorization as a tracked background task. The session's `connected_at` is **frozen at scheduling time** and passed as `connected_at_override`, so mutations that clear or reset the live column while the task is queued (`mark_error`, context rotation, a newer client) can't shrink or skip the covered message window.
- `_discard_client(background_memorize=True)` for all latency-sensitive callers: cron/persistent-cron/hook teardown, idle-client sweep, hung-CLI discard. The cron run log now closes when the turn ends, and the next fire isn't blocked.
- Error path in `_run_inner` and the pre-rotation safety net in `CronService._maybe_rotate_context` also schedule instead of awaiting (an inline memorize there held the session lock / delayed the run start by the whole queue wait).
- `_memorize_session` now reads the session row (watermark) **inside** the global lock — queued memorizations for the same session see the watermark advanced by the previous one instead of re-indexing the same window and regressing it (this race predates the change via the stop-path `create_task`).
- `shutdown()` cancels queued background memorizations; the periodic sweep re-indexes anything they would have covered since the watermark only advances after a successful pass.

## Test plan

- [x] New `tests/test_memorize_background.py`: frozen-bound handoff, override semantics after `connected_at` is cleared, watermark-inside-lock (no double indexing), non-blocking discard, cron/hook teardown contract, shutdown flush.
- [x] `tests/test_cron.py`: rotation schedules background memorize instead of awaiting inline.
- [x] Full suite: 1014 passed.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*