### PR TITLE
Eliminate sync-in-async: dedicated memU loop, WAL, persistent vector index

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -465,7 +465,8 @@ class AgentEngine:
         logger.info("Worker onboarding: starting first-boot setup session")
 
         task_md = self.config.workspace / "TASK.md"
-        task_description = task_md.read_text(encoding="utf-8").strip()
+        raw_task = await asyncio.to_thread(task_md.read_text, encoding="utf-8")
+        task_description = raw_task.strip()
         # Strip the "# Task\n\n" prefix
         if task_description.startswith("# Task\n\n"):
             task_description = task_description[len("# Task\n\n"):]
@@ -644,6 +645,13 @@ class AgentEngine:
                 await self._xmemory_bridge.aclose()
             except Exception as e:  # pragma: no cover - defensive
                 logger.debug("Error closing xmemory bridge: %s", e)
+
+        # Stop the memU bridge's dedicated event-loop thread.
+        if self._memory_bridge is not None:
+            try:
+                await self._memory_bridge.shutdown()
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug("Error shutting down memU bridge: %s", e)
 
     # ------------------------------------------------------------------ #
     #  Channel router                                                      #
@@ -874,9 +882,10 @@ class AgentEngine:
                     sessions_indexed += 1
 
             # Release memory after the sweep — prevents RSS ratcheting
-            # from intermediate list[float]→numpy conversions and JSON parsing.
+            # from intermediate list[float]→numpy conversions and JSON
+            # parsing.  gc.collect can take 100ms+ — keep it off the loop.
             if self._memory_bridge:
-                self._memory_bridge._release_memory()
+                await asyncio.to_thread(self._memory_bridge._release_memory)
 
             stats = {
                 "sessions_scanned": len(sessions),

--- a/nerve/agent/tools/handlers/memory.py
+++ b/nerve/agent/tools/handlers/memory.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-import tempfile
 import time
 from pathlib import Path
 
@@ -266,6 +265,60 @@ async def session_context_handler(ctx: ToolContext, args: dict) -> ToolResult:
     return ToolResult.text("\n\n---\n\n".join(parts))
 
 
+def _fetch_history_rows(
+    db_path: str, date: str, end_date: str, limit: int,
+) -> list[dict]:
+    """Query items by happened_at range.  Sync — call via asyncio.to_thread.
+
+    ``date()`` on the column defeats any index, so this is a full scan of
+    memu_memory_items; with 20K+ rows it takes long enough to matter on
+    the event loop.
+    """
+    db = sqlite3.connect(db_path, timeout=10)
+    db.row_factory = sqlite3.Row
+    try:
+        rows = db.execute(
+            "SELECT id, memory_type, summary, happened_at FROM memu_memory_items "
+            "WHERE happened_at IS NOT NULL "
+            "AND date(happened_at) >= date(?) AND date(happened_at) <= date(?) "
+            "ORDER BY happened_at DESC "
+            "LIMIT ?",
+            (date, end_date, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        db.close()
+
+
+def _fetch_records_rows(
+    db_path: str, date: str, end_date: str, limit: int, include_updated: bool,
+) -> list[dict]:
+    """Query items by created/updated range.  Sync — call via asyncio.to_thread."""
+    db = sqlite3.connect(db_path, timeout=10)
+    db.row_factory = sqlite3.Row
+    try:
+        if include_updated:
+            query = (
+                "SELECT id, memory_type, summary, created_at, updated_at FROM memu_memory_items "
+                "WHERE (date(created_at) >= date(?) AND date(created_at) <= date(?)) "
+                "   OR (date(updated_at) >= date(?) AND date(updated_at) <= date(?) AND date(updated_at) != date(created_at)) "
+                "ORDER BY created_at DESC "
+                "LIMIT ?"
+            )
+            rows = db.execute(query, (date, end_date, date, end_date, limit)).fetchall()
+        else:
+            query = (
+                "SELECT id, memory_type, summary, created_at, updated_at FROM memu_memory_items "
+                "WHERE date(created_at) >= date(?) AND date(created_at) <= date(?) "
+                "ORDER BY created_at DESC "
+                "LIMIT ?"
+            )
+            rows = db.execute(query, (date, end_date, limit)).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        db.close()
+
+
 async def conversation_history_handler(ctx: ToolContext, args: dict) -> ToolResult:
     date = args["date"]
     end_date = args.get("end_date", "") or date
@@ -276,17 +329,9 @@ async def conversation_history_handler(ctx: ToolContext, args: dict) -> ToolResu
 
     try:
         db_path = _resolve_memu_db_path(ctx)
-        db = sqlite3.connect(db_path)
-        db.row_factory = sqlite3.Row
-        rows = db.execute(
-            "SELECT id, memory_type, summary, happened_at FROM memu_memory_items "
-            "WHERE happened_at IS NOT NULL "
-            "AND date(happened_at) >= date(?) AND date(happened_at) <= date(?) "
-            "ORDER BY happened_at DESC "
-            "LIMIT ?",
-            (date, end_date, limit),
-        ).fetchall()
-        db.close()
+        rows = await asyncio.to_thread(
+            _fetch_history_rows, db_path, date, end_date, limit,
+        )
 
         if not rows:
             label = f"{date}" + (f" to {end_date}" if end_date != date else "")
@@ -313,28 +358,10 @@ async def memory_records_by_date_handler(ctx: ToolContext, args: dict) -> ToolRe
 
     try:
         db_path = _resolve_memu_db_path(ctx)
-        db = sqlite3.connect(db_path)
-        db.row_factory = sqlite3.Row
-
-        if include_updated:
-            query = (
-                "SELECT id, memory_type, summary, created_at, updated_at FROM memu_memory_items "
-                "WHERE (date(created_at) >= date(?) AND date(created_at) <= date(?)) "
-                "   OR (date(updated_at) >= date(?) AND date(updated_at) <= date(?) AND date(updated_at) != date(created_at)) "
-                "ORDER BY created_at DESC "
-                "LIMIT ?"
-            )
-            rows = db.execute(query, (date, end_date, date, end_date, limit)).fetchall()
-        else:
-            query = (
-                "SELECT id, memory_type, summary, created_at, updated_at FROM memu_memory_items "
-                "WHERE date(created_at) >= date(?) AND date(created_at) <= date(?) "
-                "ORDER BY created_at DESC "
-                "LIMIT ?"
-            )
-            rows = db.execute(query, (date, end_date, limit)).fetchall()
-
-        db.close()
+        rows = await asyncio.to_thread(
+            _fetch_records_rows, db_path, date, end_date, limit,
+            bool(include_updated),
+        )
 
         if not rows:
             label = f"{date}" + (f" to {end_date}" if end_date != date else "")
@@ -367,9 +394,13 @@ async def memorize_handler(ctx: ToolContext, args: dict) -> ToolResult:
     memu_err: str | None = None
     try:
         mem_dir = Path("~/.nerve/memu-manual").expanduser()
-        mem_dir.mkdir(parents=True, exist_ok=True)
         mem_path = mem_dir / f"memorize-{int(time.time())}.txt"
-        mem_path.write_text(f"{memory_type}: {content}", encoding="utf-8")
+
+        def _write_memorize_file() -> None:
+            mem_dir.mkdir(parents=True, exist_ok=True)
+            mem_path.write_text(f"{memory_type}: {content}", encoding="utf-8")
+
+        await asyncio.to_thread(_write_memorize_file)
 
         memu_ok = await ctx.memory_bridge.memorize_file(str(mem_path), modality="document")
     except Exception as e:

--- a/nerve/agent/tools/handlers/plans.py
+++ b/nerve/agent/tools/handlers/plans.py
@@ -246,7 +246,9 @@ async def plan_approve_handler(ctx: ToolContext, args: dict) -> ToolResult:
     if task.get("file_path") and ctx.config:
         task_file = ctx.config.workspace / task["file_path"]
         if task_file.exists():
-            task_content = task_file.read_text(encoding="utf-8")
+            task_content = await asyncio.to_thread(
+                task_file.read_text, encoding="utf-8",
+            )
 
     if plan_type in ("skill-create", "skill-update"):
         prompt = (

--- a/nerve/agent/tools/handlers/skills.py
+++ b/nerve/agent/tools/handlers/skills.py
@@ -4,6 +4,7 @@ skill_run_script, skill_create, skill_update.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 
@@ -69,11 +70,15 @@ async def skill_get_handler(ctx: ToolContext, args: dict) -> ToolResult:
 
         if skill.has_scripts:
             scripts_dir = ctx.skill_manager.skills_dir / skill_id / "scripts"
-            scripts = sorted(
-                str(f.relative_to(scripts_dir))
-                for f in scripts_dir.rglob("*")
-                if f.is_file()
-            )
+
+            def _list_scripts() -> list[str]:
+                return sorted(
+                    str(f.relative_to(scripts_dir))
+                    for f in scripts_dir.rglob("*")
+                    if f.is_file()
+                )
+
+            scripts = await asyncio.to_thread(_list_scripts)
             if scripts:
                 parts.append(f"\n**Scripts available** (use `skill_run_script` to execute):")
                 for s in scripts:

--- a/nerve/agent/tools/handlers/sources.py
+++ b/nerve/agent/tools/handlers/sources.py
@@ -8,7 +8,6 @@ trigger any actual sync work (that's the cron-driven source runners).
 from __future__ import annotations
 
 import logging
-import sqlite3
 from datetime import datetime, timezone
 
 from nerve.agent.tools.registry import ToolContext, ToolResult, ToolSpec
@@ -97,16 +96,11 @@ async def sync_status_handler(ctx: ToolContext, args: dict) -> ToolResult:
         return ToolResult.text("Database not available.")
 
     if source == "all":
-        # Collate known sources from sync_cursors + source_run_log.
+        # Collate known sources from sync_cursors + source_run_log
+        # (async DB layer — never raw sqlite3 on the event loop).
         known: set[str] = set()
         try:
-            db_path = str(ctx.db.db_path)
-            conn = sqlite3.connect(db_path)
-            for row in conn.execute("SELECT DISTINCT source FROM sync_cursors"):
-                known.add(row[0])
-            for row in conn.execute("SELECT DISTINCT source FROM source_run_log"):
-                known.add(row[0])
-            conn.close()
+            known = set(await ctx.db.get_known_source_names())
         except Exception:
             pass
         # Always include the base types

--- a/nerve/agent/tools/handlers/tasks.py
+++ b/nerve/agent/tools/handlers/tasks.py
@@ -11,6 +11,7 @@ all sessions).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from datetime import datetime, timezone
@@ -210,7 +211,9 @@ async def task_create_handler(ctx: ToolContext, args: dict) -> ToolResult:
     md_parts.append("\n## Updates\n")
     md_parts.append(f"- {datetime.now(timezone.utc).strftime('%Y-%m-%d')}: Created")
 
-    file_path.write_text("\n".join(md_parts), encoding="utf-8")
+    await asyncio.to_thread(
+        file_path.write_text, "\n".join(md_parts), encoding="utf-8",
+    )
 
     if ctx.db:
         rel_path = str(file_path.relative_to(ctx.workspace)) if ctx.workspace else str(file_path)
@@ -313,7 +316,9 @@ async def task_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
         if ctx.workspace and (note or deadline or raw_tags or new_title):
             file_path = ctx.workspace / task["file_path"]
             if file_path.exists():
-                content = file_path.read_text(encoding="utf-8")
+                content = await asyncio.to_thread(
+                    file_path.read_text, encoding="utf-8",
+                )
                 if new_title:
                     content = re.sub(r"^# .+", f"# {new_title}", content, count=1)
                     await ctx.db.upsert_task(
@@ -349,7 +354,9 @@ async def task_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
                         )
                         if "**Tags:**" not in content:
                             content = content.replace("\n\n", f"\n**Tags:** {display_tags}\n\n", 1)
-                file_path.write_text(content, encoding="utf-8")
+                await asyncio.to_thread(
+                    file_path.write_text, content, encoding="utf-8",
+                )
 
     return ToolResult.text(f"Task {task_id} updated.")
 
@@ -365,7 +372,9 @@ async def task_read_handler(ctx: ToolContext, args: dict) -> ToolResult:
         if ctx.workspace:
             file_path = ctx.workspace / task["file_path"]
             if file_path.exists():
-                content = file_path.read_text(encoding="utf-8")
+                content = await asyncio.to_thread(
+                    file_path.read_text, encoding="utf-8",
+                )
                 _tasks_read.add(task_id)
                 return ToolResult.text(content)
 
@@ -395,7 +404,7 @@ async def task_write_handler(ctx: ToolContext, args: dict) -> ToolResult:
         return ToolResult.text("Workspace not configured.")
 
     file_path = ctx.workspace / task["file_path"]
-    file_path.write_text(new_content, encoding="utf-8")
+    await asyncio.to_thread(file_path.write_text, new_content, encoding="utf-8")
 
     from nerve.tasks.models import (
         parse_task_frontmatter,
@@ -444,7 +453,7 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
         if ctx.workspace:
             src = ctx.workspace / task["file_path"]
             if src.exists():
-                content = src.read_text(encoding="utf-8")
+                content = await asyncio.to_thread(src.read_text, encoding="utf-8")
                 today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
                 if note:
                     content += f"\n- {today}: DONE — {note}"
@@ -452,8 +461,12 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
                     content += f"\n- {today}: DONE"
 
                 dst = _done_dir(ctx) / src.name
-                dst.write_text(content, encoding="utf-8")
-                src.unlink()
+
+                def _move_to_done() -> None:
+                    dst.write_text(content, encoding="utf-8")
+                    src.unlink()
+
+                await asyncio.to_thread(_move_to_done)
 
                 rel_path = str(dst.relative_to(ctx.workspace))
                 await ctx.db.upsert_task(

--- a/nerve/db/base.py
+++ b/nerve/db/base.py
@@ -130,7 +130,9 @@ class Database(
                 try:
                     fp = workspace / row["file_path"]
                     if fp.exists():
-                        content = fp.read_text(encoding="utf-8")
+                        content = await asyncio.to_thread(
+                            fp.read_text, encoding="utf-8",
+                        )
                 except Exception as e:
                     logger.warning("Failed to read %s for FTS reseed: %s", row["file_path"], e)
                 await self.db.execute(

--- a/nerve/gateway/routes/files.py
+++ b/nerve/gateway/routes/files.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 import uuid
@@ -86,7 +87,7 @@ async def upload_files(
         file_type = _classify_file(media_type)
 
         disk_path = upload_dir / f"{file_id}_{filename}"
-        disk_path.write_bytes(data)
+        await asyncio.to_thread(disk_path.write_bytes, data)
 
         await deps.db.save_uploaded_file(
             file_id=file_id,

--- a/nerve/gateway/routes/memory.py
+++ b/nerve/gateway/routes/memory.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
 
 from nerve.config import get_config
@@ -20,31 +23,39 @@ router = APIRouter()
 
 # --- Memory files ---
 
+def _list_memory_files_sync(workspace: Path) -> list[dict]:
+    """Walk + stat memory markdown files.  Sync — call via asyncio.to_thread."""
+    files = []
+    memory_dir = workspace / "memory"
+    if memory_dir.exists():
+        for f in sorted(memory_dir.rglob("*.md")):
+            rel = f.relative_to(workspace)
+            st = f.stat()
+            files.append({
+                "path": str(rel),
+                "name": f.name,
+                "size": st.st_size,
+                "modified": datetime.fromtimestamp(st.st_mtime, timezone.utc).isoformat(),
+            })
+
+    # Also include root-level md files
+    for f in sorted(workspace.glob("*.md")):
+        st = f.stat()
+        files.append({
+            "path": f.name,
+            "name": f.name,
+            "size": st.st_size,
+            "modified": datetime.fromtimestamp(st.st_mtime, timezone.utc).isoformat(),
+        })
+
+    return files
+
+
 @router.get("/api/memory/files")
 async def list_memory_files(user: dict = Depends(require_auth)):
     """List markdown files in workspace memory directory."""
     config = get_config()
-    memory_dir = config.workspace / "memory"
-    files = []
-    if memory_dir.exists():
-        for f in sorted(memory_dir.rglob("*.md")):
-            rel = f.relative_to(config.workspace)
-            files.append({
-                "path": str(rel),
-                "name": f.name,
-                "size": f.stat().st_size,
-                "modified": datetime.fromtimestamp(f.stat().st_mtime, timezone.utc).isoformat(),
-            })
-
-    # Also include root-level md files
-    for f in sorted(config.workspace.glob("*.md")):
-        files.append({
-            "path": f.name,
-            "name": f.name,
-            "size": f.stat().st_size,
-            "modified": datetime.fromtimestamp(f.stat().st_mtime, timezone.utc).isoformat(),
-        })
-
+    files = await asyncio.to_thread(_list_memory_files_sync, config.workspace)
     return {"files": files}
 
 
@@ -52,14 +63,14 @@ async def list_memory_files(user: dict = Depends(require_auth)):
 async def read_memory_file(file_path: str, user: dict = Depends(require_auth)):
     config = get_config()
     full_path = config.workspace / file_path
-    if not full_path.exists() or not full_path.is_file():
-        raise HTTPException(status_code=404, detail="File not found")
     # Prevent path traversal
     try:
         full_path.resolve().relative_to(config.workspace.resolve())
     except ValueError:
         raise HTTPException(status_code=403, detail="Access denied")
-    content = full_path.read_text(encoding="utf-8")
+    if not full_path.exists() or not full_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    content = await asyncio.to_thread(full_path.read_text, encoding="utf-8")
     return {"path": file_path, "content": content}
 
 
@@ -75,8 +86,12 @@ async def write_memory_file(file_path: str, req: FileWriteRequest, user: dict = 
         full_path.resolve().relative_to(config.workspace.resolve())
     except ValueError:
         raise HTTPException(status_code=403, detail="Access denied")
-    full_path.parent.mkdir(parents=True, exist_ok=True)
-    full_path.write_text(req.content, encoding="utf-8")
+
+    def _write() -> None:
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(req.content, encoding="utf-8")
+
+    await asyncio.to_thread(_write)
     return {"path": file_path, "saved": True}
 
 
@@ -89,22 +104,16 @@ def _require_memu():
     return deps.engine._memory_bridge
 
 
-@router.get("/api/memory/memu")
-async def get_memu_data(user: dict = Depends(require_auth)):
-    """Get memU categories and items for the memory UI."""
-    deps = get_deps()
-    if not deps.engine or not hasattr(deps.engine, '_memory_bridge') or not deps.engine._memory_bridge or not deps.engine._memory_bridge.available:
-        return {"available": False, "categories": [], "items": [], "resources": []}
+def _read_memu_snapshot_sync(db_path: str) -> str:
+    """Read the full memU snapshot and JSON-encode it.
 
-    config = get_config()
-    dsn = config.memory.sqlite_dsn
-    # Extract file path from sqlite:///path
-    db_path = dsn.replace("sqlite:///", "")
-
+    Sync — call via asyncio.to_thread.  With 20K+ items this is a multi-MB
+    payload; both the table scans AND the json.dumps are deliberately done
+    in the worker thread so the event loop never pays for them.
+    """
+    db = sqlite3.connect(db_path, timeout=10)
+    db.row_factory = sqlite3.Row
     try:
-        db = sqlite3.connect(db_path)
-        db.row_factory = sqlite3.Row
-
         categories = []
         for row in db.execute("SELECT id, name, description, summary FROM memu_memory_categories ORDER BY name"):
             categories.append({
@@ -139,16 +148,33 @@ async def get_memu_data(user: dict = Depends(require_auth)):
         cat_items: dict[str, list[str]] = {}
         for row in db.execute("SELECT category_id, item_id FROM memu_category_items"):
             cat_items.setdefault(row["category_id"], []).append(row["item_id"])
-
+    finally:
         db.close()
 
-        return {
-            "available": True,
-            "categories": categories,
-            "items": items,
-            "resources": resources,
-            "category_items": cat_items,
-        }
+    return json.dumps({
+        "available": True,
+        "categories": categories,
+        "items": items,
+        "resources": resources,
+        "category_items": cat_items,
+    })
+
+
+@router.get("/api/memory/memu")
+async def get_memu_data(user: dict = Depends(require_auth)):
+    """Get memU categories and items for the memory UI."""
+    deps = get_deps()
+    if not deps.engine or not hasattr(deps.engine, '_memory_bridge') or not deps.engine._memory_bridge or not deps.engine._memory_bridge.available:
+        return {"available": False, "categories": [], "items": [], "resources": []}
+
+    config = get_config()
+    dsn = config.memory.sqlite_dsn
+    # Extract file path from sqlite:///path
+    db_path = dsn.replace("sqlite:///", "")
+
+    try:
+        payload = await asyncio.to_thread(_read_memu_snapshot_sync, db_path)
+        return Response(content=payload, media_type="application/json")
     except Exception as e:
         logger.error("Failed to read memU data: %s", e)
         return {"available": False, "categories": [], "items": [], "resources": [], "error": str(e)}

--- a/nerve/gateway/routes/plans.py
+++ b/nerve/gateway/routes/plans.py
@@ -180,7 +180,9 @@ async def approve_plan(
     if task.get("file_path"):
         task_file = config.workspace / task["file_path"]
         if task_file.exists():
-            task_content = task_file.read_text(encoding="utf-8")
+            task_content = await asyncio.to_thread(
+                task_file.read_text, encoding="utf-8",
+            )
 
     # Build implementation prompt — skill-aware
     if plan_type in ("skill-create", "skill-update"):

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -280,7 +280,9 @@ async def get_modified_files(session_id: str, user: dict = Depends(require_auth)
         file_path = snap["file_path"]
         # Read current content from disk
         try:
-            current = Path(file_path).read_text(encoding="utf-8", errors="replace")
+            current = await asyncio.to_thread(
+                Path(file_path).read_text, encoding="utf-8", errors="replace",
+            )
         except (FileNotFoundError, OSError):
             current = None
 
@@ -288,7 +290,7 @@ async def get_modified_files(session_id: str, user: dict = Depends(require_auth)
         full_snap = await deps.db.get_file_snapshot(session_id, file_path)
         original = full_snap["original_content"] if full_snap else None
 
-        stats = compute_quick_stats(original, current)
+        stats = await asyncio.to_thread(compute_quick_stats, original, current)
         total_add += stats["additions"]
         total_del += stats["deletions"]
 
@@ -344,14 +346,18 @@ async def get_file_diff(
 
     # Read current file from disk
     try:
-        current = Path(path).read_text(encoding="utf-8", errors="replace")
+        current = await asyncio.to_thread(
+            Path(path).read_text, encoding="utf-8", errors="replace",
+        )
     except (FileNotFoundError, OSError):
         current = None
 
     from nerve.gateway.diff import compute_file_diff
 
     config = get_config()
-    diff = compute_file_diff(
+    # Diffing large files is CPU-bound — off the event loop.
+    diff = await asyncio.to_thread(
+        compute_file_diff,
         original_content=original,
         current_content=current,
         file_path=path,

--- a/nerve/gateway/routes/tasks.py
+++ b/nerve/gateway/routes/tasks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
@@ -111,7 +113,7 @@ async def get_task(task_id: str, user: dict = Depends(require_auth)):
     file_path = config.workspace / task["file_path"]
     content = ""
     if file_path.exists():
-        content = file_path.read_text(encoding="utf-8")
+        content = await asyncio.to_thread(file_path.read_text, encoding="utf-8")
     return {**dict(task), "content": content}
 
 
@@ -128,7 +130,9 @@ async def update_task(task_id: str, req: TaskUpdateRequest, user: dict = Depends
         config = get_config()
         file_path = config.workspace / task["file_path"]
         if file_path.exists():
-            file_path.write_text(req.content, encoding="utf-8")
+            await asyncio.to_thread(
+                file_path.write_text, req.content, encoding="utf-8",
+            )
             # Re-sync title from markdown to SQLite
             from nerve.tasks.models import parse_task_title, parse_task_frontmatter
             new_title = parse_task_title(req.content)

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -650,14 +650,17 @@ async def _load_uploaded_files(
             logger.warning("Uploaded file not found on disk: %s", disk_path)
             continue
 
-        data = disk_path.read_bytes()
+        # Multi-MB reads + base64 of uploads are blocking — off the loop.
+        data = await asyncio.to_thread(disk_path.read_bytes)
         file_type = rec["file_type"]
         media_type = rec["media_type"]
         file_id = rec["id"]
         filename = rec["filename"]
 
         if file_type in ("image", "pdf"):
-            b64 = base64.b64encode(data).decode("utf-8")
+            b64 = await asyncio.to_thread(
+                lambda d=data: base64.b64encode(d).decode("utf-8"),
+            )
             images.append({
                 "type": "base64",
                 "media_type": media_type,

--- a/nerve/houseofagents/runner.py
+++ b/nerve/houseofagents/runner.py
@@ -62,57 +62,61 @@ async def _tail_session_jsonl(
 
     logger.info("Tailing inner session %s → %s", inner_session_id, jsonl_path)
 
+    def _read_new(pos: int) -> tuple[str, int]:
+        """Read appended JSONL content from ``pos``.  Sync — runs in a thread."""
+        with open(jsonl_path, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(pos)
+            return f.read(), f.tell()
+
     last_pos = 0
     while True:
         try:
-            stat = jsonl_path.stat()
+            stat = await asyncio.to_thread(jsonl_path.stat)
             if stat.st_size > last_pos:
-                with open(jsonl_path, "r", encoding="utf-8", errors="replace") as f:
-                    f.seek(last_pos)
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            msg = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
+                chunk, last_pos = await asyncio.to_thread(_read_new, last_pos)
+                for line in chunk.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        msg = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
 
-                        # Only forward assistant tool_use entries
-                        if msg.get("type") != "assistant":
+                    # Only forward assistant tool_use entries
+                    if msg.get("type") != "assistant":
+                        continue
+                    content = msg.get("message", {}).get("content", [])
+                    if not isinstance(content, list):
+                        continue
+                    for block in content:
+                        if block.get("type") != "tool_use":
                             continue
-                        content = msg.get("message", {}).get("content", [])
-                        if not isinstance(content, list):
-                            continue
-                        for block in content:
-                            if block.get("type") != "tool_use":
-                                continue
-                            name = block.get("name", "?")
-                            inp = block.get("input", {})
-                            # Build a concise summary
-                            if name == "Bash":
-                                detail = str(inp.get("command", ""))[:120]
-                            elif name in ("Read", "Write", "Edit"):
-                                detail = str(inp.get("file_path", ""))[:100]
-                            elif name in ("Glob", "Grep"):
-                                detail = str(inp.get("pattern", inp.get("path", "")))[:100]
-                            elif name == "Task":
-                                detail = str(inp.get("description", ""))[:80]
-                            else:
-                                detail = str(inp)[:80]
+                        name = block.get("name", "?")
+                        inp = block.get("input", {})
+                        # Build a concise summary
+                        if name == "Bash":
+                            detail = str(inp.get("command", ""))[:120]
+                        elif name in ("Read", "Write", "Edit"):
+                            detail = str(inp.get("file_path", ""))[:100]
+                        elif name in ("Glob", "Grep"):
+                            detail = str(inp.get("pattern", inp.get("path", "")))[:100]
+                        elif name == "Task":
+                            detail = str(inp.get("description", ""))[:80]
+                        else:
+                            detail = str(inp)[:80]
 
-                            await broadcaster.broadcast(nerve_session_id, {
-                                "type": "hoa_progress",
-                                "session_id": nerve_session_id,
-                                "event": {
-                                    "event": "tool_call",
-                                    "label": block_label,
-                                    "agent": "Claude",
-                                    "tool": name,
-                                    "detail": detail,
-                                },
-                            })
-                    last_pos = f.tell()
+                        await broadcaster.broadcast(nerve_session_id, {
+                            "type": "hoa_progress",
+                            "session_id": nerve_session_id,
+                            "event": {
+                                "event": "tool_call",
+                                "label": block_label,
+                                "agent": "Claude",
+                                "tool": name,
+                                "detail": detail,
+                            },
+                        })
         except FileNotFoundError:
             pass
         except asyncio.CancelledError:

--- a/nerve/houseofagents/service.py
+++ b/nerve/houseofagents/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import os
@@ -104,22 +105,24 @@ class HoAService:
             resp.raise_for_status()
             archive_bytes = resp.content
 
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        def _extract_and_install() -> None:
+            """Untar + write the binary (CPU + disk) — off the event loop."""
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
+                binary_member = None
+                for member in tar.getmembers():
+                    if member.name.endswith("houseofagents") and member.isfile():
+                        binary_member = member
+                        break
+                if binary_member is None:
+                    raise RuntimeError("houseofagents binary not found in archive")
+                extracted = tar.extractfile(binary_member)
+                if extracted is None:
+                    raise RuntimeError("Failed to extract houseofagents")
+                dest.write_bytes(extracted.read())
+            dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
-            binary_member = None
-            for member in tar.getmembers():
-                if member.name.endswith("houseofagents") and member.isfile():
-                    binary_member = member
-                    break
-            if binary_member is None:
-                raise RuntimeError("houseofagents binary not found in archive")
-            extracted = tar.extractfile(binary_member)
-            if extracted is None:
-                raise RuntimeError("Failed to extract houseofagents")
-            dest.write_bytes(extracted.read())
-
-        dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        await asyncio.to_thread(_extract_and_install)
         logger.info("Installed houseofagents to %s", dest)
 
     async def _cargo_install(self, dest: Path) -> None:

--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -11,12 +11,13 @@ import ctypes
 import gc
 import json
 import logging
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Coroutine
 from zoneinfo import ZoneInfo
 
 import numpy as np
@@ -63,6 +64,194 @@ def _category_breadcrumb(name: str, description: str, summary: str) -> str:
     if len(text) > _CATEGORY_BREADCRUMB_MAXLEN:
         text = text[: _CATEGORY_BREADCRUMB_MAXLEN - 1].rstrip() + "…"
     return text
+
+
+class _VectorIndex:
+    """Incremental brute-force vector index over memU item embeddings.
+
+    ``cosine_topk`` re-stacks every embedding into a fresh ``(n, dim)``
+    matrix on each call — ~130 MB of allocation+copy per search with 20K+
+    items.  This index keeps ONE persistent float32 matrix (amortised
+    capacity growth), appends rows as items are created, and answers
+    similarity queries with a single mat-vec.
+
+    Not thread-safe by itself — all mutations and searches happen on the
+    dedicated memU event-loop thread, which serialises access.
+    """
+
+    __slots__ = (
+        "count", "capacity", "dim", "matrix", "norms", "ids", "types",
+        "id_to_row", "seen_items_len", "dirty",
+    )
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.capacity = 0
+        self.dim = 0
+        self.matrix: np.ndarray | None = None
+        self.norms: np.ndarray | None = None
+        self.ids: list[str] = []
+        self.types: np.ndarray | None = None  # dtype='U32', parallel to rows
+        self.id_to_row: dict[str, int] = {}
+        # Snapshot of len(repo.items) at last sync — drift triggers rebuild.
+        self.seen_items_len = -1
+        self.dirty = True
+
+    def _ensure_capacity(self, extra: int = 1) -> None:
+        needed = self.count + extra
+        if self.matrix is not None and needed <= self.capacity:
+            return
+        new_cap = max(256, needed, int(self.capacity * 3 // 2))
+        new_matrix = np.zeros((new_cap, self.dim), dtype=np.float32)
+        new_norms = np.zeros(new_cap, dtype=np.float32)
+        new_types = np.zeros(new_cap, dtype="U32")
+        if self.matrix is not None and self.count:
+            new_matrix[: self.count] = self.matrix[: self.count]
+            new_norms[: self.count] = self.norms[: self.count]
+            new_types[: self.count] = self.types[: self.count]
+        self.matrix, self.norms, self.types = new_matrix, new_norms, new_types
+        self.capacity = new_cap
+
+    @staticmethod
+    def _as_vec(embedding: Any) -> np.ndarray | None:
+        if embedding is None:
+            return None
+        try:
+            vec = np.asarray(embedding, dtype=np.float32)
+        except (ValueError, TypeError):
+            return None
+        if vec.ndim != 1 or not vec.size:
+            return None
+        return vec
+
+    def build(self, items: dict[str, Any]) -> None:
+        """(Re)build the index from the repo's in-memory item cache."""
+        rows: list[tuple[str, str, np.ndarray]] = []
+        dim = 0
+        for item_id, item in items.items():
+            vec = self._as_vec(getattr(item, "embedding", None))
+            if vec is None:
+                continue
+            if not dim:
+                dim = int(vec.shape[0])
+            if vec.shape[0] != dim:
+                continue  # mixed dims — skip outliers
+            rows.append((item_id, str(getattr(item, "memory_type", "")), vec))
+
+        self.dim = dim
+        self.count = len(rows)
+        self.capacity = max(256, self.count * 3 // 2)
+        self.ids = [r[0] for r in rows]
+        self.id_to_row = {item_id: i for i, (item_id, _, _) in enumerate(rows)}
+        if dim:
+            self.matrix = np.zeros((self.capacity, dim), dtype=np.float32)
+            self.norms = np.zeros(self.capacity, dtype=np.float32)
+            self.types = np.zeros(self.capacity, dtype="U32")
+            for i, (_, mtype, vec) in enumerate(rows):
+                self.matrix[i] = vec
+                self.types[i] = mtype
+            self.norms[: self.count] = np.linalg.norm(
+                self.matrix[: self.count], axis=1,
+            )
+        else:
+            self.matrix = self.norms = self.types = None
+            self.capacity = 0
+        self.seen_items_len = len(items)
+        self.dirty = False
+
+    def upsert(self, item_id: str, memory_type: str, embedding: Any) -> None:
+        vec = self._as_vec(embedding)
+        if vec is None:
+            return
+        if not self.dim:
+            self.dim = int(vec.shape[0])
+        if vec.shape[0] != self.dim:
+            self.dirty = True  # dim change — force rebuild on next search
+            return
+        row = self.id_to_row.get(item_id)
+        if row is None:
+            self._ensure_capacity()
+            row = self.count
+            self.count += 1
+            self.ids.append(item_id)
+            self.id_to_row[item_id] = row
+        self.matrix[row] = vec
+        self.norms[row] = float(np.linalg.norm(vec))
+        self.types[row] = memory_type
+
+    def remove(self, item_id: str) -> None:
+        row = self.id_to_row.pop(item_id, None)
+        if row is None:
+            return
+        last = self.count - 1
+        if row != last:
+            self.matrix[row] = self.matrix[last]
+            self.norms[row] = self.norms[last]
+            self.types[row] = self.types[last]
+            moved_id = self.ids[last]
+            self.ids[row] = moved_id
+            self.id_to_row[moved_id] = row
+        self.ids.pop()
+        self.count = last
+
+    def search(
+        self, query_vec: Any, k: int, memory_type: str | None = None,
+    ) -> list[tuple[str, float]]:
+        """Cosine top-k via one mat-vec over the persistent matrix."""
+        if not self.count or self.matrix is None:
+            return []
+        q = self._as_vec(query_vec)
+        if q is None or q.shape[0] != self.dim:
+            return []
+        q_norm = float(np.linalg.norm(q))
+        scores = (self.matrix[: self.count] @ q) / (
+            self.norms[: self.count] * q_norm + 1e-9
+        )
+        if memory_type is not None:
+            mask = self.types[: self.count] == memory_type
+            if not mask.any():
+                return []
+            scores = np.where(mask, scores, -np.inf)
+        k = min(k, self.count)
+        if k <= 0:
+            return []
+        top = np.argpartition(scores, -k)[-k:]
+        top = top[np.argsort(scores[top])[::-1]]
+        return [
+            (self.ids[i], float(scores[i]))
+            for i in top
+            if np.isfinite(scores[i])
+        ]
+
+
+def _vec_index_for(repo: Any) -> _VectorIndex:
+    """Get (lazily building) the vector index attached to an item repo.
+
+    Rebuilds when marked dirty or when the repo cache size drifted from the
+    last sync (something mutated items without going through our hooks).
+    """
+    idx: _VectorIndex | None = getattr(repo, "_nerve_vec_index", None)
+    if idx is None:
+        idx = _VectorIndex()
+        repo._nerve_vec_index = idx
+    if idx.dirty or idx.seen_items_len != len(repo.items):
+        idx.build(repo.items)
+    return idx
+
+
+def _vec_index_note(repo: Any) -> _VectorIndex | None:
+    """Return the index for mutation hooks (no build) — None if not built."""
+    return getattr(repo, "_nerve_vec_index", None)
+
+
+def _log_audit_failure(future: Any) -> None:
+    """Done-callback for cross-loop audit writes — log, never raise."""
+    try:
+        exc = future.exception()
+    except Exception:  # pragma: no cover - cancelled
+        return
+    if exc is not None:
+        logger.warning("Audit log failed: %s", exc)
 
 
 class _BedrockLLMClient:
@@ -452,14 +641,146 @@ class MemUBridge:
         # Debounce tracking for file re-indexing (path -> asyncio.Task)
         self._reindex_tasks: dict[str, asyncio.Task] = {}
         self._anthropic_client: Any | None = None  # Lazy sync Anthropic
+        # Dedicated event loop (own thread) that runs ALL memU service
+        # coroutines.  memU's async pipeline steps call synchronous
+        # SQLite/numpy work inline; isolating the whole service on its own
+        # loop keeps those blocking calls off the main event loop.
+        self._memu_loop: asyncio.AbstractEventLoop | None = None
+        self._memu_thread: threading.Thread | None = None
+        # Main loop handle — captured in initialize() so audit writes
+        # (aiosqlite, bound to the main loop) can be routed back to it
+        # when triggered from the memU loop.
+        self._main_loop: asyncio.AbstractEventLoop | None = None
+
+    # ------------------------------------------------------------------
+    # Dedicated memU event loop
+    # ------------------------------------------------------------------
+
+    def _start_memu_loop(self) -> None:
+        """Spawn the daemon thread running the memU event loop (idempotent)."""
+        if self._memu_loop is not None and not self._memu_loop.is_closed():
+            return
+        ready = threading.Event()
+
+        def _run() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._memu_loop = loop
+            ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                # Drain pending tasks so cancellations complete cleanly.
+                pending = asyncio.all_tasks(loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True),
+                    )
+                loop.close()
+
+        self._memu_thread = threading.Thread(
+            target=_run, name="memu-loop", daemon=True,
+        )
+        self._memu_thread.start()
+        ready.wait(timeout=10)
+
+    async def _submit(self, coro: Coroutine) -> Any:
+        """Run ``coro`` on the memU event loop and await its result.
+
+        Falls back to awaiting inline when the memU loop isn't running
+        (unit tests construct bridges without ``initialize()``) or when the
+        caller is already executing ON the memU loop (re-entrant impl
+        calls).  Cancelling the returned awaitable cancels the task on the
+        memU loop (``run_coroutine_threadsafe`` propagates cancellation),
+        so ``asyncio.wait_for`` timeouts behave exactly as before.
+        """
+        loop = self._memu_loop
+        if loop is None or loop.is_closed():
+            return await coro
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - defensive
+            running = None
+        if running is loop:
+            return await coro
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return await asyncio.wrap_future(future)
+
+    async def shutdown(self) -> None:
+        """Close LLM clients and stop the memU event loop thread."""
+        loop = self._memu_loop
+        if loop is not None and not loop.is_closed():
+            try:
+                await asyncio.wait_for(
+                    self._submit(self._close_service_impl()), timeout=10,
+                )
+            except Exception as e:
+                logger.debug("memU client close during shutdown: %s", e)
+            loop.call_soon_threadsafe(loop.stop)
+        self._memu_loop = None
+        thread = self._memu_thread
+        self._memu_thread = None
+        if thread is not None and thread.is_alive():
+            await asyncio.to_thread(thread.join, 5)
+        self._available = False
+        self._metrics.service_available = False
+
+    async def _close_service_impl(self) -> None:
+        """Close LLM transports + DB engine.  Runs on the memU loop."""
+        if not self._service:
+            return
+        for profile, client in list(
+            getattr(self._service, "_llm_clients", {}).items()
+        ):
+            try:
+                if isinstance(client, _BedrockLLMClient):
+                    await client.close()
+                else:
+                    inner = getattr(client, "client", None)
+                    http = getattr(inner, "_client", None) or getattr(
+                        inner, "http_client", None,
+                    )
+                    if http is not None and hasattr(http, "aclose"):
+                        await http.aclose()
+            except Exception as e:
+                logger.debug("Closing LLM client %s: %s", profile, e)
+        try:
+            sessions = getattr(self._service.database, "_sessions", None)
+            if sessions is not None:
+                sessions.close()
+        except Exception as e:
+            logger.debug("Closing memU DB engine: %s", e)
 
     async def _audit(self, action: str, target_type: str, target_id: str | None = None,
                      source: str = "bridge", details: dict | None = None) -> None:
-        if self._audit_db:
-            try:
-                await self._audit_db.log_audit(action, target_type, target_id, source, details)
-            except Exception as e:
-                logger.warning("Audit log failed: %s", e)
+        """Best-effort audit write.
+
+        ``_audit_db`` is aiosqlite bound to the main event loop.  When
+        called from the memU loop, schedule the write on the main loop
+        instead of awaiting it here (fire-and-forget — audit is advisory).
+        """
+        if not self._audit_db:
+            return
+        coro = self._audit_db.log_audit(action, target_type, target_id, source, details)
+        main_loop = self._main_loop
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - defensive
+            running = None
+        if (
+            main_loop is not None
+            and running is not main_loop
+            and not main_loop.is_closed()
+        ):
+            future = asyncio.run_coroutine_threadsafe(coro, main_loop)
+            future.add_done_callback(_log_audit_failure)
+            return
+        try:
+            await coro
+        except Exception as e:
+            logger.warning("Audit log failed: %s", e)
 
     # memU version these patches were written for. If the installed version
     # differs, the internal APIs we monkey-patch may have changed.
@@ -609,14 +930,20 @@ class MemUBridge:
 
             # Fix 3: vector_search_items calls list_items() on every query,
             # re-reading and JSON-parsing all embeddings from SQLite (~2s for 3K items).
-            # The items cache (self.items) is already kept in sync by create/update/delete,
-            # so use it directly when available.
+            # Worse, cosine_topk re-stacks every embedding into a brand-new
+            # (n, dim) float32 matrix per call (~130 MB with 20K items).
+            # Use the persistent incremental _VectorIndex instead: one
+            # mat-vec per query, rows appended as items are created.
             from memu.database.sqlite.repositories.memory_item_repo import SQLiteMemoryItemRepo
             from memu.database.inmemory.vector import cosine_topk, cosine_topk_salience
 
             _original_vector_search = SQLiteMemoryItemRepo.vector_search_items
 
             def _fast_vector_search(self, query_vec, top_k, where=None, *, ranking="similarity", recency_decay_days=30.0):
+                # Fast path: persistent matrix index (no filters, default ranking).
+                if self.items and not where and ranking == "similarity":
+                    return _vec_index_for(self).search(query_vec, top_k)
+
                 # Use in-memory cache when it's populated and no filters applied
                 if self.items and not where:
                     pool = self.items
@@ -636,6 +963,42 @@ class MemUBridge:
                 return cosine_topk(query_vec, [(i.id, i.embedding) for i in pool.values()], k=top_k)
 
             SQLiteMemoryItemRepo.vector_search_items = _fast_vector_search
+
+            # Keep the vector index in sync on update/delete/clear.  Creates
+            # are handled by the create_item wrapper installed in
+            # _initialize_impl (which also converts embeddings to numpy).
+            _original_update_item = SQLiteMemoryItemRepo.update_item
+            _original_delete_item = SQLiteMemoryItemRepo.delete_item
+            _original_clear_items = SQLiteMemoryItemRepo.clear_items
+
+            def _indexed_update_item(self, item_id, *args, **kwargs):
+                result = _original_update_item(self, item_id, *args, **kwargs)
+                idx = _vec_index_note(self)
+                if idx is not None:
+                    cached = self.items.get(item_id)
+                    if cached is not None and cached.embedding is not None:
+                        idx.upsert(item_id, str(cached.memory_type), cached.embedding)
+                    idx.seen_items_len = len(self.items)
+                return result
+
+            def _indexed_delete_item(self, item_id, *args, **kwargs):
+                result = _original_delete_item(self, item_id, *args, **kwargs)
+                idx = _vec_index_note(self)
+                if idx is not None:
+                    idx.remove(item_id)
+                    idx.seen_items_len = len(self.items)
+                return result
+
+            def _indexed_clear_items(self, *args, **kwargs):
+                result = _original_clear_items(self, *args, **kwargs)
+                idx = _vec_index_note(self)
+                if idx is not None:
+                    idx.dirty = True
+                return result
+
+            SQLiteMemoryItemRepo.update_item = _indexed_update_item
+            SQLiteMemoryItemRepo.delete_item = _indexed_delete_item
+            SQLiteMemoryItemRepo.clear_items = _indexed_clear_items
 
             # Same fix for category repo
             from memu.database.sqlite.repositories.memory_category_repo import SQLiteMemoryCategoryRepo
@@ -766,14 +1129,13 @@ class MemUBridge:
             ):
                 threshold = _SEMANTIC_DEDUP_THRESHOLD
                 if threshold > 0 and embedding is not None and self.items:
-                    corpus = [
-                        (iid, item.embedding)
-                        for iid, item in self.items.items()
-                        if item.memory_type == memory_type and item.embedding is not None
-                    ]
-                    if corpus:
-                        hits = cosine_topk(embedding, corpus, k=1)
-                        if hits and hits[0][1] >= threshold:
+                    # Type-filtered top-1 via the persistent matrix index —
+                    # no per-item corpus rebuild.
+                    hits = _vec_index_for(self).search(
+                        embedding, k=1, memory_type=str(memory_type),
+                    )
+                    if hits:
+                        if hits[0][1] >= threshold:
                             match_id, score = hits[0]
                             matched = self.items[match_id]
                             logger.info(
@@ -903,8 +1265,75 @@ class MemUBridge:
         except Exception as exc:
             logger.warning("memU datetime sanitization skipped: %s", exc)
 
+    @staticmethod
+    def _setup_sqlite_pragmas(sqlite_dsn: str) -> None:
+        """One-time SQLite tuning for the memU database.
+
+        ``journal_mode=WAL`` is a persistent database property: writers no
+        longer block readers and commits stop paying the rollback-journal
+        create/delete cycle.  Run before memu-py opens the database (the
+        conversion needs no other connections).
+        """
+        import sqlite3 as _sqlite3
+
+        db_path = sqlite_dsn.replace("sqlite:///", "")
+        try:
+            conn = _sqlite3.connect(db_path, timeout=10)
+            mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            conn.close()
+            if str(mode).lower() != "wal":
+                logger.warning(
+                    "memU DB journal_mode is %r (wanted WAL) — concurrent "
+                    "readers will block on writers", mode,
+                )
+            else:
+                logger.info("memU DB journal_mode=WAL")
+        except Exception as exc:
+            logger.warning("memU WAL setup skipped: %s", exc)
+
+    def _attach_engine_pragmas(self) -> None:
+        """Per-connection pragmas for memU's SQLAlchemy engine.
+
+        ``synchronous`` and ``busy_timeout`` are per-connection settings
+        (unlike journal_mode), so they must be applied on every new pooled
+        connection via the ``connect`` event.  ``synchronous=NORMAL`` is
+        the recommended pairing with WAL (fsync on checkpoint, not on every
+        commit); ``busy_timeout`` stops concurrent writers from failing
+        fast with "database is locked".
+        """
+        try:
+            from sqlalchemy import event
+
+            engine = self._service.database._sessions.engine
+
+            @event.listens_for(engine, "connect")
+            def _set_pragmas(dbapi_conn, _record):  # pragma: no cover - thin
+                cursor = dbapi_conn.cursor()
+                cursor.execute("PRAGMA busy_timeout=10000")
+                cursor.execute("PRAGMA synchronous=NORMAL")
+                cursor.close()
+
+            # Recycle connections opened before the listener existed
+            # (table-creation during MemoryService init).
+            engine.dispose()
+            logger.info("memU engine pragmas attached (busy_timeout, synchronous=NORMAL)")
+        except Exception as exc:
+            logger.warning("Could not attach memU engine pragmas: %s", exc)
+
     async def initialize(self) -> bool:
-        """Initialize the memU service with SQLite persistence."""
+        """Initialize the memU service.
+
+        Spawns the dedicated memU event-loop thread, then runs the actual
+        initialization there: memU's pipelines execute synchronous SQLite
+        and numpy work inline, so the service must live where that cannot
+        stall the main event loop.
+        """
+        self._main_loop = asyncio.get_running_loop()
+        self._start_memu_loop()
+        return await self._submit(self._initialize_impl())
+
+    async def _initialize_impl(self) -> bool:
+        """Initialize the memU service with SQLite persistence (memU loop)."""
         try:
             from memu.app.service import MemoryService
 
@@ -925,6 +1354,12 @@ class MemUBridge:
             # non-string values, breaking list_items() and the entire item
             # cache.  Sanitize on startup and add a defensive type adapter.
             self._sanitize_memu_datetimes(sqlite_dsn)
+
+            # ── SQLite tuning ──
+            # Convert to WAL once (persistent) so writers stop blocking
+            # readers; per-connection pragmas are attached to the engine
+            # right after the service is constructed.
+            self._setup_sqlite_pragmas(sqlite_dsn)
 
             # ── Bedrock detection ──
             # When provider is Bedrock, anthropic_api_base_url and
@@ -1048,6 +1483,9 @@ class MemUBridge:
             self._metrics.service_available = True
             self._metrics.initialized_at = datetime.now(timezone.utc).isoformat()
             logger.info("memU service initialized with SQLite at %s", sqlite_dsn)
+
+            # Per-connection pragmas (busy_timeout, synchronous=NORMAL).
+            self._attach_engine_pragmas()
 
             # ── Bedrock client injection ──
             # Replace the placeholder OpenAISDKClient instances with real
@@ -1287,6 +1725,10 @@ class MemUBridge:
                 # Release the list[float] objects immediately
                 self._release_memory()
 
+                # Pre-build the persistent vector index so the first
+                # search doesn't pay the full matrix stack.
+                _vec_index_for(self._service.database.memory_item_repo)
+
                 logger.info(
                     "Preloaded %d items and %d categories into vector cache "
                     "(%d embeddings converted to numpy float32)",
@@ -1297,20 +1739,32 @@ class MemUBridge:
             except Exception as e:
                 logger.warning("Failed to preload vector cache: %s", e)
 
-            # Monkey-patch create_item to keep new embeddings as numpy too.
+            # Monkey-patch create_item to keep new embeddings as numpy and
+            # append them to the persistent vector index.
             from memu.database.sqlite.repositories.memory_item_repo import SQLiteMemoryItemRepo
-            _original_create_item = SQLiteMemoryItemRepo.create_item
 
-            def _numpy_create_item(self, *args, **kwargs):
-                result = _original_create_item(self, *args, **kwargs)
-                # Convert the newly cached item's embedding to numpy
-                if result and hasattr(result, "id"):
-                    cached = self.items.get(result.id)
-                    if cached and cached.embedding is not None and not isinstance(cached.embedding, np.ndarray):
-                        cached.__dict__["embedding"] = np.array(cached.embedding, dtype=np.float32)
-                return result
+            if not getattr(SQLiteMemoryItemRepo.create_item, "_nerve_numpy_wrapped", False):
+                _original_create_item = SQLiteMemoryItemRepo.create_item
 
-            SQLiteMemoryItemRepo.create_item = _numpy_create_item
+                def _numpy_create_item(self, *args, **kwargs):
+                    result = _original_create_item(self, *args, **kwargs)
+                    # Convert the newly cached item's embedding to numpy
+                    if result and hasattr(result, "id"):
+                        cached = self.items.get(result.id)
+                        if cached and cached.embedding is not None and not isinstance(cached.embedding, np.ndarray):
+                            cached.__dict__["embedding"] = np.array(cached.embedding, dtype=np.float32)
+                        idx = _vec_index_note(self)
+                        if idx is not None:
+                            if cached is not None and cached.embedding is not None:
+                                idx.upsert(
+                                    result.id, str(cached.memory_type),
+                                    cached.embedding,
+                                )
+                            idx.seen_items_len = len(self.items)
+                    return result
+
+                _numpy_create_item._nerve_numpy_wrapped = True  # type: ignore[attr-defined]
+                SQLiteMemoryItemRepo.create_item = _numpy_create_item
 
             return True
 
@@ -1338,7 +1792,9 @@ class MemUBridge:
             if cat_cfg.name in existing:
                 continue
             try:
-                await self.create_category(cat_cfg.name, cat_cfg.description)
+                # Already on the memU loop (called from _initialize_impl) —
+                # invoke the impl directly instead of re-submitting.
+                await self._create_category_impl(cat_cfg.name, cat_cfg.description)
             except Exception as e:
                 logger.warning("Failed to seed category %s: %s", cat_cfg.name, e)
 
@@ -1543,6 +1999,14 @@ class MemUBridge:
     async def _reset_llm_clients(self) -> None:
         """Evict cached LLM clients and force fresh HTTP connections.
 
+        Proxy: the clients (and their httpx transports) live on the memU
+        event loop, so the reset must run there.
+        """
+        await self._submit(self._reset_llm_clients_impl())
+
+    async def _reset_llm_clients_impl(self) -> None:
+        """Reset LLM clients (memU loop).
+
         After a timeout the API may be rate-limiting, overloaded, or the
         connection may be stale.  We close the transport, evict the cached
         client so _get_llm_base_client() creates a new one, then re-apply
@@ -1639,11 +2103,15 @@ class MemUBridge:
                 )
                 t0 = time.monotonic()
 
+                # The memorize pipeline interleaves async LLM calls with
+                # synchronous SQLite writes and numpy work — run it on the
+                # dedicated memU loop.  Cancellation (wait_for timeout)
+                # propagates through _submit to the memU-loop task.
                 response = await asyncio.wait_for(
-                    self._service.memorize(
+                    self._submit(self._service.memorize(
                         resource_url=file_path,
                         modality=modality,
-                    ),
+                    )),
                     timeout=self._MEMORIZE_TIMEOUT,
                 )
 
@@ -1664,7 +2132,9 @@ class MemUBridge:
                             name=f"filter-knowledge-{Path(file_path).name}",
                         )
 
-                self._release_memory()
+                # gc.collect + malloc_trim can take 100ms+ on a large heap
+                # — run off the event loop.
+                await asyncio.to_thread(self._release_memory)
                 return True
 
             except asyncio.TimeoutError:
@@ -1736,7 +2206,7 @@ class MemUBridge:
             attempt += 1
 
         logger.error("memU memorize_file gave up after %d attempts for %s", attempt, file_path)
-        self._release_memory()
+        await asyncio.to_thread(self._release_memory)
         return False
 
     async def memorize_conversation(self, session_id: str, messages: list[dict]) -> bool:
@@ -1771,14 +2241,22 @@ class MemUBridge:
 
         now = int(time.time())
         conv_dir = Path("~/.nerve/memu-conversations").expanduser()
-        conv_dir.mkdir(parents=True, exist_ok=True)
         conv_path = conv_dir / f"session-{session_id}-{now}.json"
-        conv_path.write_text(json.dumps(entries, ensure_ascii=False), encoding="utf-8")
+
+        def _write_conversation() -> int:
+            """JSON-encode and write the conversation (off the event loop —
+            10K messages serialize to multiple MB)."""
+            conv_dir.mkdir(parents=True, exist_ok=True)
+            payload = json.dumps(entries, ensure_ascii=False)
+            conv_path.write_text(payload, encoding="utf-8")
+            return len(payload.encode("utf-8"))
+
+        payload_bytes = await asyncio.to_thread(_write_conversation)
 
         try:
             logger.info(
                 "Memorizing conversation: session=%s, messages=%d, file=%s (%d bytes)",
-                session_id, len(entries), conv_path.name, conv_path.stat().st_size,
+                session_id, len(entries), conv_path.name, payload_bytes,
             )
             ok = await self.memorize_file(str(conv_path), modality="conversation")
 
@@ -1835,6 +2313,7 @@ class MemUBridge:
         try:
             db = sqlite3.connect(db_path, timeout=10)
             db.row_factory = sqlite3.Row
+            db.execute("PRAGMA synchronous=NORMAL")
 
             rows = db.execute(
                 "SELECT id, memory_type, summary, extra "
@@ -2106,9 +2585,11 @@ class MemUBridge:
             return []
         op_id = self._metrics.begin_op("recall", query[:80])
         try:
-            result = await self._service.retrieve(
+            # Retrieve runs vector search (numpy) and possibly SQLite reads
+            # inline — keep it on the memU loop.
+            result = await self._submit(self._service.retrieve(
                 queries=[{"role": "user", "content": query}],
-            )
+            ))
 
             items_out: list[dict[str, str]] = []
             cats_out: list[dict[str, str]] = []
@@ -2231,7 +2712,7 @@ class MemUBridge:
         if not self._available or not self._service:
             return []
         try:
-            result = await self._service.list_memory_items(where=None)
+            result = await self._submit(self._service.list_memory_items(where=None))
             items = []
             for item in result.get("items", []):
                 items.append({
@@ -2252,7 +2733,7 @@ class MemUBridge:
         if not self._available or not self._service:
             return []
         try:
-            result = await self._service.list_memory_categories(where=None)
+            result = await self._submit(self._service.list_memory_categories(where=None))
             cats = []
             for cat in result.get("categories", []):
                 cats.append({
@@ -2285,7 +2766,7 @@ class MemUBridge:
                 kwargs["memory_type"] = memory_type
             if categories is not None:
                 kwargs["memory_categories"] = categories
-            await self._service.update_memory_item(**kwargs)
+            await self._submit(self._service.update_memory_item(**kwargs))
             logger.info("Updated memory item: %s", memory_id)
             await self._audit("item_updated", "item", memory_id, source, {
                 "content_changed": content is not None,
@@ -2302,7 +2783,7 @@ class MemUBridge:
         if not self._available or not self._service:
             return False
         try:
-            await self._service.delete_memory_item(memory_id=memory_id)
+            await self._submit(self._service.delete_memory_item(memory_id=memory_id))
             logger.info("Deleted memory item: %s", memory_id)
             await self._audit("item_deleted", "item", memory_id, source)
             return True
@@ -2313,6 +2794,12 @@ class MemUBridge:
     async def create_category(self, name: str, description: str, source: str = "bridge") -> bool:
         """Create a new memory category at runtime."""
         if not self._available or not self._service:
+            return False
+        return await self._submit(self._create_category_impl(name, description, source))
+
+    async def _create_category_impl(self, name: str, description: str, source: str = "bridge") -> bool:
+        """Create a category — repo write + context mutation (memU loop)."""
+        if not self._service:
             return False
         try:
             # Generate embedding for the category (requires OpenAI key)
@@ -2363,6 +2850,18 @@ class MemUBridge:
         """Update a category's summary and/or description, then re-embed."""
         if not self._available or not self._service:
             return False
+        return await self._submit(
+            self._update_category_impl(category_id, summary, description, source),
+        )
+
+    async def _update_category_impl(
+        self,
+        category_id: str,
+        summary: str | None = None,
+        description: str | None = None,
+        source: str = "bridge",
+    ) -> bool:
+        """Update a category — embed + repo write (memU loop)."""
         try:
             repo = self._service.database.memory_category_repo
             cat = repo.categories.get(category_id)
@@ -2409,18 +2908,15 @@ class MemUBridge:
         if not self._available or not self._service:
             return 0
 
-        # Get already-indexed resource URLs
+        # Get already-indexed resource URLs.  The first list_resources()
+        # call reads + JSON-parses every resource row — memU loop.
         existing_urls: set[str] = set()
         try:
-            resources = self._service.database.resource_repo.list_resources()
-            for res_id, res in resources.items():
-                url = getattr(res, "url", "")
-                if url:
-                    existing_urls.add(url)
+            existing_urls = await self._submit(self._list_resource_urls_impl())
         except Exception as e:
             logger.warning("Could not load existing resources: %s", e)
 
-        md_files = self._collect_md_files(workspace)
+        md_files = await asyncio.to_thread(self._collect_md_files, workspace)
         indexed_count = 0
 
         for file_path, file_type in md_files:
@@ -2434,6 +2930,16 @@ class MemUBridge:
 
         logger.info("Indexed %d new files into memU (%d already indexed)", indexed_count, len(existing_urls))
         return indexed_count
+
+    async def _list_resource_urls_impl(self) -> set[str]:
+        """Collect indexed resource URLs (sync repo read — memU loop)."""
+        urls: set[str] = set()
+        resources = self._service.database.resource_repo.list_resources()
+        for _res_id, res in resources.items():
+            url = getattr(res, "url", "")
+            if url:
+                urls.add(url)
+        return urls
 
     async def reindex_file(self, file_path: str) -> bool:
         """Re-index a single file after edit, with 5s debounce."""
@@ -2458,15 +2964,7 @@ class MemUBridge:
 
         op_id = self._metrics.begin_op("reindex_file", file_path)
         try:
-            # Find and remove old resource entries for this URL
-            resources = self._service.database.resource_repo.list_resources()
-            for res_id, res in resources.items():
-                if getattr(res, "url", "") == file_path:
-                    # Find items linked to this resource and delete them
-                    items = self._service.database.memory_item_repo.list_items()
-                    for item_id, item in items.items():
-                        if getattr(item, "resource_id", None) == res_id:
-                            await self._service.delete_memory_item(memory_id=item_id)
+            await self._submit(self._clear_file_entries_impl(file_path))
             logger.debug("Cleared old entries for %s", file_path)
         except Exception as e:
             logger.warning("Failed to clear old entries for %s: %s", file_path, e)
@@ -2480,6 +2978,17 @@ class MemUBridge:
         result = await self.memorize_file(file_path, modality=modality)
         self._metrics.end_op(op_id, success=result)
         return result
+
+    async def _clear_file_entries_impl(self, file_path: str) -> None:
+        """Remove old resource + item entries for a URL (memU loop)."""
+        resources = self._service.database.resource_repo.list_resources()
+        for res_id, res in resources.items():
+            if getattr(res, "url", "") == file_path:
+                # Find items linked to this resource and delete them
+                items = self._service.database.memory_item_repo.list_items()
+                for item_id, item in items.items():
+                    if getattr(item, "resource_id", None) == res_id:
+                        await self._service.delete_memory_item(memory_id=item_id)
 
     def _collect_md_files(self, workspace: Path) -> list[tuple[Path, str]]:
         """Collect all .md files that should be indexed."""

--- a/nerve/proxy/service.py
+++ b/nerve/proxy/service.py
@@ -107,27 +107,30 @@ class ProxyService:
             resp.raise_for_status()
             archive_bytes = resp.content
 
-        # Extract the binary from the tarball.
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
-            # The binary is named "cli-proxy-api" inside the archive.
-            binary_member = None
-            for member in tar.getmembers():
-                if member.name.endswith("cli-proxy-api") and member.isfile():
-                    binary_member = member
-                    break
+        def _extract_and_install() -> None:
+            """Untar + write the binary (CPU + disk) — off the event loop."""
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
+                # The binary is named "cli-proxy-api" inside the archive.
+                binary_member = None
+                for member in tar.getmembers():
+                    if member.name.endswith("cli-proxy-api") and member.isfile():
+                        binary_member = member
+                        break
 
-            if binary_member is None:
-                raise RuntimeError("cli-proxy-api binary not found in archive")
+                if binary_member is None:
+                    raise RuntimeError("cli-proxy-api binary not found in archive")
 
-            extracted = tar.extractfile(binary_member)
-            if extracted is None:
-                raise RuntimeError("Failed to extract cli-proxy-api from archive")
+                extracted = tar.extractfile(binary_member)
+                if extracted is None:
+                    raise RuntimeError("Failed to extract cli-proxy-api from archive")
 
-            dest.write_bytes(extracted.read())
+                dest.write_bytes(extracted.read())
 
-        # Make executable.
-        dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            # Make executable.
+            dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        await asyncio.to_thread(_extract_and_install)
         logger.info("Installed CLIProxyAPI to %s", dest)
 
     # ------------------------------------------------------------------ #
@@ -161,11 +164,15 @@ class ProxyService:
     async def start(self) -> None:
         """Start the CLIProxyAPI subprocess."""
         binary = await self.ensure_binary()
-        config_path = self._write_proxy_config()
+        config_path = await asyncio.to_thread(self._write_proxy_config)
 
         log_file = self.config.proxy.log_file.expanduser()
-        log_file.parent.mkdir(parents=True, exist_ok=True)
-        log_fd = open(log_file, "a")  # noqa: SIM115
+
+        def _open_log():
+            log_file.parent.mkdir(parents=True, exist_ok=True)
+            return open(log_file, "a")  # noqa: SIM115
+
+        log_fd = await asyncio.to_thread(_open_log)
 
         self._process = await asyncio.create_subprocess_exec(
             str(binary),

--- a/nerve/skills/manager.py
+++ b/nerve/skills/manager.py
@@ -113,22 +113,30 @@ class SkillManager:
         Returns all discovered skills. Also removes DB entries for skills
         that no longer exist on the filesystem.
         """
-        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self.skills_dir.mkdir, parents=True, exist_ok=True)
         discovered: list[SkillMeta] = []
         found_ids: set[str] = set()
 
-        for skill_dir in sorted(self.skills_dir.iterdir()):
-            if not skill_dir.is_dir():
-                continue
-            skill_md = skill_dir / "SKILL.md"
-            if not skill_md.exists():
-                continue
+        def _scan_skill_dirs() -> list[tuple[Path, str]]:
+            """Collect (skill_dir, raw SKILL.md) pairs off the event loop."""
+            out: list[tuple[Path, str]] = []
+            for sdir in sorted(self.skills_dir.iterdir()):
+                if not sdir.is_dir():
+                    continue
+                smd = sdir / "SKILL.md"
+                if not smd.exists():
+                    continue
+                try:
+                    out.append((sdir, smd.read_text(encoding="utf-8")))
+                except OSError as e:
+                    logger.error("Failed to read skill %s: %s", sdir.name, e)
+            return out
 
+        for skill_dir, raw in await asyncio.to_thread(_scan_skill_dirs):
             skill_id = skill_dir.name
             found_ids.add(skill_id)
 
             try:
-                raw = skill_md.read_text(encoding="utf-8")
                 fm, body = _parse_skill_md(raw)
 
                 name = fm.get("name", skill_id)
@@ -216,7 +224,7 @@ class SkillManager:
         if not skill_md.exists():
             return None
 
-        raw = skill_md.read_text(encoding="utf-8")
+        raw = await asyncio.to_thread(skill_md.read_text, encoding="utf-8")
         fm, body = _parse_skill_md(raw)
 
         # Get metadata from cache or DB
@@ -260,11 +268,15 @@ class SkillManager:
         """Create a new skill directory + SKILL.md and index in DB."""
         skill_id = _slugify(name)
         skill_dir = self.skills_dir / skill_id
-        skill_dir.mkdir(parents=True, exist_ok=True)
 
         # Build SKILL.md
         raw = _build_skill_md(name, description, content, version)
-        (skill_dir / "SKILL.md").write_text(raw, encoding="utf-8")
+
+        def _write_skill() -> None:
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(raw, encoding="utf-8")
+
+        await asyncio.to_thread(_write_skill)
 
         # Sync to DB
         await self.db.upsert_skill(
@@ -286,7 +298,7 @@ class SkillManager:
         if not skill_md.exists():
             return None
 
-        skill_md.write_text(content, encoding="utf-8")
+        await asyncio.to_thread(skill_md.write_text, content, encoding="utf-8")
 
         # Re-parse and sync
         fm, body = _parse_skill_md(content)
@@ -315,7 +327,7 @@ class SkillManager:
         """Remove skill directory and DB record."""
         skill_dir = self.skills_dir / skill_id
         if skill_dir.exists():
-            shutil.rmtree(skill_dir)
+            await asyncio.to_thread(shutil.rmtree, skill_dir)
         await self.db.delete_skill_row(skill_id)
         self._cache.pop(skill_id, None)
         return True
@@ -335,7 +347,15 @@ class SkillManager:
         refs_dir = self.skills_dir / skill_id / "references"
         if not refs_dir.is_dir():
             return []
-        return sorted(str(f.relative_to(refs_dir)) for f in refs_dir.rglob("*") if f.is_file())
+
+        def _walk() -> list[str]:
+            return sorted(
+                str(f.relative_to(refs_dir))
+                for f in refs_dir.rglob("*")
+                if f.is_file()
+            )
+
+        return await asyncio.to_thread(_walk)
 
     async def read_reference(self, skill_id: str, rel_path: str) -> str | None:
         """Read a reference file from a skill."""
@@ -347,7 +367,7 @@ class SkillManager:
             return None
         if not ref_file.exists() or not ref_file.is_file():
             return None
-        return ref_file.read_text(encoding="utf-8")
+        return await asyncio.to_thread(ref_file.read_text, encoding="utf-8")
 
     async def run_script(self, skill_id: str, rel_path: str, args: str = "") -> str:
         """Execute a script from a skill's scripts/ directory."""

--- a/nerve/tasks/manager.py
+++ b/nerve/tasks/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,9 +30,10 @@ class TaskManager:
         count = 0
 
         for directory, status in [(self.active_dir, "pending"), (self.done_dir, "done")]:
-            for md_file in directory.glob("*.md"):
+            md_files = await asyncio.to_thread(lambda d=directory: sorted(d.glob("*.md")))
+            for md_file in md_files:
                 try:
-                    content = md_file.read_text(encoding="utf-8")
+                    content = await asyncio.to_thread(md_file.read_text, encoding="utf-8")
                     title = parse_task_title(content)
                     fields = parse_task_frontmatter(content)
                     task_id = md_file.stem
@@ -68,7 +70,9 @@ class TaskManager:
         task = Task.from_db_row(row)
         file_path = self.workspace / row["file_path"]
         if file_path.exists():
-            task.content = file_path.read_text(encoding="utf-8")
+            task.content = await asyncio.to_thread(
+                file_path.read_text, encoding="utf-8",
+            )
         return task
 
     async def mark_done(self, task_id: str) -> bool:
@@ -80,11 +84,15 @@ class TaskManager:
         src = self.workspace / row["file_path"]
         if src.exists():
             dst = self.done_dir / src.name
-            content = src.read_text(encoding="utf-8")
+            content = await asyncio.to_thread(src.read_text, encoding="utf-8")
             today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             content += f"\n- {today}: DONE"
-            dst.write_text(content, encoding="utf-8")
-            src.unlink()
+
+            def _move_to_done() -> None:
+                dst.write_text(content, encoding="utf-8")
+                src.unlink()
+
+            await asyncio.to_thread(_move_to_done)
 
             # Update DB
             rel_path = str(dst.relative_to(self.workspace))

--- a/tests/test_memu_bridge.py
+++ b/tests/test_memu_bridge.py
@@ -683,3 +683,199 @@ class TestValidateDateValue:
     def test_non_string_non_number(self):
         assert MemUBridge._validate_date_value([2025]) is None
         assert MemUBridge._validate_date_value({"year": 2025}) is None
+
+
+# ---------------------------------------------------------------------------
+# _VectorIndex — persistent incremental matrix index
+# ---------------------------------------------------------------------------
+
+class _FakeItem:
+    def __init__(self, memory_type: str, embedding):
+        self.memory_type = memory_type
+        self.embedding = embedding
+
+
+class TestVectorIndex:
+    def _items(self):
+        import numpy as np
+        return {
+            "a": _FakeItem("event", np.array([1.0, 0.0, 0.0], dtype="float32")),
+            "b": _FakeItem("profile", np.array([0.0, 1.0, 0.0], dtype="float32")),
+            "c": _FakeItem("event", np.array([0.0, 0.0, 1.0], dtype="float32")),
+            "no-vec": _FakeItem("event", None),
+        }
+
+    def test_build_and_search(self):
+        from nerve.memory.memu_bridge import _VectorIndex
+        idx = _VectorIndex()
+        idx.build(self._items())
+        assert idx.count == 3  # embedding-less item excluded
+        hits = idx.search([1.0, 0.0, 0.0], k=2)
+        assert hits[0][0] == "a"
+        assert hits[0][1] == pytest.approx(1.0, abs=1e-4)
+
+    def test_type_filtered_search(self):
+        from nerve.memory.memu_bridge import _VectorIndex
+        idx = _VectorIndex()
+        idx.build(self._items())
+        # Without filter, "b" wins for [0,1,0]; with event filter it must not.
+        hits = idx.search([0.0, 1.0, 0.0], k=1, memory_type="event")
+        assert hits
+        assert hits[0][0] in ("a", "c")
+        # No matches for unknown type
+        assert idx.search([0.0, 1.0, 0.0], k=1, memory_type="nope") == []
+
+    def test_upsert_appends_and_updates(self):
+        from nerve.memory.memu_bridge import _VectorIndex
+        idx = _VectorIndex()
+        idx.build(self._items())
+        idx.upsert("d", "knowledge", [0.5, 0.5, 0.0])
+        assert idx.count == 4
+        hits = idx.search([0.5, 0.5, 0.0], k=1)
+        assert hits[0][0] == "d"
+        # Update in place — no growth
+        idx.upsert("d", "knowledge", [0.0, 0.0, 1.0])
+        assert idx.count == 4
+        hits = idx.search([0.0, 0.0, 1.0], k=1)
+        assert hits[0][0] in ("c", "d")
+
+    def test_remove_swaps_last_row(self):
+        from nerve.memory.memu_bridge import _VectorIndex
+        idx = _VectorIndex()
+        idx.build(self._items())
+        idx.remove("a")
+        assert idx.count == 2
+        assert "a" not in idx.id_to_row
+        # Remaining vectors still searchable
+        hits = idx.search([0.0, 1.0, 0.0], k=1)
+        assert hits[0][0] == "b"
+        # Removing a missing id is a no-op
+        idx.remove("missing")
+        assert idx.count == 2
+
+    def test_empty_index(self):
+        from nerve.memory.memu_bridge import _VectorIndex
+        idx = _VectorIndex()
+        idx.build({})
+        assert idx.count == 0
+        assert idx.search([1.0, 0.0, 0.0], k=5) == []
+        # Upsert into an empty index bootstraps the dimension
+        idx.upsert("x", "event", [1.0, 0.0])
+        assert idx.count == 1
+        assert idx.search([1.0, 0.0], k=1)[0][0] == "x"
+
+    def test_capacity_growth(self):
+        import numpy as np
+        from nerve.memory.memu_bridge import _VectorIndex
+        idx = _VectorIndex()
+        idx.build({})
+        rng = np.random.default_rng(42)
+        for i in range(600):  # exceeds initial 256 capacity
+            idx.upsert(f"item-{i}", "event", rng.random(8).astype("float32"))
+        assert idx.count == 600
+        assert idx.capacity >= 600
+
+    def test_vec_index_for_rebuilds_on_drift(self):
+        from nerve.memory.memu_bridge import _vec_index_for
+
+        class _Repo:
+            pass
+
+        repo = _Repo()
+        repo.items = self._items()
+        idx = _vec_index_for(repo)
+        assert idx.count == 3
+        # Mutate items WITHOUT going through the hooks — drift detected
+        import numpy as np
+        repo.items["e"] = _FakeItem("event", np.array([1.0, 1.0, 0.0], dtype="float32"))
+        idx2 = _vec_index_for(repo)
+        assert idx2.count == 4
+
+
+# ---------------------------------------------------------------------------
+# Dedicated memU event loop (_submit / shutdown)
+# ---------------------------------------------------------------------------
+
+class TestMemuLoop:
+    @pytest.mark.asyncio
+    async def test_submit_inline_fallback_without_loop(self, tmp_path):
+        """Bridges that never ran initialize() execute coroutines inline."""
+        bridge = MemUBridge(_make_config(tmp_path))
+
+        async def _probe():
+            return asyncio.get_running_loop()
+
+        loop = await bridge._submit(_probe())
+        assert loop is asyncio.get_running_loop()
+
+    @pytest.mark.asyncio
+    async def test_submit_runs_on_memu_loop(self, tmp_path):
+        """After _start_memu_loop, coroutines run on the dedicated loop."""
+        bridge = MemUBridge(_make_config(tmp_path))
+        bridge._start_memu_loop()
+        try:
+            async def _probe():
+                return asyncio.get_running_loop()
+
+            loop = await bridge._submit(_probe())
+            assert loop is bridge._memu_loop
+            assert loop is not asyncio.get_running_loop()
+
+            # Exceptions propagate back to the caller
+            async def _boom():
+                raise ValueError("kaput")
+
+            with pytest.raises(ValueError, match="kaput"):
+                await bridge._submit(_boom())
+        finally:
+            await bridge.shutdown()
+        assert bridge._memu_loop is None
+
+    @pytest.mark.asyncio
+    async def test_submit_timeout_cancels_memu_task(self, tmp_path):
+        """wait_for around _submit cancels the coroutine on the memU loop."""
+        bridge = MemUBridge(_make_config(tmp_path))
+        bridge._start_memu_loop()
+        cancelled = asyncio.Event()
+        main_loop = asyncio.get_running_loop()
+
+        async def _hang():
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                main_loop.call_soon_threadsafe(cancelled.set)
+                raise
+
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(bridge._submit(_hang()), timeout=0.2)
+            await asyncio.wait_for(cancelled.wait(), timeout=5)
+        finally:
+            await bridge.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_idempotent(self, tmp_path):
+        bridge = MemUBridge(_make_config(tmp_path))
+        await bridge.shutdown()  # never started — must not raise
+        bridge._start_memu_loop()
+        await bridge.shutdown()
+        await bridge.shutdown()  # double shutdown is fine
+
+
+# ---------------------------------------------------------------------------
+# SQLite pragmas
+# ---------------------------------------------------------------------------
+
+class TestSqlitePragmas:
+    def test_wal_conversion(self, tmp_path):
+        db_path = tmp_path / "memu.sqlite"
+        _create_memu_schema(str(db_path))
+        assert sqlite3.connect(db_path).execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        MemUBridge._setup_sqlite_pragmas(f"sqlite:///{db_path}")
+        assert sqlite3.connect(db_path).execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        # Idempotent
+        MemUBridge._setup_sqlite_pragmas(f"sqlite:///{db_path}")
+        assert sqlite3.connect(db_path).execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+
+    def test_missing_db_does_not_raise(self, tmp_path):
+        MemUBridge._setup_sqlite_pragmas(f"sqlite:///{tmp_path}/nope/missing.sqlite")

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -294,3 +294,67 @@ class TestConcurrentSessionIsolation:
 
         # Both session_ids appeared exactly once each, in some order.
         assert sorted(captured) == ["session-A", "session-B"]
+
+
+# ---------------------------------------------------------------------------
+# Date-query helpers for conversation_history / memory_records_by_date
+# (sync functions executed via asyncio.to_thread by the handlers)
+# ---------------------------------------------------------------------------
+
+def _make_items_db(tmp_path):
+    import sqlite3
+
+    db_path = str(tmp_path / "memu.sqlite")
+    db = sqlite3.connect(db_path)
+    db.execute(
+        "CREATE TABLE memu_memory_items ("
+        " id TEXT PRIMARY KEY, memory_type TEXT, summary TEXT,"
+        " happened_at TEXT, created_at TEXT, updated_at TEXT)"
+    )
+    rows = [
+        ("i1", "event", "went hiking", "2026-06-01", "2026-06-02", "2026-06-02"),
+        ("i2", "event", "team meeting", "2026-06-03", "2026-06-03", "2026-06-03"),
+        ("i3", "profile", "likes coffee", None, "2026-06-03", "2026-06-05"),
+        ("i4", "knowledge", "project uses sqlite", None, "2026-05-20", "2026-05-20"),
+    ]
+    db.executemany("INSERT INTO memu_memory_items VALUES (?,?,?,?,?,?)", rows)
+    db.commit()
+    db.close()
+    return db_path
+
+
+class TestHistoryQueryHelpers:
+    def test_fetch_history_rows_filters_by_happened_at(self, tmp_path):
+        from nerve.agent.tools.handlers.memory import _fetch_history_rows
+
+        db_path = _make_items_db(tmp_path)
+        rows = _fetch_history_rows(db_path, "2026-06-01", "2026-06-02", limit=10)
+        assert [r["id"] for r in rows] == ["i1"]
+        rows = _fetch_history_rows(db_path, "2026-06-01", "2026-06-03", limit=10)
+        assert {r["id"] for r in rows} == {"i1", "i2"}
+        # NULL happened_at rows never appear
+        assert all(r["happened_at"] for r in rows)
+
+    def test_fetch_records_rows_created_window(self, tmp_path):
+        from nerve.agent.tools.handlers.memory import _fetch_records_rows
+
+        db_path = _make_items_db(tmp_path)
+        rows = _fetch_records_rows(
+            db_path, "2026-06-02", "2026-06-03", limit=10, include_updated=False,
+        )
+        assert {r["id"] for r in rows} == {"i1", "i2", "i3"}
+
+    def test_fetch_records_rows_include_updated(self, tmp_path):
+        from nerve.agent.tools.handlers.memory import _fetch_records_rows
+
+        db_path = _make_items_db(tmp_path)
+        # i3 was created 06-03 but updated 06-05 — only the updated filter
+        # window catches it on 06-05.
+        rows = _fetch_records_rows(
+            db_path, "2026-06-05", "2026-06-05", limit=10, include_updated=True,
+        )
+        assert {r["id"] for r in rows} == {"i3"}
+        rows = _fetch_records_rows(
+            db_path, "2026-06-05", "2026-06-05", limit=10, include_updated=False,
+        )
+        assert rows == []


### PR DESCRIPTION
## Problem

memU's async pipeline steps execute synchronous SQLite writes (`session.commit()` per row at `journal_mode=delete`) and heavy numpy work inline on the main event loop. `schedule_memorize` (#109) made callers stop *waiting*, but the background task still ran **on the same loop** — every memorization stalled the whole server (WebSocket, Telegram, other sessions) in repeated 50–500 ms chunks. On top of that, `cosine_topk` re-stacks all embeddings into a fresh `(n, 1536)` float32 matrix (~130 MB with 20K items) on **every** search — per recall, and per extracted item during dedup.

Several raw `sqlite3` / file-IO calls in async tool handlers and routes (`conversation_history`, `memory_records_by_date`, `get_memu_data` full-table reads, uploads, diffs, skills/tasks file IO) had the same issue.

## Changes

**Dedicated memU event loop** (`memu_bridge.py`)
- The entire memU service now lives on its own daemon thread + event loop; bridge methods proxy via `run_coroutine_threadsafe`. All sync SQLite/numpy inside memU's pipelines executes there, never on the main loop. LLM clients are created on the memU loop (httpx loop-affinity respected); `wait_for` cancellation propagates to the memU-loop task.
- `_submit` falls back to inline awaiting when the loop isn't running (unit tests, pre-init).
- Audit writes triggered from the memU loop are routed back to the main loop (aiosqlite affinity), fire-and-forget.
- New `shutdown()` (wired into engine shutdown) closes LLM transports + DB engine and joins the thread.

**SQLite tuning**
- One-time `journal_mode=WAL` conversion at init; per-connection `busy_timeout=10000` + `synchronous=NORMAL` via SQLAlchemy connect event (with pool recycle).

**Persistent vector index**
- New `_VectorIndex`: one persistent float32 matrix with amortised growth, incremental upsert/remove hooks on `create_item`/`update_item`/`delete_item`/`clear_items`, drift detection + lazy rebuild. Type-filtered top-k for semantic dedup.
- `vector_search_items` fast path and `_semantic_sqlite_reinforce` now use it — no more 130 MB re-stack per call.

**Sync-in-async sweep** (AST-scan driven, all HIGH findings fixed)
- `conversation_history` / `memory_records_by_date` handlers: queries extracted to sync helpers run via `asyncio.to_thread`.
- `get_memu_data`: full snapshot read **and** JSON serialization moved to a worker thread (multi-MB payload), returned as a prebuilt `Response`.
- Memory file routes, task/skill/plan handlers and routes, task+skill managers, upload write/read + base64, session diff reads + diff compute, FTS reseed reads, hoa/proxy binary downloads + JSONL tailing, proxy config/log open — all offloaded via `asyncio.to_thread`.
- `gc.collect`+`malloc_trim` (`_release_memory`) offloaded; conversation JSON writes offloaded.
- `sync_status` handler now uses the async DB layer instead of raw `sqlite3`.

## Validation

- 1030 tests pass (16 new: `_VectorIndex`, memU-loop submit/cancellation/shutdown, WAL pragmas, date-query helpers).
- Live smoke test against a copy of a real 871 MB memU DB (21,405 × 1536 embeddings) on the Pi:
  - vector search **12.2 ms/call** (previously ~100–400 ms re-stack per call)
  - type-filtered dedup search 11.7 ms/call
  - **main-loop worst lag 4.3 ms** while a 300-search storm ran on the memU loop
  - WAL conversion + init + recall + category CRUD + clean shutdown all verified end-to-end

## Notes

- memU monkey-patches remain pinned to `memu-py==1.4.0` (version check logs loudly on mismatch).
- Sub-millisecond single syscalls (`mkdir`, `stat`, `unlink`) intentionally stay inline; everything content-sized or query-shaped is offloaded.
- First WAL conversion on the production DB happens automatically at next startup.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*