### PR TITLE
Bootstrap UX: config-dir resolution, wizard resume, Telegram pairing

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,7 +36,14 @@ gateway:
 # Channels
 telegram:
   enabled: true
-  dm_policy: pairing             # "open" or "pairing" (require pairing code)
+  # DM authorization:
+  #   pairing — only users in allowed_users may talk to the bot. New users
+  #             authorize with a one-time code: run `nerve pair` on the
+  #             server, then send the bot `/pair <code>`. Paired IDs are
+  #             persisted to config.local.yaml automatically.
+  #   open    — anyone can talk to the bot (dangerous: full agent access).
+  dm_policy: pairing
+  # allowed_users: [123456789]   # numeric Telegram user IDs (or pair instead)
   stream_mode: partial           # "partial" (edit messages) or "full" (wait for complete)
 
 # Quiet hours (local timezone)

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,6 +5,22 @@ Nerve uses two YAML config files:
 - `config.local.yaml` — Secrets and personal overrides (gitignored)
 
 Values in `config.local.yaml` are deep-merged on top of `config.yaml`.
+Unknown keys are ignored but logged as warnings at startup (and shown by
+`nerve doctor`) so typos don't fail silently.
+
+## Config Directory Resolution
+
+`nerve` commands locate the config directory via a waterfall, so they work
+from any working directory:
+
+1. `--config-dir` / `-c` flag
+2. `NERVE_CONFIG_DIR` environment variable
+3. The current directory, if it contains `config.yaml` or `config.local.yaml`
+4. The pointer file `~/.nerve/config_dir` (written by `nerve init` and on
+   daemon start)
+5. The current directory (fresh-install fallback)
+
+`nerve doctor` reports which directory was used and how it was found.
 
 ## Core
 
@@ -42,8 +58,26 @@ Values in `config.local.yaml` are deep-merged on top of `config.yaml`.
 |-----|------|---------|-------------|
 | `telegram.enabled` | bool | `true` | Enable Telegram bot |
 | `telegram.bot_token` | string | - | Bot token from @BotFather |
-| `telegram.dm_policy` | string | `pairing` | `open` or `pairing` |
+| `telegram.dm_policy` | string | `pairing` | `pairing` (allowlist + one-time pairing codes) or `open` (anyone — dangerous) |
+| `telegram.allowed_users` | list[int] | `[]` | Telegram user IDs allowed to DM the bot |
 | `telegram.stream_mode` | string | `partial` | `partial` (edit msgs) or `full` |
+
+### Pairing
+
+With `dm_policy: pairing` (the default), the bot only talks to users in
+`allowed_users` and rejects everyone else. To authorize a user without
+editing config files:
+
+1. Run `nerve pair` on the server — it prints a one-time 6-digit code
+   (valid 1 hour). On a fresh install with no `allowed_users`, a code is
+   also generated automatically at startup and printed to the log.
+2. Send the bot `/pair <code>` from the Telegram account to authorize.
+3. The user ID is appended to `telegram.allowed_users` in
+   `config.local.yaml` and takes effect immediately.
+
+An unauthorized `/start` gets a reply with the sender's numeric ID and
+pairing instructions (rate-limited); all other messages from unauthorized
+users are ignored.
 
 ## Quiet Hours
 

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,23 @@ get_python_version() {
 
 trap 'error "Installation failed at line $LINENO. See above for details."' ERR
 
+# A clean message on Ctrl+C / SIGTERM beats silent death: tell the user
+# what state they're in and how to continue.
+on_interrupt() {
+    trap - INT TERM ERR
+    printf "\n"
+    warn "Interrupted."
+    if [ "${INSTALL_DONE:-0}" = "1" ]; then
+        info "Installation itself is complete — finish setup anytime with: nerve init"
+        info "(setup answers are saved; it resumes where you left off)"
+    else
+        info "Re-run the installer to continue — completed steps are skipped."
+    fi
+    exit 130
+}
+trap on_interrupt INT TERM
+INSTALL_DONE=0
+
 # --- OS Detection ---
 
 detect_os() {
@@ -450,20 +467,66 @@ setup_path() {
 
 # --- Run nerve init ---
 
-run_init() {
-    step "Running Nerve setup"
+INIT_COMPLETED=0
+INIT_SKIPPED=0
 
+run_init() {
     local nerve_bin="$INSTALL_DIR/.venv/bin/nerve"
     local config_local="$INSTALL_DIR/config.local.yaml"
 
     if [ "$IS_UPGRADE" = "1" ] && [ -f "$config_local" ]; then
         info "Existing configuration found — skipping setup wizard"
         info "Run 'nerve init' to reconfigure"
+        INIT_COMPLETED=1
         return
     fi
 
+    # Clear boundary between installation and configuration: everything is
+    # installed at this point — the wizard is optional and resumable.
+    printf "\n"
+    printf "${BOLD}${GREEN}  Installation complete.${NC}\n"
+    printf "\n"
+    printf "  Next: an interactive setup wizard configures your API keys,\n"
+    printf "  workspace, and channels. It takes a few minutes; Ctrl+C is\n"
+    printf "  safe — answers are saved and ${BOLD}nerve init${NC} resumes later.\n"
+    printf "\n"
+
+    if ! confirm "Run the setup wizard now?"; then
+        info "Skipping setup. Run it later with: nerve init"
+        INIT_SKIPPED=1
+        return
+    fi
+
+    step "Running Nerve setup"
     cd "$INSTALL_DIR" || exit 1
-    "$nerve_bin" init
+    # Don't let a wizard abort look like a failed installation (set -e).
+    if "$nerve_bin" init; then
+        INIT_COMPLETED=1
+    else
+        printf "\n"
+        warn "Setup did not finish. Installation itself is complete."
+        info "Resume setup anytime with: nerve init"
+        INIT_SKIPPED=1
+    fi
+}
+
+# --- Offer to start the daemon ---
+
+offer_start() {
+    # Only when freshly configured and interactive
+    if [ "$INIT_COMPLETED" != "1" ] || [ "$IS_UPGRADE" = "1" ]; then
+        return
+    fi
+    printf "\n"
+    if ! confirm "Start Nerve now?"; then
+        return
+    fi
+    local nerve_bin="$INSTALL_DIR/.venv/bin/nerve"
+    if "$nerve_bin" start; then
+        NERVE_STARTED=1
+    else
+        warn "Start failed — check logs with: nerve logs"
+    fi
 }
 
 # --- Summary ---
@@ -478,6 +541,14 @@ print_summary() {
     if [ "$IS_UPGRADE" = "1" ]; then
         printf "  ${BOLD}Upgrade complete.${NC} Restart to apply changes:\n"
         printf "    ${CYAN}nerve restart${NC}\n"
+    elif [ "${NERVE_STARTED:-0}" = "1" ]; then
+        printf "  ${BOLD}Nerve is running.${NC}\n"
+        printf "    ${CYAN}http://localhost:8900${NC}     Open the web UI\n"
+        printf "    ${CYAN}nerve logs${NC}            Follow daemon logs\n"
+    elif [ "$INIT_SKIPPED" = "1" ]; then
+        printf "  ${BOLD}Finish setup, then start:${NC}\n"
+        printf "    ${CYAN}nerve init${NC}            Resume the setup wizard\n"
+        printf "    ${CYAN}nerve start${NC}           Start as daemon\n"
     else
         printf "  ${BOLD}Get started:${NC}\n"
         printf "    ${CYAN}nerve start${NC}           Start as daemon\n"
@@ -502,6 +573,7 @@ print_summary() {
         warn "nerve is not yet on PATH in this shell session"
         printf "  Run: ${BOLD}source ~/.bashrc${NC}  (or restart your terminal)\n\n"
     fi
+    printf "  ${DIM}Installer finished — you can close this terminal.${NC}\n\n"
 }
 
 # --- Usage ---
@@ -564,8 +636,11 @@ main() {
     setup_python_env
     build_web_ui
     setup_path
+    INSTALL_DONE=1
     run_init
+    offer_start
     print_summary
+    exit 0
 }
 
 main "$@"

--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -190,6 +190,9 @@ class SetupChoices:
     timezone: str = "America/New_York"
     user_name: str = ""
     telegram_bot_token: str = ""
+    # Telegram user IDs authorized to DM the bot. Empty = pair after setup
+    # via `nerve pair` + /pair <code>.
+    telegram_allowed_users: list[int] = field(default_factory=list)
     password: str = ""  # plaintext during wizard, hashed at write time
     enabled_crons: list[str] = field(default_factory=list)
     # sync sources
@@ -352,6 +355,124 @@ def _resolve_gh_token() -> tuple[str, str]:
     return ("", "none")
 
 
+# --- Bedrock helpers ---
+
+
+def bedrock_geo_prefix(region: str) -> str:
+    """Map an AWS region to its Bedrock cross-region inference-profile prefix.
+
+    Bedrock inference profiles are geography-scoped: ``us.``, ``eu.`` and
+    ``apac.``. Writing a ``us.`` model ID for an ``eu-*`` region yields an
+    instant 400 ("The provided model identifier is invalid").
+    """
+    region = (region or "").lower()
+    if region.startswith("eu-"):
+        return "eu"
+    if region.startswith(("ap-", "au-")):
+        return "apac"
+    # us-*, ca-*, sa-*, mx-* and unknown regions route via the US profile
+    return "us"
+
+
+# --- Credential validators (used by the wizard and preflight) ---
+
+
+def _telegram_get_me(token: str, timeout: float = 7.0) -> tuple[bool, str]:
+    """Validate a Telegram bot token via getMe.
+
+    Returns (True, bot_username) or (False, error_description).
+    """
+    import httpx
+
+    try:
+        resp = httpx.get(
+            f"https://api.telegram.org/bot{token}/getMe", timeout=timeout,
+        )
+        data = resp.json()
+        if resp.status_code == 200 and data.get("ok"):
+            return (True, data.get("result", {}).get("username", "") or "bot")
+        return (False, data.get("description", f"HTTP {resp.status_code}"))
+    except Exception as e:
+        return (False, str(e))
+
+
+def _check_openai_key(key: str, timeout: float = 7.0) -> tuple[bool, str]:
+    """Validate an OpenAI API key with a models list call."""
+    import httpx
+
+    try:
+        resp = httpx.get(
+            "https://api.openai.com/v1/models",
+            headers={"Authorization": f"Bearer {key}"},
+            timeout=timeout,
+        )
+        if resp.status_code == 200:
+            return (True, "key valid")
+        detail = f"HTTP {resp.status_code}"
+        try:
+            detail = resp.json().get("error", {}).get("message", detail)
+        except Exception:
+            pass
+        return (False, detail)
+    except Exception as e:
+        return (False, str(e))
+
+
+# --- Wizard progress persistence ---
+#
+# The wizard collects ~10 steps of answers and used to be all-or-nothing:
+# a Ctrl+C (or a killed installer) threw everything away and the user had
+# to start over. Answers are now checkpointed after every step so an
+# interrupted setup resumes where it left off.
+
+INIT_STATE_FILE = Path("~/.nerve/init-state.json")
+
+
+def _save_init_state(choices: SetupChoices, completed: set[str]) -> None:
+    """Checkpoint wizard progress (best-effort — never breaks the wizard)."""
+    import dataclasses
+    from datetime import datetime
+
+    try:
+        data = dataclasses.asdict(choices)
+        data["workspace_path"] = str(choices.workspace_path)
+        state = {
+            "choices": data,
+            "completed": sorted(completed),
+            "saved_at": datetime.now().isoformat(timespec="seconds"),
+        }
+        path = INIT_STATE_FILE.expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state), encoding="utf-8")
+        os.chmod(path, 0o600)  # contains API keys
+    except OSError:
+        pass
+
+
+def _load_init_state() -> dict | None:
+    try:
+        return json.loads(
+            INIT_STATE_FILE.expanduser().read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _clear_init_state() -> None:
+    INIT_STATE_FILE.expanduser().unlink(missing_ok=True)
+
+
+def _choices_from_dict(data: dict) -> SetupChoices:
+    """Rebuild SetupChoices from a saved state dict (ignores unknown keys)."""
+    import dataclasses
+
+    valid = {f.name for f in dataclasses.fields(SetupChoices)}
+    kwargs = {k: v for k, v in dict(data).items() if k in valid}
+    if "workspace_path" in kwargs:
+        kwargs["workspace_path"] = Path(kwargs["workspace_path"])
+    return SetupChoices(**kwargs)
+
+
 class SetupWizard:
     """Interactive first-run setup wizard."""
 
@@ -360,39 +481,113 @@ class SetupWizard:
         self.choices = SetupChoices()
         self._inside_docker = inside_docker
         self._step_counter = 0
+        self._completed_steps: set[str] = set()
         if inside_docker:
             self.choices.deployment = "docker"
+
+    def _planned_total(self) -> int | None:
+        """Total number of steps, known once the mode has been chosen."""
+        if "mode" not in self._completed_steps:
+            return None
+        total = 0 if self._inside_docker else 1  # deployment
+        total += 4  # mode, api keys, workspace, password
+        total += 6 if self.choices.mode == "personal" else 1
+        return total
 
     def _next_step(self, label: str) -> str:
         """Return a formatted step header with auto-incrementing number."""
         self._step_counter += 1
+        total = self._planned_total()
+        if total:
+            return f"Step {self._step_counter}/{total}: {label}"
         return f"Step {self._step_counter}: {label}"
 
+    def _do(self, name: str, step_fn) -> None:
+        """Run a wizard step with checkpointing.
+
+        Skips steps already answered in a resumed session (keeping the
+        step counter consistent) and saves progress after each step so an
+        interrupted wizard can resume instead of starting over.
+        """
+        if name in self._completed_steps:
+            self._step_counter += 1
+            return
+        step_fn()
+        self._completed_steps.add(name)
+        _save_init_state(self.choices, self._completed_steps)
+
+    def _maybe_resume(self) -> bool:
+        """Offer to resume an interrupted setup. Returns True if resumed."""
+        state = _load_init_state()
+        if not state or not state.get("completed"):
+            return False
+        completed = list(state.get("completed", []))
+        saved_at = state.get("saved_at", "")
+
+        click.clear()
+        click.secho("Interrupted setup found", fg="cyan", bold=True)
+        click.echo()
+        when = f" (saved {saved_at})" if saved_at else ""
+        click.secho(
+            f"A previous 'nerve init' didn't finish{when}.\n"
+            f"Answered steps: {', '.join(completed)}",
+            dim=True,
+        )
+        click.echo()
+        if click.confirm("Resume where you left off?", default=True):
+            try:
+                self.choices = _choices_from_dict(state.get("choices", {}))
+            except (TypeError, ValueError):
+                click.secho("  Saved answers unreadable — starting fresh.", fg="yellow")
+                _clear_init_state()
+                return False
+            if self._inside_docker:
+                self.choices.deployment = "docker"
+            self._completed_steps = set(completed)
+            click.echo()
+            return True
+        _clear_init_state()
+        return False
+
     def run(self) -> SetupChoices:
-        """Run the full interactive wizard. Returns choices (nothing written yet)."""
-        self._welcome()
-        if not self._inside_docker:
-            self._step_deployment()
-            if self.choices.deployment == "docker":
-                self._step_docker_credentials()
-                self._launch_docker()
-                return self.choices  # Never reached — execvp replaces process
-        self._step_mode()
-        self._step_api_keys()
-        self._step_workspace()
-        self._step_password()
-        if self.choices.mode == "personal":
-            self._step_identity()
-            self._step_channels()
-            self._step_sources()
-            self._step_crons()
-            self._step_houseofagents()
-            self._step_external_agents()
-        else:
-            self._step_worker_setup()
-        self._step_review()
-        self._apply()
-        self._done()
+        """Run the full interactive wizard.
+
+        Nothing is applied until the review step; answers are checkpointed
+        along the way so Ctrl+C never loses progress.
+        """
+        resumed = self._maybe_resume()
+        try:
+            if not resumed:
+                self._welcome()
+            if not self._inside_docker:
+                self._do("deployment", self._step_deployment)
+                if self.choices.deployment == "docker":
+                    self._do("docker_credentials", self._step_docker_credentials)
+                    self._launch_docker()
+                    return self.choices  # Never reached — execvp replaces process
+            self._do("mode", self._step_mode)
+            self._do("api_keys", self._step_api_keys)
+            self._do("workspace", self._step_workspace)
+            self._do("password", self._step_password)
+            if self.choices.mode == "personal":
+                self._do("identity", self._step_identity)
+                self._do("channels", self._step_channels)
+                self._do("sources", self._step_sources)
+                self._do("crons", self._step_crons)
+                self._do("houseofagents", self._step_houseofagents)
+                self._do("external_agents", self._step_external_agents)
+            else:
+                self._do("worker_setup", self._step_worker_setup)
+            self._step_review()
+            self._apply()
+            _clear_init_state()
+            self._preflight()
+            self._done()
+        except (KeyboardInterrupt, click.Abort):
+            click.echo()
+            click.secho("  Setup interrupted — your answers are saved.", fg="yellow")
+            click.secho("  Resume anytime with: nerve init", dim=True)
+            raise SystemExit(130)
         return self.choices
 
     # --- Welcome ---
@@ -789,10 +984,22 @@ class SetupWizard:
         if profile:
             self.choices.aws_profile = profile
 
+        # Bedrock model IDs are geography-scoped (us./eu./apac. inference
+        # profiles) — derive the right prefix from the region instead of
+        # assuming us. and failing with a 400 on the first message.
+        prefix = bedrock_geo_prefix(region)
+        click.echo()
+        click.secho(
+            f"  → Model IDs will use the '{prefix}.' inference-profile prefix\n"
+            f"    (e.g. {prefix}.anthropic.claude-opus-4-8) based on region {region}.",
+            fg="green",
+        )
         click.echo()
         click.secho(
             "  Make sure you have enabled Claude model access in the\n"
-            "  AWS Bedrock console for your region.",
+            "  AWS Bedrock console for your region. Not every model is\n"
+            "  offered in every geography — the preflight check at the end\n"
+            "  of setup will tell you if this one isn't.",
             fg="yellow",
         )
         click.echo()
@@ -977,10 +1184,46 @@ class SetupWizard:
         )
         click.echo()
         if click.confirm("Set up Telegram bot?", default=False):
-            token = click.prompt("  Bot token (from @BotFather)")
-            self.choices.telegram_bot_token = token
-            click.echo()
-            click.secho("  ✓ Telegram bot configured", fg="green")
+            token = click.prompt("  Bot token (from @BotFather)").strip()
+
+            # Validate immediately — a bad token is much cheaper to fix now
+            # than after the first silent failure.
+            click.echo("  Verifying token...", nl=False)
+            ok, detail = _telegram_get_me(token)
+            if ok:
+                click.secho(f" ✓ @{detail}", fg="green")
+            else:
+                click.secho(f" ✗ {detail}", fg="yellow")
+                if not click.confirm("  Keep this token anyway?", default=False):
+                    token = ""
+                    click.secho("  → Skipping Telegram.", dim=True)
+
+            if token:
+                self.choices.telegram_bot_token = token
+                click.echo()
+                click.secho(
+                    "  Only authorized users can talk to the bot. Enter your\n"
+                    "  numeric Telegram user ID to authorize yourself now\n"
+                    "  (message @userinfobot on Telegram to get it).\n\n"
+                    "  Or press Enter to skip — after setup, run 'nerve pair'\n"
+                    "  and send the bot /pair <code> to authorize.",
+                    dim=True,
+                )
+                click.echo()
+                uid_raw = click.prompt(
+                    "  Your Telegram user ID (Enter to skip)", default="",
+                ).strip()
+                if uid_raw:
+                    try:
+                        self.choices.telegram_allowed_users = [int(uid_raw)]
+                        click.secho("  ✓ You're authorized to DM the bot", fg="green")
+                    except ValueError:
+                        click.secho(
+                            "  Not a number — skipping. Pair later with 'nerve pair'.",
+                            fg="yellow",
+                        )
+                click.echo()
+                click.secho("  ✓ Telegram bot configured", fg="green")
         else:
             click.secho("  → Skipping Telegram. You can set it up later in config.local.yaml.", dim=True)
         click.echo()
@@ -1333,7 +1576,12 @@ class SetupWizard:
         else:
             api_status += "  OpenAI —"
 
-        tg_status = "configured" if self.choices.telegram_bot_token else "not configured"
+        if not self.choices.telegram_bot_token:
+            tg_status = "not configured"
+        elif self.choices.telegram_allowed_users:
+            tg_status = "configured (you're authorized)"
+        else:
+            tg_status = "configured (pair after setup)"
 
         click.secho("  ┌──────────────────────────────────────────────┐", dim=True)
         click.secho("  │            Setup Summary                     │", bold=True)
@@ -1388,12 +1636,17 @@ class SetupWizard:
 
         if not click.confirm("  Apply this configuration?", default=True):
             if click.confirm("  Restart setup?", default=True):
-                # Re-run the whole wizard
+                # Re-run the whole wizard from scratch
+                _clear_init_state()
                 self.choices = SetupChoices()
+                if self._inside_docker:
+                    self.choices.deployment = "docker"
+                self._completed_steps = set()
+                self._step_counter = 0
                 self.run()
                 raise SystemExit(0)
             else:
-                click.secho("  Aborted.", fg="yellow")
+                click.secho("  Aborted — your answers are saved; resume with 'nerve init'.", fg="yellow")
                 raise SystemExit(0)
 
     # --- Apply ---
@@ -1437,29 +1690,41 @@ class SetupWizard:
                 encoding="utf-8",
             )
 
-        # 6. Write config.yaml
+        # 6. Back up existing configs before regenerating — re-running init
+        # must never silently destroy hand edits (model tweaks, paired
+        # Telegram users, ...).
+        backed_up = []
+        for name in ("config.yaml", "config.local.yaml"):
+            existing = self.config_dir / name
+            if existing.exists():
+                shutil.copy2(existing, existing.with_suffix(existing.suffix + ".bak"))
+                backed_up.append(f"{name}.bak")
+        if backed_up:
+            click.echo(f"  Backed up existing config → {', '.join(backed_up)}")
+
+        # 7. Write config.yaml
         click.echo("  Writing config.yaml...", nl=False)
         self._write_config_yaml()
         click.secho(" ✓", fg="green")
 
-        # 7. Write config.local.yaml
+        # 8. Write config.local.yaml
         click.echo("  Writing config.local.yaml...", nl=False)
         self._write_config_local_yaml()
         click.secho(" ✓", fg="green")
 
-        # 8. Create ~/.nerve directory structure
+        # 9. Create ~/.nerve directory structure
         click.echo("  Setting up ~/.nerve/...", nl=False)
         nerve_dir = Path("~/.nerve").expanduser()
         nerve_dir.mkdir(parents=True, exist_ok=True)
         (nerve_dir / "cron").mkdir(parents=True, exist_ok=True)
         click.secho(" ✓", fg="green")
 
-        # 9. Write cron jobs
+        # 10. Write cron jobs
         click.echo("  Configuring cron jobs...", nl=False)
         self._write_cron_jobs()
         click.secho(" ✓", fg="green")
 
-        # 10. Configure external agents (Codex, Claude Code, ...) if any
+        # 11. Configure external agents (Codex, Claude Code, ...) if any
         if self.choices.external_agents:
             click.echo("  Configuring external agents...", nl=False)
             try:
@@ -1468,7 +1733,7 @@ class SetupWizard:
             except Exception as e:
                 click.secho(f" ✗ {e}", fg="red")
 
-        # 11. Build web UI (server mode only — Docker handles this in entrypoint)
+        # 12. Build web UI (server mode only — Docker handles this in entrypoint)
         if not self._inside_docker:
             self._build_web_ui()
 
@@ -1751,13 +2016,16 @@ class SetupWizard:
             }
             if self.choices.aws_profile:
                 config["provider"]["aws_profile"] = self.choices.aws_profile
-            # Override model names to Bedrock IDs
-            config["agent"]["model"] = "us.anthropic.claude-opus-4-8"
-            config["agent"]["cron_model"] = "us.anthropic.claude-sonnet-4-6"
-            config["agent"]["title_model"] = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
-            config["memory"]["recall_model"] = "us.anthropic.claude-sonnet-4-6"
-            config["memory"]["memorize_model"] = "us.anthropic.claude-sonnet-4-6"
-            config["memory"]["fast_model"] = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+            # Override model names to Bedrock inference-profile IDs.
+            # The prefix is geography-scoped (us./eu./apac.) and must match
+            # the configured region or every call 400s.
+            geo = bedrock_geo_prefix(self.choices.aws_region)
+            config["agent"]["model"] = f"{geo}.anthropic.claude-opus-4-8"
+            config["agent"]["cron_model"] = f"{geo}.anthropic.claude-sonnet-4-6"
+            config["agent"]["title_model"] = f"{geo}.anthropic.claude-haiku-4-5-20251001-v1:0"
+            config["memory"]["recall_model"] = f"{geo}.anthropic.claude-sonnet-4-6"
+            config["memory"]["memorize_model"] = f"{geo}.anthropic.claude-sonnet-4-6"
+            config["memory"]["fast_model"] = f"{geo}.anthropic.claude-haiku-4-5-20251001-v1:0"
 
         if self.choices.use_proxy:
             config["proxy"] = {
@@ -1805,6 +2073,10 @@ class SetupWizard:
             local["telegram"] = {
                 "bot_token": self.choices.telegram_bot_token,
             }
+            if self.choices.telegram_allowed_users:
+                local["telegram"]["allowed_users"] = list(
+                    self.choices.telegram_allowed_users
+                )
 
         # Sync credentials (secrets — go in local config)
         if self.choices.telegram_sync and self.choices.telegram_api_id:
@@ -1919,6 +2191,84 @@ class SetupWizard:
                 f.write("# Format is the same as system.yaml — see it for examples.\n\n")
                 f.write("jobs: []\n")
 
+    # --- Preflight ---
+
+    def _preflight(self) -> None:
+        """Validate the configuration that was just written with real calls.
+
+        Catches bad API keys, unavailable Bedrock models (wrong region /
+        no model access), and broken Telegram tokens at setup time instead
+        of at the first message. Failures are informative, never fatal.
+        """
+        click.echo()
+        click.secho("  Preflight checks:", bold=True)
+        failures: list[str] = []
+
+        # --- Claude API ---
+        if self.choices.use_proxy:
+            click.secho(
+                "    – Claude API: skipped (proxy mode — verified at first start)",
+                dim=True,
+            )
+        elif self.choices.claude_oauth_token:
+            click.secho(
+                "    – Claude API: skipped (OAuth token — verified on first use)",
+                dim=True,
+            )
+        elif self.choices.provider_type == "bedrock" or self.choices.anthropic_api_key:
+            click.echo("    · Claude API: testing...", nl=False)
+            try:
+                from nerve.cli import _check_api_connectivity
+                from nerve.config import load_config as _load_config
+
+                cfg = _load_config(self.config_dir)
+                ok, detail = _check_api_connectivity(cfg)
+            except Exception as e:  # never let preflight crash the wizard
+                ok, detail = False, str(e)
+            if ok:
+                click.secho(f" ✓ {detail}", fg="green")
+            else:
+                click.secho(f" ✗ {detail}", fg="red")
+                failures.append("Claude API")
+                if self.choices.provider_type == "bedrock":
+                    click.secho(
+                        "      Check Claude model access for your region in the AWS\n"
+                        "      Bedrock console. If this model isn't offered in your\n"
+                        "      geography, edit agent.model in config.yaml.",
+                        dim=True,
+                    )
+        else:
+            click.secho("    – Claude API: no credentials configured", dim=True)
+
+        # --- Telegram ---
+        if self.choices.telegram_bot_token:
+            click.echo("    · Telegram bot: testing...", nl=False)
+            ok, detail = _telegram_get_me(self.choices.telegram_bot_token)
+            if ok:
+                click.secho(f" ✓ @{detail}", fg="green")
+            else:
+                click.secho(f" ✗ {detail}", fg="red")
+                failures.append("Telegram")
+
+        # --- OpenAI (optional embeddings) ---
+        if self.choices.openai_api_key:
+            click.echo("    · OpenAI API: testing...", nl=False)
+            ok, detail = _check_openai_key(self.choices.openai_api_key)
+            if ok:
+                click.secho(f" ✓ {detail}", fg="green")
+            else:
+                click.secho(f" ✗ {detail}", fg="red")
+                failures.append("OpenAI")
+
+        if failures:
+            click.echo()
+            click.secho(
+                f"  ⚠ {len(failures)} check(s) failed: {', '.join(failures)}.\n"
+                "    Nerve will still start — fix the values in config.local.yaml\n"
+                "    (or config.yaml) and re-verify with 'nerve doctor'.",
+                fg="yellow",
+            )
+
     # --- Done ---
 
     def _done(self) -> None:
@@ -1943,6 +2293,12 @@ class SetupWizard:
         click.echo("    Edit SOUL.md to customize Nerve's personality")
         click.echo("    Edit USER.md to tell Nerve about yourself")
         click.echo()
+        if self.choices.telegram_bot_token and not self.choices.telegram_allowed_users:
+            click.secho("  Telegram pairing:", bold=True)
+            click.echo("    1. Start Nerve, then run: nerve pair")
+            click.echo("    2. Send the bot:  /pair <code>")
+            click.echo("    (until paired, the bot ignores all DMs)")
+            click.echo()
         click.secho(
             "  Tip: Nerve learns from every conversation. The more\n"
             "  you interact, the more useful it becomes.",
@@ -2006,6 +2362,19 @@ def run_non_interactive(config_dir: Path) -> SetupChoices:
     choices.workspace_path = Path(os.environ.get("NERVE_WORKSPACE", default_ws))
     choices.timezone = os.environ.get("NERVE_TIMEZONE", "America/New_York")
     choices.telegram_bot_token = os.environ.get("NERVE_TELEGRAM_BOT_TOKEN", "")
+    # Comma-separated Telegram user IDs allowed to DM the bot. Without this
+    # the bot starts in pairing mode (authorize via `nerve pair`).
+    allowed_raw = os.environ.get("NERVE_TELEGRAM_ALLOWED_USERS", "")
+    if allowed_raw.strip():
+        try:
+            choices.telegram_allowed_users = [
+                int(u.strip()) for u in allowed_raw.split(",") if u.strip()
+            ]
+        except ValueError:
+            raise click.ClickException(
+                f"NERVE_TELEGRAM_ALLOWED_USERS must be comma-separated numeric "
+                f"user IDs, got: {allowed_raw!r}"
+            )
     choices.password = os.environ.get("NERVE_PASSWORD", "")
 
     # Sources — auto-detect from available CLIs

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -244,6 +244,8 @@ class TelegramChannel(BaseChannel):
             collections.OrderedDict()
         )
         self._message_cache_max = 200
+        # Rate limiter for replies to unauthorized users: user_id -> monotonic ts
+        self._unauth_reply_times: dict[int, float] = {}
 
     def set_notification_service(self, service) -> None:
         """Wire the notification service for callback query handling."""
@@ -300,6 +302,7 @@ class TelegramChannel(BaseChannel):
 
         # Register handlers
         app.add_handler(CommandHandler("start", self._handle_start))
+        app.add_handler(CommandHandler("pair", self._handle_pair))
         app.add_handler(CommandHandler("session", self._handle_session))
         app.add_handler(CommandHandler("sessions", self._handle_sessions))
         app.add_handler(CommandHandler("new", self._handle_new_session))
@@ -341,10 +344,38 @@ class TelegramChannel(BaseChannel):
         self._last_update_time = time.monotonic()
         logger.info("Telegram bot started polling (with TCP keepalive)")
 
+        self._announce_auth_state()
+
         # Launch watchdog for monitoring + recovery
         self._watchdog_task = asyncio.create_task(
             self._run_watchdog(), name="telegram-polling-watchdog",
         )
+
+    def _announce_auth_state(self) -> None:
+        """Log how DM authorization is configured — loudly when it matters.
+
+        A fresh install with an empty allowlist used to be silently dead:
+        the bot polled fine but rejected every DM with only a log line.
+        Now pairing mode generates a code and tells the operator what to do.
+        """
+        tg = self.config.telegram
+        if tg.dm_policy == "open":
+            logger.warning(
+                "telegram.dm_policy is 'open' — ANY Telegram user can talk to "
+                "this bot and use the agent. Set dm_policy: pairing unless you "
+                "really want this."
+            )
+            return
+        if not self._allowed_users:
+            from nerve import pairing
+
+            code = pairing.get_or_create_pairing_code()
+            logger.info(
+                "Telegram: no allowed_users configured — pairing mode active. "
+                "Send the bot:  /pair %s  to authorize your account "
+                "(code valid for 1h; run `nerve pair` to get a fresh one).",
+                code,
+            )
 
     async def stop(self) -> None:
         self._stopping = True
@@ -672,12 +703,33 @@ class TelegramChannel(BaseChannel):
     # ------------------------------------------------------------------ #
 
     def _is_authorized(self, user_id: int) -> bool:
-        """Check if a user is in the allowed_users whitelist."""
+        """Check if a user may talk to the bot.
+
+        dm_policy "open" authorizes everyone (a startup warning is logged).
+        Otherwise the allowed_users allowlist applies; an empty allowlist
+        blocks everyone (fail closed) until a user pairs via /pair.
+        """
+        if self.config.telegram.dm_policy == "open":
+            return True
         if not self._allowed_users:
             # No whitelist configured — block everyone (fail closed)
             logger.warning("No allowed_users configured — rejecting user %d", user_id)
             return False
         return user_id in self._allowed_users
+
+    def _should_reply_unauthorized(self, user_id: int) -> bool:
+        """Rate-limit replies to unauthorized users (once per 10 min each)."""
+        now = time.monotonic()
+        if now - self._unauth_reply_times.get(user_id, 0.0) < 600:
+            return False
+        self._unauth_reply_times[user_id] = now
+        # Bound the dict so strangers can't grow it unboundedly
+        if len(self._unauth_reply_times) > 500:
+            for uid, _ in sorted(
+                self._unauth_reply_times.items(), key=lambda kv: kv[1],
+            )[:250]:
+                self._unauth_reply_times.pop(uid, None)
+        return True
 
     # ------------------------------------------------------------------ #
     #  Command handlers — delegate to router for session management        #
@@ -693,9 +745,73 @@ class TelegramChannel(BaseChannel):
         user_id = update.effective_user.id
         if not self._is_authorized(user_id):
             logger.warning("Unauthorized /start from user %d", user_id)
+            # In pairing mode, tell the user how to pair instead of going
+            # silent — surfacing their ID is the single most useful hint.
+            if (
+                self.config.telegram.dm_policy == "pairing"
+                and self._should_reply_unauthorized(user_id)
+            ):
+                await update.message.reply_text(
+                    "This Nerve instance isn't paired with your account.\n"
+                    f"Your Telegram ID: {user_id}\n\n"
+                    "To pair, run `nerve pair` on the server, then send me:\n"
+                    "/pair <code>"
+                )
             return
         await update.message.reply_text(
             "Connected to Nerve. Send me a message to start chatting."
+        )
+
+    async def _handle_pair(self, update: Update, context: Any) -> None:
+        """Handle /pair <code> — authorize a user via a one-time pairing code."""
+        self._touch()
+        user_id = update.effective_user.id
+
+        if self._is_authorized(user_id):
+            await update.message.reply_text("Already paired — you're authorized.")
+            return
+
+        if self.config.telegram.dm_policy != "pairing":
+            logger.warning("Ignoring /pair from user %d (dm_policy != pairing)", user_id)
+            return
+
+        from nerve import pairing
+        from nerve.config import append_telegram_allowed_user
+
+        args = getattr(context, "args", None) or []
+        code = args[0].strip() if args else ""
+        if not code:
+            if self._should_reply_unauthorized(user_id):
+                await update.message.reply_text(
+                    "Usage: /pair <code>\n"
+                    "Get the code by running `nerve pair` on the server."
+                )
+            return
+
+        if not pairing.verify_pairing_code(code):
+            logger.warning("Failed /pair attempt from user %d", user_id)
+            if self._should_reply_unauthorized(user_id):
+                await update.message.reply_text(
+                    "Invalid or expired code. Run `nerve pair` on the server "
+                    "to get a fresh one."
+                )
+            return
+
+        # Success: authorize in memory and persist to config.local.yaml
+        self._allowed_users.add(user_id)
+        try:
+            append_telegram_allowed_user(self.config.config_dir, user_id)
+        except Exception:
+            logger.exception("Paired user %d but failed to persist to config", user_id)
+            await update.message.reply_text(
+                "Paired for this run, but saving to config failed — check "
+                "server logs. Add your ID to telegram.allowed_users manually "
+                "to make it permanent."
+            )
+            return
+        logger.info("Telegram user %d paired successfully", user_id)
+        await update.message.reply_text(
+            "✓ Paired. You're now authorized — send me a message to start chatting."
         )
         logger.info("Telegram user authorized: %d", user_id)
 

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -26,12 +26,16 @@ from pathlib import Path
 
 import click
 
-from nerve.config import load_config, set_config
+from nerve.config import (
+    load_config,
+    resolve_config_dir,
+    set_config,
+    write_config_pointer,
+)
 
 # Default PID file location
 PID_DIR = Path("~/.nerve").expanduser()
 PID_FILE = PID_DIR / "nerve.pid"
-CONFIG_DIR_FILE = PID_DIR / "config_dir"
 LOG_FILE = PID_DIR / "nerve.log"
 
 
@@ -74,15 +78,7 @@ def _write_pid(pid: int, config_dir: Path | None = None) -> None:
     PID_DIR.mkdir(parents=True, exist_ok=True)
     PID_FILE.write_text(str(pid))
     if config_dir is not None:
-        CONFIG_DIR_FILE.write_text(str(config_dir.resolve()))
-
-
-def _read_config_dir() -> Path | None:
-    """Read stored config directory. Returns None if not available."""
-    try:
-        return Path(CONFIG_DIR_FILE.read_text().strip())
-    except (FileNotFoundError, ValueError):
-        return None
+        write_config_pointer(config_dir)
 
 
 def _remove_pid() -> None:
@@ -169,17 +165,27 @@ def _docker_compose(
 
 
 @click.group()
-@click.option("--config-dir", "-c", type=click.Path(), default=".", help="Config directory")
+@click.option(
+    "--config-dir", "-c", type=click.Path(), default=None,
+    help="Config directory (default: auto-detected — see `nerve doctor`)",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Enable debug logging")
 @click.pass_context
-def main(ctx: click.Context, config_dir: str, verbose: bool) -> None:
+def main(ctx: click.Context, config_dir: str | None, verbose: bool) -> None:
     """Nerve — Personal AI Assistant"""
     setup_logging(verbose)
-    config = load_config(Path(config_dir))
+    # Resolve the config directory via the waterfall (flag → env → cwd →
+    # pointer file) so commands work from any directory, not just the
+    # install dir.
+    resolved_dir, config_source = resolve_config_dir(config_dir)
+    if not resolved_dir.is_absolute():
+        resolved_dir = resolved_dir.resolve()
+    config = load_config(resolved_dir)
     set_config(config)
     ctx.ensure_object(dict)
     ctx.obj["config"] = config
-    ctx.obj["config_dir"] = config_dir
+    ctx.obj["config_dir"] = str(resolved_dir)
+    ctx.obj["config_source"] = config_source
     ctx.obj["verbose"] = verbose
 
 
@@ -209,6 +215,10 @@ def init(ctx: click.Context, if_needed: bool, non_interactive: bool, inside_dock
     else:
         wizard = SetupWizard(config_dir, inside_docker=inside_docker)
         wizard.run()
+
+    # Remember where the config lives so every future `nerve` command
+    # finds it regardless of the caller's working directory.
+    write_config_pointer(config_dir)
 
     # Reload config after wizard writes files
     config = load_config(config_dir)
@@ -357,13 +367,9 @@ def restart(ctx: click.Context) -> None:
     helper runs in its own session and survives the parent's death.
     """
     config = ctx.obj["config"]
+    # Already resolved via the waterfall (flag → env → cwd → pointer), so
+    # this is an absolute path that doesn't depend on the caller's CWD.
     config_dir = Path(ctx.obj["config_dir"])
-
-    # Prefer the config dir stored by the running daemon — it's an absolute
-    # path that doesn't depend on the caller's CWD.
-    stored = _read_config_dir()
-    if stored is not None and stored.is_dir():
-        config_dir = stored
 
     # Docker mode: proxy to docker compose
     if _is_docker_mode(config):
@@ -654,11 +660,44 @@ def upgrade(ctx: click.Context, no_frontend: bool, no_deps: bool, no_pull: bool)
     click.echo("  nerve restart")
 
 
-def doctor_report(config) -> str:
+_CONFIG_SOURCE_LABELS = {
+    "flag": "--config-dir flag",
+    "env": "NERVE_CONFIG_DIR env var",
+    "cwd": "current directory",
+    "pointer": "~/.nerve/config_dir pointer",
+    "default": "current directory (no config found anywhere)",
+}
+
+
+def _check_api_connectivity(config) -> tuple[bool, str]:
+    """Make a 1-token API call through the configured provider.
+
+    Catches bad API keys, missing Bedrock model access, and wrong
+    inference-profile prefixes — at diagnosis time instead of first message.
+    """
+    model = config.agent.title_model
+    try:
+        client = config.create_anthropic_client(timeout=15.0)
+        client.messages.create(
+            model=model,
+            max_tokens=1,
+            messages=[{"role": "user", "content": "ping"}],
+        )
+        return True, f"model {model} reachable"
+    except Exception as e:
+        detail = str(e)
+        if len(detail) > 200:
+            detail = detail[:200] + "…"
+        return False, f"{model}: {detail}"
+
+
+def doctor_report(config, config_source: str = "", check_api: bool = False) -> str:
     """Run doctor checks and return the report as a plain-text string.
 
     Used by both the CLI ``nerve doctor`` command and the Telegram ``/doctor``
-    command so they share the same diagnostics.
+    command so they share the same diagnostics. ``check_api`` makes a real
+    (1-token) API call through the configured provider — enabled for the CLI,
+    skipped for the in-daemon Telegram handler to avoid blocking the loop.
     """
     lines: list[str] = []
     errors: list[str] = []
@@ -666,6 +705,41 @@ def doctor_report(config) -> str:
 
     lines.append("Nerve Doctor")
     lines.append("=" * 40)
+
+    # Where the config came from — surfaces CWD mixups immediately
+    config_dir = getattr(config, "config_dir", None)
+    if config_dir is not None:
+        source_label = _CONFIG_SOURCE_LABELS.get(config_source, config_source)
+        suffix = f" (via {source_label})" if source_label else ""
+        has_base = (Path(config_dir) / "config.yaml").exists()
+        has_local = (Path(config_dir) / "config.local.yaml").exists()
+        if has_base or has_local:
+            present = " + ".join(
+                n for n, ok in (
+                    ("config.yaml", has_base), ("config.local.yaml", has_local),
+                ) if ok
+            )
+            lines.append(f"[OK] Config: {config_dir} ({present}){suffix}")
+        else:
+            errors.append(
+                f"[ERR] No config files in {config_dir}{suffix} — "
+                "run 'nerve init', or point at an existing install with "
+                "-c/--config-dir or NERVE_CONFIG_DIR"
+            )
+
+    # Unknown / misspelled config keys
+    try:
+        from nerve.config import _deep_merge, validate_config_keys
+        merged: dict = {}
+        for name in ("config.yaml", "config.local.yaml"):
+            p = Path(config_dir or ".") / name
+            if p.exists():
+                import yaml as _yaml
+                merged = _deep_merge(merged, _yaml.safe_load(p.read_text()) or {})
+        for w in validate_config_keys(merged):
+            warnings.append(f"[WARN] config: {w}")
+    except Exception:
+        pass
 
     # Daemon status
     running, pid = _get_daemon_status()
@@ -717,8 +791,25 @@ def doctor_report(config) -> str:
         except Exception:
             warnings.append("[WARN] Proxy not running (starts with Nerve)")
 
-    # Check API keys
-    if config.proxy.enabled:
+    # Check API keys / provider
+    if config.provider.is_bedrock:
+        region = config.provider.aws_region or "(default)"
+        lines.append(f"[OK] Provider: AWS Bedrock, region {region}")
+        # Inference-profile prefix must match the region's geography
+        # (us./eu./apac.) — a mismatch means instant 400s.
+        from nerve.bootstrap import bedrock_geo_prefix
+        expected = bedrock_geo_prefix(config.provider.aws_region)
+        for label, model in (
+            ("agent.model", config.agent.model),
+            ("agent.cron_model", config.agent.cron_model),
+        ):
+            geo = model.split(".", 1)[0] if "." in model else ""
+            if geo in ("us", "eu", "apac", "global") and geo not in (expected, "global"):
+                warnings.append(
+                    f"[WARN] {label} '{model}' uses the '{geo}.' inference profile "
+                    f"but region {region} is '{expected}.' — expect 400 errors"
+                )
+    elif config.proxy.enabled:
         if config.anthropic_api_key:
             lines.append("[--] Anthropic API key set (proxy takes precedence)")
         else:
@@ -727,6 +818,14 @@ def doctor_report(config) -> str:
         lines.append(f"[OK] Anthropic API key: ...{config.anthropic_api_key[-4:]}")
     else:
         errors.append("[ERR] Anthropic API key not set and proxy not enabled (config.local.yaml)")
+
+    # Live connectivity probe (CLI only — see check_api docstring note)
+    if check_api and (config.provider.is_bedrock or config.anthropic_api_key):
+        ok, detail = _check_api_connectivity(config)
+        if ok:
+            lines.append(f"[OK] Claude API: {detail}")
+        else:
+            errors.append(f"[ERR] Claude API: {detail}")
 
     if config.openai_api_key:
         lines.append(f"[OK] OpenAI API key: ...{config.openai_api_key[-4:]} (vector embeddings enabled)")
@@ -737,6 +836,17 @@ def doctor_report(config) -> str:
     if config.telegram.enabled:
         if config.telegram.bot_token:
             lines.append(f"[OK] Telegram bot token: ...{config.telegram.bot_token[-4:]}")
+            if config.telegram.dm_policy == "open":
+                warnings.append(
+                    "[WARN] telegram.dm_policy is 'open' — any Telegram user "
+                    "can talk to this bot"
+                )
+            elif not config.telegram.allowed_users:
+                warnings.append(
+                    "[WARN] telegram.allowed_users is empty — the bot rejects "
+                    "all DMs until you pair (run 'nerve pair', then send the "
+                    "bot /pair <code>)"
+                )
         else:
             errors.append("[ERR] Telegram enabled but bot_token not set")
     else:
@@ -829,10 +939,59 @@ def doctor_report(config) -> str:
 def doctor(ctx: click.Context) -> None:
     """Check config, DB, API keys, and connectivity."""
     config = ctx.obj["config"]
-    report = doctor_report(config)
+    report = doctor_report(
+        config,
+        config_source=ctx.obj.get("config_source", ""),
+        check_api=True,
+    )
     click.echo(report)
     if "[ERR]" in report:
         ctx.exit(1)
+
+
+@main.command()
+@click.pass_context
+def pair(ctx: click.Context) -> None:
+    """Generate a Telegram pairing code.
+
+    Send /pair <code> to your bot within an hour to authorize your
+    Telegram account. The paired user ID is persisted to
+    config.local.yaml (telegram.allowed_users).
+    """
+    config = ctx.obj["config"]
+
+    if not config.telegram.enabled or not config.telegram.bot_token:
+        click.echo("Telegram is not configured (telegram.bot_token missing).")
+        click.echo("Set it up in config.local.yaml, or re-run 'nerve init'.")
+        ctx.exit(1)
+        return
+
+    if config.telegram.dm_policy != "pairing":
+        click.echo(
+            f"telegram.dm_policy is '{config.telegram.dm_policy}' — pairing is "
+            "only used with dm_policy: pairing."
+        )
+        ctx.exit(1)
+        return
+
+    from nerve.pairing import CODE_TTL_SECONDS, generate_pairing_code
+
+    code = generate_pairing_code()
+    running, _pid = _get_daemon_status()
+
+    click.echo()
+    click.secho(f"  Pairing code: {code}", bold=True)
+    click.echo()
+    click.echo(f"  Send this to your bot:  /pair {code}")
+    click.echo(f"  Valid for {CODE_TTL_SECONDS // 60} minutes, single use.")
+    if not running:
+        click.echo()
+        click.secho(
+            "  Note: Nerve is not running — start it first ('nerve start'), "
+            "then send the command.",
+            fg="yellow",
+        )
+    click.echo()
 
 
 @main.command()

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -135,14 +135,30 @@ class TelegramConfig:
     bot_token: str = ""
     allowed_users: list[int] = field(default_factory=list)
     stream_mode: str = "partial"
+    # DM authorization policy:
+    #   "pairing" (default) — unknown users may pair with a one-time code
+    #                         (`nerve pair`); everyone else is rejected.
+    #   "open"              — anyone can talk to the bot. Dangerous: full
+    #                         agent access for any Telegram user. A warning
+    #                         is logged at startup.
+    dm_policy: str = "pairing"
 
     @classmethod
     def from_dict(cls, d: dict) -> TelegramConfig:
+        dm_policy = d.get("dm_policy", "pairing")
+        if dm_policy not in ("pairing", "open"):
+            logger.warning(
+                "telegram.dm_policy %r is not one of ('pairing', 'open') — "
+                "falling back to 'pairing'",
+                dm_policy,
+            )
+            dm_policy = "pairing"
         return cls(
             enabled=d.get("enabled", True),
             bot_token=d.get("bot_token", ""),
-            allowed_users=d.get("allowed_users", []),
+            allowed_users=[int(u) for u in d.get("allowed_users", []) or []],
             stream_mode=d.get("stream_mode", "partial"),
+            dm_policy=dm_policy,
         )
 
 
@@ -889,6 +905,11 @@ class NerveConfig:
     openai_api_key: str = ""
     brave_search_api_key: str = ""
 
+    # Where this config was loaded from (set by load_config, not a YAML key).
+    # Used by anything that needs to write back (e.g. Telegram pairing
+    # persisting allowed_users to config.local.yaml).
+    config_dir: Path = field(default_factory=Path.cwd)
+
     @property
     def anthropic_api_base_url(self) -> str:
         """Effective Anthropic API base URL — proxy or direct."""
@@ -1028,13 +1049,93 @@ def load_mcp_servers(config_dir: Path | None = None) -> list[McpServerConfig]:
     return _parse_mcp_servers(merged)
 
 
+# --- Config directory resolution ---
+#
+# Nerve commands used to be CWD-sensitive: running `nerve start` from any
+# directory other than the install dir silently loaded an empty config and
+# reported "fresh install".  Resolution now follows a waterfall so commands
+# work from anywhere:
+#
+#   1. Explicit --config-dir / -c flag
+#   2. NERVE_CONFIG_DIR environment variable
+#   3. Current directory, if it contains config.yaml or config.local.yaml
+#      (preserves the dev workflow of running nerve from a checkout)
+#   4. The pointer file ~/.nerve/config_dir (written by `nerve init` and on
+#      daemon start), if it names a directory that still has config files
+#   5. Current directory (fresh-install fallback)
+
+CONFIG_POINTER_FILE = Path("~/.nerve/config_dir")
+
+
+def _has_config_files(directory: Path) -> bool:
+    """True if the directory contains config.yaml or config.local.yaml."""
+    try:
+        return (directory / "config.yaml").exists() or (
+            directory / "config.local.yaml"
+        ).exists()
+    except OSError:
+        return False
+
+
+def read_config_pointer() -> Path | None:
+    """Read the persisted config directory pointer. None if absent/invalid."""
+    try:
+        raw = CONFIG_POINTER_FILE.expanduser().read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return None
+    if not raw:
+        return None
+    p = Path(raw)
+    return p if p.is_dir() else None
+
+
+def write_config_pointer(config_dir: Path) -> None:
+    """Persist the config directory so future commands find it from any CWD.
+
+    Written by `nerve init` (after a successful apply) and on daemon start.
+    Best-effort: failure to write must never break the caller.
+    """
+    try:
+        pointer = CONFIG_POINTER_FILE.expanduser()
+        pointer.parent.mkdir(parents=True, exist_ok=True)
+        pointer.write_text(str(Path(config_dir).expanduser().resolve()), encoding="utf-8")
+    except OSError as e:
+        logger.warning("Could not write config pointer %s: %s", CONFIG_POINTER_FILE, e)
+
+
+def resolve_config_dir(explicit: str | Path | None = None) -> tuple[Path, str]:
+    """Resolve the effective config directory.
+
+    Returns (directory, source) where source is one of:
+    "flag", "env", "cwd", "pointer", "default".
+    """
+    if explicit is not None:
+        return Path(explicit).expanduser(), "flag"
+
+    env_dir = os.environ.get("NERVE_CONFIG_DIR", "").strip()
+    if env_dir:
+        return Path(env_dir).expanduser(), "env"
+
+    cwd = Path.cwd()
+    if _has_config_files(cwd):
+        return cwd, "cwd"
+
+    pointer = read_config_pointer()
+    if pointer is not None and _has_config_files(pointer):
+        return pointer, "pointer"
+
+    return cwd, "default"
+
+
 def load_config(config_dir: Path | None = None) -> NerveConfig:
     """Load config from config.yaml + config.local.yaml in the given directory.
 
-    If config_dir is None, uses the current working directory.
+    If config_dir is None, the directory is resolved via the waterfall in
+    :func:`resolve_config_dir` (flag/env/cwd/pointer), so commands behave the
+    same regardless of the caller's working directory.
     """
     if config_dir is None:
-        config_dir = Path.cwd()
+        config_dir, _source = resolve_config_dir()
 
     base_path = config_dir / "config.yaml"
     local_path = config_dir / "config.local.yaml"
@@ -1050,7 +1151,118 @@ def load_config(config_dir: Path | None = None) -> NerveConfig:
             local = yaml.safe_load(f) or {}
 
     merged = _deep_merge(base, local)
-    return NerveConfig.from_dict(merged)
+
+    # Surface typos and stale keys instead of silently ignoring them.
+    for warning in validate_config_keys(merged):
+        logger.warning("config: %s", warning)
+
+    config = NerveConfig.from_dict(merged)
+    config.config_dir = Path(config_dir)
+    return config
+
+
+# --- Unknown-key validation ---
+
+# YAML keys that are intentionally not dataclass fields — keyed by dotted
+# prefix ("" is the top level). claude_oauth_token / github_token are read
+# from config.local.yaml by the Docker entrypoint, not by NerveConfig.
+_EXTRA_ALLOWED_KEYS: dict[str, set[str]] = {
+    "": {"claude_oauth_token", "github_token"},
+}
+
+# Subtrees we don't descend into: free-form mappings or lists of mappings
+# whose schema isn't a nested dataclass.
+_OPAQUE_PREFIXES = {
+    "mcp_servers",
+    "memory.categories",
+    "external_agents.targets",
+    "docker.extra_mounts",
+    "langfuse.redact_patterns",
+}
+
+
+def validate_config_keys(merged: dict) -> list[str]:
+    """Compare a merged config dict against the NerveConfig dataclass tree.
+
+    Returns human-readable warnings for keys that no dataclass field will
+    ever read (typos, removed options). Warning-only by design — unknown
+    keys must not break startup (forward/backward compatibility).
+    """
+    import dataclasses
+
+    warnings: list[str] = []
+
+    def _walk(d: dict, cls: type, prefix: str) -> None:
+        field_map = {f.name: f for f in dataclasses.fields(cls)}
+        allowed_extra = _EXTRA_ALLOWED_KEYS.get(prefix, set())
+        for key, value in d.items():
+            dotted = f"{prefix}.{key}" if prefix else key
+            if key not in field_map:
+                if key in allowed_extra:
+                    continue
+                warnings.append(
+                    f"unknown key '{dotted}' — it is ignored (typo or removed option?)"
+                )
+                continue
+            if dotted in _OPAQUE_PREFIXES:
+                continue
+            # Descend into nested dataclasses only
+            ftype = field_map[key].type
+            nested = _resolve_dataclass(ftype)
+            if nested is not None and isinstance(value, dict):
+                _walk(value, nested, dotted)
+
+    def _resolve_dataclass(ftype: Any) -> type | None:
+        """Map a (possibly string) field annotation to a dataclass type."""
+        if isinstance(ftype, type) and dataclasses.is_dataclass(ftype):
+            return ftype
+        if isinstance(ftype, str):
+            candidate = globals().get(ftype)
+            if candidate is None and ftype == "HouseOfAgentsConfig":
+                candidate = HouseOfAgentsConfig
+            if isinstance(candidate, type) and dataclasses.is_dataclass(candidate):
+                return candidate
+        return None
+
+    _walk(merged, NerveConfig, "")
+    return warnings
+
+
+# --- Write-back helpers ---
+
+
+def append_telegram_allowed_user(config_dir: Path, user_id: int) -> bool:
+    """Append a Telegram user ID to telegram.allowed_users in config.local.yaml.
+
+    Used by the pairing flow. Reads, merges, and rewrites the local config
+    (config.local.yaml is generated — comment loss is acceptable there).
+    Returns True if the file was updated (False if the ID was already present).
+    """
+    local_path = Path(config_dir) / "config.local.yaml"
+    data: dict[str, Any] = {}
+    if local_path.exists():
+        try:
+            data = yaml.safe_load(local_path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as e:
+            logger.error("Cannot parse %s to persist pairing: %s", local_path, e)
+            return False
+
+    telegram = data.setdefault("telegram", {})
+    users = telegram.setdefault("allowed_users", [])
+    if user_id in users:
+        return False
+    users.append(user_id)
+
+    with open(local_path, "w", encoding="utf-8") as f:
+        f.write("# Nerve — Secrets (gitignored)\n")
+        f.write("# API keys, tokens, and other sensitive configuration.\n\n")
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+    try:
+        os.chmod(local_path, 0o600)
+    except OSError:
+        pass
+    logger.info("Persisted Telegram user %d to %s", user_id, local_path)
+    return True
 
 
 # Singleton config instance, loaded lazily

--- a/nerve/pairing.py
+++ b/nerve/pairing.py
@@ -1,0 +1,120 @@
+"""One-time pairing codes for Telegram DM authorization.
+
+The pairing flow connects a Telegram user to a Nerve instance without
+hand-editing config files:
+
+  1. A code is generated on the server — either automatically at channel
+     startup (fresh install with no ``allowed_users``) or on demand via
+     ``nerve pair``.
+  2. The user sends ``/pair <code>`` to the bot.
+  3. On a match the user's ID is appended to ``telegram.allowed_users`` in
+     config.local.yaml and authorized immediately.
+
+The code lives in ``~/.nerve/telegram_pairing`` (mode 0600) so the CLI and
+the daemon — separate processes — share it. Codes are single-use, expire
+after :data:`CODE_TTL_SECONDS`, and are invalidated after
+:data:`MAX_ATTEMPTS` failed guesses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PAIRING_FILE = Path("~/.nerve/telegram_pairing")
+CODE_TTL_SECONDS = 60 * 60  # 1 hour
+MAX_ATTEMPTS = 5
+
+
+def _pairing_path() -> Path:
+    return PAIRING_FILE.expanduser()
+
+
+def _read_state() -> dict | None:
+    try:
+        return json.loads(_pairing_path().read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _write_state(state: dict) -> None:
+    path = _pairing_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state), encoding="utf-8")
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def generate_pairing_code() -> str:
+    """Generate, persist, and return a fresh 6-digit pairing code."""
+    code = f"{secrets.randbelow(1_000_000):06d}"
+    _write_state({
+        "code": code,
+        "created_at": time.time(),
+        "expires_at": time.time() + CODE_TTL_SECONDS,
+        "attempts": 0,
+    })
+    return code
+
+
+def read_pairing_code() -> str | None:
+    """Return the current valid pairing code, or None if absent/expired."""
+    state = _read_state()
+    if state is None:
+        return None
+    if time.time() > float(state.get("expires_at", 0)):
+        return None
+    if int(state.get("attempts", 0)) >= MAX_ATTEMPTS:
+        return None
+    return str(state.get("code") or "") or None
+
+
+def get_or_create_pairing_code() -> str:
+    """Return the current valid code, generating a new one if needed."""
+    return read_pairing_code() or generate_pairing_code()
+
+
+def verify_pairing_code(submitted: str) -> bool:
+    """Check a submitted code. Single-use: the code is cleared on success.
+
+    Failed attempts are counted; after MAX_ATTEMPTS the code is invalidated
+    (a new one must be generated with ``nerve pair``).
+    """
+    state = _read_state()
+    if state is None:
+        return False
+    if time.time() > float(state.get("expires_at", 0)):
+        clear_pairing_code()
+        return False
+    if int(state.get("attempts", 0)) >= MAX_ATTEMPTS:
+        return False
+
+    expected = str(state.get("code") or "")
+    ok = bool(expected) and secrets.compare_digest(
+        submitted.strip(), expected,
+    )
+    if ok:
+        clear_pairing_code()
+        return True
+
+    state["attempts"] = int(state.get("attempts", 0)) + 1
+    if state["attempts"] >= MAX_ATTEMPTS:
+        logger.warning(
+            "Telegram pairing code invalidated after %d failed attempts",
+            state["attempts"],
+        )
+    _write_state(state)
+    return False
+
+
+def clear_pairing_code() -> None:
+    """Remove the pairing code file (e.g. after successful pairing)."""
+    _pairing_path().unlink(missing_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,31 @@ def event_loop():
     loop.close()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_nerve_state_files(tmp_path, monkeypatch):
+    """Keep tests away from the real ~/.nerve state files.
+
+    The config-dir pointer, wizard init-state, and Telegram pairing files
+    all live under ~/.nerve on a real install. Tests must never read or
+    mutate them (running the suite on a live box would otherwise repoint
+    the daemon's config discovery or leak pairing codes).
+    """
+    import nerve.bootstrap
+    import nerve.config
+    import nerve.pairing
+
+    state_dir = tmp_path / "_nerve_state"
+    monkeypatch.setattr(
+        nerve.config, "CONFIG_POINTER_FILE", state_dir / "config_dir",
+    )
+    monkeypatch.setattr(
+        nerve.bootstrap, "INIT_STATE_FILE", state_dir / "init-state.json",
+    )
+    monkeypatch.setattr(
+        nerve.pairing, "PAIRING_FILE", state_dir / "telegram_pairing",
+    )
+
+
 @pytest_asyncio.fixture
 async def db(tmp_path):
     """Create a fresh in-memory-like database for each test."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -719,3 +719,212 @@ class TestSetupChoicesNewFields:
         c = SetupChoices()
         assert c.claude_oauth_token == ""
         assert c.github_token == ""
+
+
+class TestBedrockGeoPrefix:
+    """Region → Bedrock inference-profile prefix mapping."""
+
+    def test_us_regions(self) -> None:
+        from nerve.bootstrap import bedrock_geo_prefix
+        assert bedrock_geo_prefix("us-east-1") == "us"
+        assert bedrock_geo_prefix("us-west-2") == "us"
+
+    def test_eu_regions(self) -> None:
+        from nerve.bootstrap import bedrock_geo_prefix
+        assert bedrock_geo_prefix("eu-central-1") == "eu"
+        assert bedrock_geo_prefix("eu-west-3") == "eu"
+        assert bedrock_geo_prefix("EU-NORTH-1") == "eu"
+
+    def test_apac_regions(self) -> None:
+        from nerve.bootstrap import bedrock_geo_prefix
+        assert bedrock_geo_prefix("ap-southeast-2") == "apac"
+        assert bedrock_geo_prefix("ap-northeast-1") == "apac"
+
+    def test_other_regions_default_us(self) -> None:
+        from nerve.bootstrap import bedrock_geo_prefix
+        assert bedrock_geo_prefix("ca-central-1") == "us"
+        assert bedrock_geo_prefix("sa-east-1") == "us"
+        assert bedrock_geo_prefix("") == "us"
+
+
+class TestNonInteractiveBedrockRegion:
+    """Bedrock model IDs must match the configured region's geography."""
+
+    def test_eu_region_writes_eu_models(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        env = {
+            "NERVE_PROVIDER": "bedrock",
+            "NERVE_AWS_REGION": "eu-central-1",
+            "NERVE_MODE": "personal",
+            "NERVE_WORKSPACE": str(tmp_path / "ws"),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            run_non_interactive(tmp_path)
+
+        config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        assert config["provider"]["aws_region"] == "eu-central-1"
+        assert config["agent"]["model"].startswith("eu.anthropic.")
+        assert config["agent"]["cron_model"].startswith("eu.anthropic.")
+        assert config["memory"]["fast_model"].startswith("eu.anthropic.")
+
+    def test_us_region_writes_us_models(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        env = {
+            "NERVE_PROVIDER": "bedrock",
+            "NERVE_AWS_REGION": "us-east-1",
+            "NERVE_MODE": "personal",
+            "NERVE_WORKSPACE": str(tmp_path / "ws"),
+        }
+        with patch.dict(os.environ, env, clear=False):
+            run_non_interactive(tmp_path)
+
+        config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        assert config["agent"]["model"].startswith("us.anthropic.")
+
+
+class TestNonInteractiveTelegramAllowedUsers:
+    """NERVE_TELEGRAM_ALLOWED_USERS env wiring."""
+
+    def test_allowed_users_written_to_local(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        env = {
+            "ANTHROPIC_API_KEY": "sk-ant-api03-tg",
+            "NERVE_MODE": "personal",
+            "NERVE_WORKSPACE": str(tmp_path / "ws"),
+            "NERVE_TELEGRAM_BOT_TOKEN": "123456:ABC-test",
+            "NERVE_TELEGRAM_ALLOWED_USERS": "111, 222",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            run_non_interactive(tmp_path)
+
+        local = yaml.safe_load((tmp_path / "config.local.yaml").read_text())
+        assert local["telegram"]["allowed_users"] == [111, 222]
+
+    def test_invalid_allowed_users_rejected(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        env = {
+            "ANTHROPIC_API_KEY": "sk-ant-api03-tg",
+            "NERVE_WORKSPACE": str(tmp_path / "ws"),
+            "NERVE_TELEGRAM_BOT_TOKEN": "123456:ABC-test",
+            "NERVE_TELEGRAM_ALLOWED_USERS": "not-a-number",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with pytest.raises(Exception):
+                run_non_interactive(tmp_path)
+
+
+class TestInitStatePersistence:
+    """Wizard progress checkpointing (resume support)."""
+
+    def test_save_load_round_trip(self) -> None:
+        from nerve.bootstrap import (
+            _choices_from_dict,
+            _load_init_state,
+            _save_init_state,
+        )
+
+        choices = SetupChoices()
+        choices.mode = "personal"
+        choices.anthropic_api_key = "sk-ant-saved"
+        choices.workspace_path = Path("/tmp/some-ws")
+        choices.telegram_allowed_users = [42]
+        _save_init_state(choices, {"deployment", "mode"})
+
+        state = _load_init_state()
+        assert state is not None
+        assert sorted(state["completed"]) == ["deployment", "mode"]
+
+        restored = _choices_from_dict(state["choices"])
+        assert restored.anthropic_api_key == "sk-ant-saved"
+        assert restored.workspace_path == Path("/tmp/some-ws")
+        assert restored.telegram_allowed_users == [42]
+
+    def test_clear(self) -> None:
+        from nerve.bootstrap import (
+            _clear_init_state,
+            _load_init_state,
+            _save_init_state,
+        )
+
+        _save_init_state(SetupChoices(), {"mode"})
+        _clear_init_state()
+        assert _load_init_state() is None
+
+    def test_state_file_permissions(self) -> None:
+        import nerve.bootstrap as bootstrap_mod
+        from nerve.bootstrap import _save_init_state
+
+        _save_init_state(SetupChoices(), {"mode"})
+        path = bootstrap_mod.INIT_STATE_FILE.expanduser()
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o600
+
+    def test_choices_from_dict_ignores_unknown_keys(self) -> None:
+        from nerve.bootstrap import _choices_from_dict
+
+        restored = _choices_from_dict({"mode": "worker", "legacy_field": True})
+        assert restored.mode == "worker"
+
+    def test_load_missing_returns_none(self) -> None:
+        from nerve.bootstrap import _clear_init_state, _load_init_state
+
+        _clear_init_state()
+        assert _load_init_state() is None
+
+
+class TestApplyBackups:
+    """Re-running init must back up existing configs, not silently nuke them."""
+
+    def test_existing_configs_backed_up(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        wizard = SetupWizard(tmp_path)
+        wizard.choices.anthropic_api_key = "sk-ant-one"
+        wizard.choices.workspace_path = tmp_path / "ws"
+        wizard.choices.mode = "personal"
+        wizard._apply()
+
+        # Hand-edit, then re-apply
+        (tmp_path / "config.yaml").write_text("# hand-edited\nworkspace: ~/custom\n")
+        wizard2 = SetupWizard(tmp_path)
+        wizard2.choices.anthropic_api_key = "sk-ant-two"
+        wizard2.choices.workspace_path = tmp_path / "ws"
+        wizard2.choices.mode = "personal"
+        wizard2._apply()
+
+        bak = tmp_path / "config.yaml.bak"
+        assert bak.exists()
+        assert bak.read_text().startswith("# hand-edited")
+        assert (tmp_path / "config.local.yaml.bak").exists()
+
+
+class TestStepCounter:
+    """Step numbering shows totals once the mode is known."""
+
+    def test_no_total_before_mode(self, tmp_path: Path) -> None:
+        wizard = SetupWizard(tmp_path)
+        assert wizard._next_step("Deployment") == "Step 1: Deployment"
+
+    def test_total_after_mode_personal(self, tmp_path: Path) -> None:
+        wizard = SetupWizard(tmp_path)
+        wizard._next_step("Deployment")
+        wizard._next_step("Mode")
+        wizard.choices.mode = "personal"
+        wizard._completed_steps.add("mode")
+        assert wizard._next_step("API") == "Step 3/11: API"
+
+    def test_total_after_mode_worker(self, tmp_path: Path) -> None:
+        wizard = SetupWizard(tmp_path)
+        wizard._next_step("Deployment")
+        wizard._next_step("Mode")
+        wizard.choices.mode = "worker"
+        wizard._completed_steps.add("mode")
+        assert wizard._next_step("API") == "Step 3/6: API"
+
+    def test_skipped_steps_keep_numbering(self, tmp_path: Path) -> None:
+        wizard = SetupWizard(tmp_path)
+        wizard._completed_steps = {"deployment", "mode"}
+        wizard.choices.mode = "personal"
+        wizard._do("deployment", lambda: None)
+        wizard._do("mode", lambda: None)
+        assert wizard._step_counter == 2
+        assert wizard._next_step("API") == "Step 3/11: API"

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -1,0 +1,228 @@
+"""Tests for config-dir resolution, the pointer file, unknown-key
+validation, and config write-back helpers."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nerve.config import (
+    TelegramConfig,
+    append_telegram_allowed_user,
+    load_config,
+    read_config_pointer,
+    resolve_config_dir,
+    validate_config_keys,
+    write_config_pointer,
+)
+
+
+@pytest.fixture
+def configured(tmp_path: Path) -> Path:
+    """A directory that looks like a real install."""
+    d = tmp_path / "install"
+    d.mkdir()
+    (d / "config.yaml").write_text("workspace: ~/ws\n")
+    (d / "config.local.yaml").write_text("anthropic_api_key: sk-ant-test\n")
+    return d
+
+
+@pytest.fixture
+def elsewhere(tmp_path: Path) -> Path:
+    """An empty directory with no config files."""
+    d = tmp_path / "elsewhere"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture(autouse=True)
+def _no_env_override(monkeypatch):
+    monkeypatch.delenv("NERVE_CONFIG_DIR", raising=False)
+
+
+class TestResolveConfigDir:
+    def test_explicit_flag_wins(self, configured, elsewhere, monkeypatch):
+        monkeypatch.setenv("NERVE_CONFIG_DIR", str(configured))
+        d, source = resolve_config_dir(str(elsewhere))
+        assert d == elsewhere
+        assert source == "flag"
+
+    def test_env_var(self, configured, elsewhere, monkeypatch):
+        monkeypatch.chdir(elsewhere)
+        monkeypatch.setenv("NERVE_CONFIG_DIR", str(configured))
+        d, source = resolve_config_dir()
+        assert d == configured
+        assert source == "env"
+
+    def test_cwd_with_config(self, configured, monkeypatch):
+        monkeypatch.chdir(configured)
+        d, source = resolve_config_dir()
+        assert d == configured
+        assert source == "cwd"
+
+    def test_pointer_used_from_other_cwd(self, configured, elsewhere, monkeypatch):
+        """The classic footgun: install configured in ~/nerve, command run from $HOME."""
+        write_config_pointer(configured)
+        monkeypatch.chdir(elsewhere)
+        d, source = resolve_config_dir()
+        assert d == configured.resolve()
+        assert source == "pointer"
+
+    def test_cwd_config_beats_pointer(self, configured, tmp_path, monkeypatch):
+        """Dev workflow: a checkout with its own config wins over the pointer."""
+        write_config_pointer(configured)
+        dev = tmp_path / "dev-checkout"
+        dev.mkdir()
+        (dev / "config.yaml").write_text("workspace: ~/dev-ws\n")
+        monkeypatch.chdir(dev)
+        d, source = resolve_config_dir()
+        assert d == dev
+        assert source == "cwd"
+
+    def test_stale_pointer_falls_back(self, tmp_path, elsewhere, monkeypatch):
+        gone = tmp_path / "gone"
+        gone.mkdir()
+        write_config_pointer(gone)
+        gone.rmdir()
+        monkeypatch.chdir(elsewhere)
+        d, source = resolve_config_dir()
+        assert d == elsewhere
+        assert source == "default"
+
+    def test_pointer_without_config_files_ignored(self, elsewhere, tmp_path, monkeypatch):
+        empty_install = tmp_path / "empty-install"
+        empty_install.mkdir()
+        write_config_pointer(empty_install)
+        monkeypatch.chdir(elsewhere)
+        d, source = resolve_config_dir()
+        assert source == "default"
+
+    def test_fresh_install_default(self, elsewhere, monkeypatch):
+        monkeypatch.chdir(elsewhere)
+        d, source = resolve_config_dir()
+        assert d == elsewhere
+        assert source == "default"
+
+
+class TestConfigPointer:
+    def test_round_trip(self, configured):
+        write_config_pointer(configured)
+        assert read_config_pointer() == configured.resolve()
+
+    def test_missing_returns_none(self):
+        assert read_config_pointer() is None
+
+    def test_deleted_dir_returns_none(self, tmp_path):
+        d = tmp_path / "d"
+        d.mkdir()
+        write_config_pointer(d)
+        d.rmdir()
+        assert read_config_pointer() is None
+
+
+class TestLoadConfigDir:
+    def test_load_config_records_dir(self, configured):
+        config = load_config(configured)
+        assert config.config_dir == configured
+
+    def test_load_config_uses_resolution(self, configured, elsewhere, monkeypatch):
+        """load_config(None) resolves via the waterfall, not bare CWD."""
+        write_config_pointer(configured)
+        monkeypatch.chdir(elsewhere)
+        config = load_config()
+        assert config.anthropic_api_key == "sk-ant-test"
+
+
+class TestValidateConfigKeys:
+    def test_clean_config_no_warnings(self):
+        merged = {
+            "workspace": "~/ws",
+            "timezone": "UTC",
+            "anthropic_api_key": "sk-ant-x",
+            "telegram": {
+                "enabled": True,
+                "dm_policy": "pairing",
+                "allowed_users": [1],
+                "stream_mode": "partial",
+            },
+            "agent": {"model": "claude-opus-4-8"},
+            "auth": {"jwt_secret": "s"},
+        }
+        assert validate_config_keys(merged) == []
+
+    def test_unknown_top_level_key(self):
+        warnings = validate_config_keys({"workspaec": "~/ws"})
+        assert len(warnings) == 1
+        assert "workspaec" in warnings[0]
+
+    def test_unknown_nested_key_with_dotted_path(self):
+        warnings = validate_config_keys({"telegram": {"dm_policyy": "pairing"}})
+        assert len(warnings) == 1
+        assert "telegram.dm_policyy" in warnings[0]
+
+    def test_docker_entrypoint_keys_allowed(self):
+        merged = {"claude_oauth_token": "tok", "github_token": "ghp_x"}
+        assert validate_config_keys(merged) == []
+
+    def test_opaque_subtrees_not_flagged(self):
+        merged = {
+            "mcp_servers": {"my-server": {"command": "x", "anything": 1}},
+            "memory": {"categories": [{"name": "a", "description": "b"}]},
+        }
+        assert validate_config_keys(merged) == []
+
+
+class TestTelegramDmPolicy:
+    def test_default_is_pairing(self):
+        assert TelegramConfig.from_dict({}).dm_policy == "pairing"
+
+    def test_open_accepted(self):
+        assert TelegramConfig.from_dict({"dm_policy": "open"}).dm_policy == "open"
+
+    def test_invalid_falls_back_to_pairing(self):
+        assert TelegramConfig.from_dict({"dm_policy": "weird"}).dm_policy == "pairing"
+
+    def test_allowed_users_coerced_to_int(self):
+        cfg = TelegramConfig.from_dict({"allowed_users": ["123", 456]})
+        assert cfg.allowed_users == [123, 456]
+
+
+class TestAppendTelegramAllowedUser:
+    def test_creates_file_when_missing(self, tmp_path):
+        assert append_telegram_allowed_user(tmp_path, 42) is True
+        data = yaml.safe_load((tmp_path / "config.local.yaml").read_text())
+        assert data["telegram"]["allowed_users"] == [42]
+
+    def test_preserves_existing_keys(self, tmp_path):
+        (tmp_path / "config.local.yaml").write_text(
+            yaml.safe_dump({
+                "anthropic_api_key": "sk-ant-keep",
+                "telegram": {"bot_token": "123:abc"},
+            })
+        )
+        assert append_telegram_allowed_user(tmp_path, 42) is True
+        data = yaml.safe_load((tmp_path / "config.local.yaml").read_text())
+        assert data["anthropic_api_key"] == "sk-ant-keep"
+        assert data["telegram"]["bot_token"] == "123:abc"
+        assert data["telegram"]["allowed_users"] == [42]
+
+    def test_duplicate_returns_false(self, tmp_path):
+        append_telegram_allowed_user(tmp_path, 42)
+        assert append_telegram_allowed_user(tmp_path, 42) is False
+        data = yaml.safe_load((tmp_path / "config.local.yaml").read_text())
+        assert data["telegram"]["allowed_users"] == [42]
+
+    def test_appends_second_user(self, tmp_path):
+        append_telegram_allowed_user(tmp_path, 1)
+        append_telegram_allowed_user(tmp_path, 2)
+        data = yaml.safe_load((tmp_path / "config.local.yaml").read_text())
+        assert data["telegram"]["allowed_users"] == [1, 2]
+
+    def test_file_permissions(self, tmp_path):
+        append_telegram_allowed_user(tmp_path, 42)
+        mode = stat.S_IMODE(os.stat(tmp_path / "config.local.yaml").st_mode)
+        assert mode == 0o600

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,92 @@
+"""Tests for the Telegram pairing-code store."""
+
+from __future__ import annotations
+
+import json
+
+import nerve.pairing as pairing
+from nerve.pairing import (
+    MAX_ATTEMPTS,
+    clear_pairing_code,
+    generate_pairing_code,
+    get_or_create_pairing_code,
+    read_pairing_code,
+    verify_pairing_code,
+)
+
+
+class TestGenerate:
+    def test_six_digits(self):
+        code = generate_pairing_code()
+        assert len(code) == 6
+        assert code.isdigit()
+
+    def test_persisted_and_readable(self):
+        code = generate_pairing_code()
+        assert read_pairing_code() == code
+
+    def test_get_or_create_reuses_valid_code(self):
+        code = generate_pairing_code()
+        assert get_or_create_pairing_code() == code
+
+    def test_get_or_create_generates_when_missing(self):
+        clear_pairing_code()
+        code = get_or_create_pairing_code()
+        assert read_pairing_code() == code
+
+
+class TestVerify:
+    def test_correct_code_single_use(self):
+        code = generate_pairing_code()
+        assert verify_pairing_code(code) is True
+        # Single use: cleared after success
+        assert read_pairing_code() is None
+        assert verify_pairing_code(code) is False
+
+    def test_wrong_code_rejected_then_correct_succeeds(self):
+        code = generate_pairing_code()
+        wrong = "000000" if code != "000000" else "111111"
+        assert verify_pairing_code(wrong) is False
+        # A few failed attempts don't burn the code (until MAX_ATTEMPTS)
+        assert verify_pairing_code(code) is True
+
+    def test_whitespace_tolerated(self):
+        code = generate_pairing_code()
+        assert verify_pairing_code(f"  {code} ") is True
+
+    def test_missing_state_rejects(self):
+        clear_pairing_code()
+        assert verify_pairing_code("123456") is False
+
+    def test_attempt_limit_invalidates(self):
+        code = generate_pairing_code()
+        wrong = "000000" if code != "000000" else "111111"
+        for _ in range(MAX_ATTEMPTS):
+            assert verify_pairing_code(wrong) is False
+        # Code is now burned — even the correct one fails
+        assert verify_pairing_code(code) is False
+        assert read_pairing_code() is None
+
+
+class TestExpiry:
+    def _force_expire(self):
+        path = pairing._pairing_path()
+        state = json.loads(path.read_text())
+        state["expires_at"] = 1.0  # long past
+        path.write_text(json.dumps(state))
+
+    def test_expired_code_unreadable(self):
+        generate_pairing_code()
+        self._force_expire()
+        assert read_pairing_code() is None
+
+    def test_expired_code_rejected(self):
+        code = generate_pairing_code()
+        self._force_expire()
+        assert verify_pairing_code(code) is False
+
+    def test_get_or_create_replaces_expired(self):
+        old = generate_pairing_code()
+        self._force_expire()
+        new = get_or_create_pairing_code()
+        assert read_pairing_code() == new


### PR DESCRIPTION
## Summary

Fixes a batch of onboarding problems reported from fresh-VM installs, plus issues found while auditing the bootstrap path.

### Config discovery is no longer CWD-dependent
`nerve start` from any directory other than the install dir used to silently load an empty config and report **"Fresh install detected"** — leading users to re-run `nerve init` and write a second config tree into `$HOME`. Commands now resolve the config dir via a waterfall: `-c` flag → `NERVE_CONFIG_DIR` → cwd-with-config (dev workflow preserved) → `~/.nerve/config_dir` pointer (now written by `nerve init`, not just daemon start) → default. `nerve doctor` reports which directory was used and how.

### Setup wizard: resumable, measurable, validated
- Answers are checkpointed to `~/.nerve/init-state.json` after every step — Ctrl+C (or a killed installer) no longer throws everything away; `nerve init` offers to resume.
- Step headers show totals (`Step 3/11`) once the mode is known.
- New **preflight step** after apply: a 1-token call through the configured provider (catches bad keys and unavailable Bedrock models), Telegram `getMe`, OpenAI key check. Failures are informative, never fatal.
- Re-running init backs up existing configs to `*.bak` instead of silently overwriting hand edits.

### Bedrock: region-aware inference-profile prefixes
The wizard hardcoded `us.anthropic.*` model IDs regardless of region — instant 400s for `eu-*`/`ap-*` regions. Model IDs now use the geography prefix derived from the region (`us.`/`eu.`/`apac.`), and `nerve doctor` warns on prefix/region mismatches.

### Telegram: pairing implemented (dm_policy was a ghost key)
`dm_policy: pairing` was written by the wizard and documented, but never parsed — and the wizard never collected `allowed_users`, so a fresh bot silently rejected every DM. Now:
- `nerve pair` issues a one-time 6-digit code (1h TTL, 5 attempts, single use); sending the bot `/pair <code>` authorizes the user and persists their ID to `config.local.yaml`.
- A fresh install with no `allowed_users` generates a code automatically at startup and logs it.
- Unauthorized `/start` replies with the sender's numeric ID + pairing instructions (rate-limited once per 10 min per user); everything else stays fail-closed.
- `dm_policy: open` is parsed too, with loud warnings. The wizard also validates the bot token live and offers to authorize your user ID during setup.

### Misc hardening
- Unknown config keys (typos, removed options) are logged as warnings at load time and listed by `nerve doctor` instead of being silently ignored.
- `install.sh`: clear "Installation complete → run the setup wizard now?" boundary instead of silently morphing into a full-screen wizard, INT/TERM traps that explain the state, a wizard abort no longer looks like a failed install, optional "Start Nerve now?" at the end, and a guaranteed exit.
- Tests no longer touch the real `~/.nerve` pointer/state/pairing files (autouse conftest fixture).

## Test plan

- [x] Full suite passes (1092 tests; +~50 new for resolution waterfall, pairing store, geo prefixes, wizard state, backups, step counters)
- [x] E2E sandbox: `init --non-interactive` → `nerve start` from a different cwd works (previously "Fresh install detected")
- [x] E2E sandbox: wizard interrupt mid-flow → state saved → `nerve init` resumes, skips answered steps, numbering consistent
- [x] E2E sandbox: `nerve pair` + `nerve doctor` (doctor correctly flags a bad API key via the live probe, shows config provenance)
- [x] Verified on a live install: `status`/`doctor`/`pair` resolve via pointer from any cwd; zero unknown-key warnings on a real config
- [x] `bash -n install.sh`

Note: `tests/test_codex_local_rollout.py` / `tests/test_codex_source_integration.py` fail on any fresh clone because `tests/fixtures/**/*.jsonl` is swallowed by the repo-wide `*.jsonl` gitignore rule — pre-existing on main, unrelated to this PR, worth a separate fix.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*