### PR TITLE
Fix chat history loss on resume for symlinked workspaces

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1402,23 +1402,37 @@ class AgentEngine:
             ~/.claude/projects/<encoded-cwd>/<sdk_session_id>.jsonl
 
         where <encoded-cwd> is the absolute cwd path with every '/'
-        replaced by '-'.  If the file is gone (typically because the
-        container's /root/.claude was not bind-mounted and got wiped on
-        restart), passing --resume to the CLI fails with exit 1.
+        replaced by '-'.  The CLI resolves the cwd symlink before
+        encoding, so when the workspace is itself a symlink (e.g. the
+        Docker deployment's /root/nerve-workspace -> /Users/.../
+        nerve-workspace) the history lives under the *realpath*-encoded
+        directory, not the symlink-encoded one.  Check the realpath
+        first and fall back to the unresolved path for non-symlinked
+        layouts.
+
+        If the file is gone (typically because the container's
+        /root/.claude was not bind-mounted and got wiped on restart),
+        passing --resume to the CLI fails with exit 1.
 
         Best-effort check: any unexpected error returns True so we still
         attempt the resume and let the CLI surface the real error,
         rather than masking unrelated bugs.
         """
         try:
-            cwd = str(self.config.workspace)
-            encoded = cwd.replace("/", "-")
-            jsonl = (
-                os.path.expanduser("~/.claude/projects")
-                + "/" + encoded
-                + "/" + sdk_session_id + ".jsonl"
-            )
-            return os.path.isfile(jsonl)
+            projects = os.path.expanduser("~/.claude/projects")
+            workspace = str(self.config.workspace)
+            bases = [os.path.realpath(workspace)]
+            if workspace not in bases:
+                bases.append(workspace)
+            for base in bases:
+                encoded = base.replace("/", "-")
+                jsonl = (
+                    projects + "/" + encoded
+                    + "/" + sdk_session_id + ".jsonl"
+                )
+                if os.path.isfile(jsonl):
+                    return True
+            return False
         except Exception as e:
             logger.debug(
                 "Could not stat resume jsonl for %s: %s, assuming present",

--- a/nerve/houseofagents/runner.py
+++ b/nerve/houseofagents/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -47,7 +48,9 @@ async def _tail_session_jsonl(
 
     # Claude CLI writes session logs to ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl
     # The cwd is encoded by replacing / with - (keeping the leading dash for absolute paths).
-    cwd_encoded = workspace.replace("/", "-")
+    # The CLI resolves the cwd symlink before encoding, so resolve the workspace
+    # realpath first (e.g. /root/nerve-workspace -> /Users/.../nerve-workspace).
+    cwd_encoded = os.path.realpath(workspace).replace("/", "-")
     projects_dir = Path.home() / ".claude" / "projects"
     jsonl_path = projects_dir / cwd_encoded / f"{inner_session_id}.jsonl"
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 """Tests for nerve.agent.engine — pure helpers (no SDK state)."""
 
 import asyncio
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -192,7 +193,11 @@ class TestSdkResumeFileExists:
             captured["path"] = path
             return True
 
-        with patch("nerve.agent.engine.os.path.isfile", side_effect=_capture):
+        # Pin realpath to identity so this test exercises only the
+        # slash-encoding, independent of any host symlinks.  Symlink
+        # resolution itself is covered by the symlinked-workspace tests.
+        with patch("nerve.agent.engine.os.path.realpath", side_effect=lambda p: p), \
+             patch("nerve.agent.engine.os.path.isfile", side_effect=_capture):
             engine._sdk_resume_file_exists("sid-abc")
 
         assert "-root-nerve-workspace" in captured["path"]
@@ -211,3 +216,67 @@ class TestSdkResumeFileExists:
             engine._sdk_resume_file_exists("myid")
 
         assert captured["path"].endswith("myid.jsonl")
+
+    def test_symlinked_workspace_checks_realpath(self, tmp_path, monkeypatch):
+        """A symlinked workspace finds its history under the *resolved*
+        (realpath) directory, matching where the CLI actually writes it.
+
+        Regression test for resume-history loss on the Docker deployment,
+        where config.workspace (/root/nerve-workspace) is a symlink and
+        the guard previously checked the unresolved-path-encoded dir,
+        which never exists, then wiped the stored sdk_session_id.
+        """
+        real_ws = tmp_path / "real-workspace"
+        real_ws.mkdir()
+        link_ws = tmp_path / "linked-workspace"
+        link_ws.symlink_to(real_ws)
+
+        fake_home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        sid = "11111111-2222-3333-4444-555555555555"
+        encoded = os.path.realpath(str(link_ws)).replace("/", "-")
+        proj_dir = fake_home / ".claude" / "projects" / encoded
+        proj_dir.mkdir(parents=True)
+        (proj_dir / f"{sid}.jsonl").write_text("{}")
+
+        engine = _make_engine(str(link_ws))
+        assert engine._sdk_resume_file_exists(sid) is True
+
+    def test_symlinked_workspace_missing_returns_false(self, tmp_path, monkeypatch):
+        """Symlinked workspace, but the .jsonl genuinely does not exist:
+        the guard returns False so the caller starts a fresh conversation."""
+        real_ws = tmp_path / "real-workspace"
+        real_ws.mkdir()
+        link_ws = tmp_path / "linked-workspace"
+        link_ws.symlink_to(real_ws)
+
+        fake_home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        encoded = os.path.realpath(str(link_ws)).replace("/", "-")
+        (fake_home / ".claude" / "projects" / encoded).mkdir(parents=True)
+
+        engine = _make_engine(str(link_ws))
+        assert engine._sdk_resume_file_exists("does-not-exist") is False
+
+    def test_falls_back_to_unresolved_path(self, tmp_path, monkeypatch):
+        """If history lives under the unresolved (symlink) encoding, the
+        fallback still finds it (non-symlinked layouts, or a future CLI
+        that stops resolving the cwd)."""
+        real_ws = tmp_path / "real-workspace"
+        real_ws.mkdir()
+        link_ws = tmp_path / "linked-workspace"
+        link_ws.symlink_to(real_ws)
+
+        fake_home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        sid = "abcd"
+        encoded_unresolved = str(link_ws).replace("/", "-")
+        proj_dir = fake_home / ".claude" / "projects" / encoded_unresolved
+        proj_dir.mkdir(parents=True)
+        (proj_dir / f"{sid}.jsonl").write_text("{}")
+
+        engine = _make_engine(str(link_ws))
+        assert engine._sdk_resume_file_exists(sid) is True


### PR DESCRIPTION
## Summary

The SDK resume guard `_sdk_resume_file_exists` built the Claude Code history path from the unresolved workspace path, but the CLI encodes the realpath of the cwd. When the workspace is a symlink (the Docker deployment points `/root/nerve-workspace` at `/Users/.../nerve-workspace`), the guard looked under `~/.claude/projects/-root-nerve-workspace/`, which never exists. It concluded the transcript was missing, cleared the stored `sdk_session_id`, and the next turn started a fresh conversation with no history.

Because the guard only runs when the in-memory client is gone, this showed up after a daemon restart, after the 60-minute idle-client sweep, or after a CLI crash. It was worst with parallel sessions: inactive ones get their clients reaped, so returning to them wiped their history while the actively-typed session looked fine. The guard was added in #65, so this is a regression for symlinked deployments (before it, the stale id went straight to `--resume` and the CLI resolved the symlink itself).

The fix resolves the workspace realpath before encoding, matching the CLI's own derivation, and falls back to the unresolved path for non-symlinked layouts. The fail-open on unexpected stat errors is kept. The houseofagents session tailer (`runner.py`) had the same bug (UI-only, degrades gracefully), fixed the same way.

Note: already-cleared `sdk_session_id` rows are not auto-recovered by this change. The `.jsonl` files still exist on disk, but relinking them is out of scope here.

## Test plan

- [x] `pytest tests/test_engine.py -v` (37 passed), including three new cases: symlinked-workspace positive, genuinely-missing negative, and the unresolved-path fallback.
- [x] `pytest tests/test_sessions.py` (45 passed).
- [x] Verified against live on-disk state: for a real session id, the old guard returns False (the bug) and the new guard returns True; a bogus id still returns False.
- [x] No frontend change, so no `npm run build`.
