### PR TITLE
Notification silences: mute known-benign alert classes

### DIFF
--- a/nerve/agent/tools/handlers/notifications.py
+++ b/nerve/agent/tools/handlers/notifications.py
@@ -17,11 +17,15 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from nerve.agent.tools.registry import ToolContext, ToolResult, ToolSpec
 from nerve.agent.tools.schemas import (
     ASK_USER_SCHEMA,
+    NOTIFICATION_SILENCE_SCHEMA,
     NOTIFY_SCHEMA,
     PROPOSE_ACTION_SCHEMA,
     REACT_SCHEMA,
@@ -39,6 +43,7 @@ async def notify_handler(ctx: ToolContext, args: dict) -> ToolResult:
     title = args.get("title", "")
     body = args.get("body", "")
     priority = args.get("priority", "normal")
+    force = bool(args.get("force", False))
 
     try:
         notification_id = await ctx.notification_service.send_notification(
@@ -46,11 +51,72 @@ async def notify_handler(ctx: ToolContext, args: dict) -> ToolResult:
             title=title,
             body=body,
             priority=priority,
+            force=force,
         )
-        return ToolResult.text(f"Notification sent: {notification_id}")
     except Exception as e:
         logger.error("notify tool failed: %s", e)
         return ToolResult.text(f"Failed to send notification: {e}")
+
+    # Read the row back to learn the delivery outcome (normal / silenced /
+    # force-delivered over a match). One indexed PK lookup on the
+    # low-volume notify path; this keeps send_notification's ``-> str``
+    # contract so cron and other callers stay untouched.
+    status, meta = await _read_notify_outcome(
+        ctx.notification_service, notification_id,
+    )
+
+    if status == "silenced":
+        sil_id = meta.get("silenced_by", "?")
+        reason = meta.get("silence_reason") or "(no reason recorded)"
+        pattern = meta.get("silence_pattern", "")
+        hits = meta.get("silence_hit_count")
+        hits_str = f"   ({hits} hits)" if hits else ""
+        return ToolResult.text(
+            f"⚠ Notification {notification_id} was SILENCED and NOT delivered "
+            f"(matched {sil_id}).\n"
+            f"  reason:  {reason}\n"
+            f"  pattern: {pattern}{hits_str}\n"
+            "If you believe this match is INCORRECT and the alert genuinely "
+            "needs to reach the user, re-send the same notification with "
+            "force=true to bypass the silence."
+        )
+
+    if meta.get("force_sent_over_silence"):
+        sil_id = meta["force_sent_over_silence"]
+        count = meta.get("force_override_count")
+        count_str = f"; override #{count} recorded" if count else ""
+        return ToolResult.text(
+            f"Notification sent: {notification_id} "
+            f"(force-delivered over silence {sil_id}{count_str})."
+        )
+
+    return ToolResult.text(f"Notification sent: {notification_id}")
+
+
+async def _read_notify_outcome(service, notification_id: str) -> tuple[str | None, dict]:
+    """Fetch a notify row's status + parsed metadata for the result string.
+
+    Defensive: any read/parse failure degrades to ``(None, {})`` so the
+    handler still reports a plain "sent" rather than erroring.
+    """
+    try:
+        row = await service.db.get_notification(notification_id)
+    except Exception:
+        return None, {}
+    if not row:
+        return None, {}
+    raw = row.get("metadata")
+    meta: dict = {}
+    if isinstance(raw, dict):
+        meta = raw
+    elif isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                meta = parsed
+        except (json.JSONDecodeError, ValueError):
+            meta = {}
+    return row.get("status"), meta
 
 
 async def ask_user_handler(ctx: ToolContext, args: dict) -> ToolResult:
@@ -174,6 +240,120 @@ async def propose_action_handler(ctx: ToolContext, args: dict) -> ToolResult:
         return ToolResult.text(f"Failed to propose action: {e}")
 
 
+async def notification_silence_handler(ctx: ToolContext, args: dict) -> ToolResult:
+    """Manage deterministic notification silence rules (add / list / remove).
+
+    Silences suppress known-benign ``notify`` classes at the service
+    chokepoint: a match is persisted but not delivered, and the sending
+    agent is told so it can force-send a wrong match. Create rules only
+    on explicit user instruction or a recorded MEMORY ruling.
+    """
+    if not ctx.db:
+        return ToolResult.text("Database not available.")
+
+    op = str(args.get("op", "")).strip().lower()
+    if op == "add":
+        return await _silence_add(ctx, args)
+    if op == "list":
+        return await _silence_list(ctx)
+    if op == "remove":
+        return await _silence_remove(ctx, args)
+    return ToolResult.text(
+        "notification_silence: 'op' must be one of add, list, remove."
+    )
+
+
+async def _silence_add(ctx: ToolContext, args: dict) -> ToolResult:
+    pattern = str(args.get("pattern", "")).strip()
+    if not pattern:
+        return ToolResult.text("notification_silence add: 'pattern' is required.")
+    try:
+        compiled = re.compile(pattern, re.IGNORECASE)
+    except re.error as exc:
+        return ToolResult.text(
+            f"notification_silence add: invalid regex {pattern!r}: {exc}"
+        )
+
+    reason = str(args.get("reason", "")).strip()
+    try:
+        ttl_hours = float(args.get("ttl_hours", 0) or 0)
+    except (TypeError, ValueError):
+        ttl_hours = 0.0
+    expires_at = None
+    if ttl_hours > 0:
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(hours=ttl_hours)
+        ).isoformat()
+
+    silence_id = f"sil-{uuid.uuid4().hex[:8]}"
+    await ctx.db.create_silence(
+        silence_id=silence_id,
+        pattern=pattern,
+        reason=reason,
+        created_by=ctx.session_id,
+        expires_at=expires_at,
+    )
+    # Take effect immediately for the running service.
+    if ctx.notification_service:
+        ctx.notification_service.invalidate_silence_cache()
+
+    example = str(args.get("example", "")).strip()
+    example_line = ""
+    if example:
+        verdict = "WOULD match" if compiled.search(example) else "would NOT match"
+        example_line = f"\nExample {example!r} {verdict} this pattern."
+
+    ttl_str = "permanent" if not expires_at else f"expires in {ttl_hours:g}h"
+    reason_str = f" — {reason}" if reason else ""
+    return ToolResult.text(
+        f"Silence created: {silence_id}  pattern={pattern}  ({ttl_str}){reason_str}\n"
+        "Future 'notify' calls whose title+body match this pattern will be "
+        "suppressed (persisted as silenced, not delivered)." + example_line
+    )
+
+
+async def _silence_list(ctx: ToolContext) -> ToolResult:
+    rows = await ctx.db.list_silences()
+    if not rows:
+        return ToolResult.text("No active notification silences.")
+    lines: list[str] = []
+    for r in rows:
+        expires_at = r.get("expires_at")
+        expiry = (
+            "permanent" if not expires_at
+            else f"expires {str(expires_at)[:16].replace('T', ' ')}"
+        )
+        hits = r.get("hit_count") or 0
+        overrides = r.get("override_count") or 0
+        counters = f"{hits} hits"
+        if overrides:
+            counters += f", {overrides} override" + ("s" if overrides != 1 else "")
+        reason = r.get("reason") or ""
+        reason_str = f" — {reason}" if reason else ""
+        flag = "  ⚠ over-broad? (force-overridden)" if overrides else ""
+        lines.append(
+            f"{r['id']}  {r['pattern']}  {r.get('action', 'silence')}  "
+            f"{counters}  {expiry}{reason_str}{flag}"
+        )
+    return ToolResult.text(
+        "Active notification silences:\n" + "\n".join(lines)
+    )
+
+
+async def _silence_remove(ctx: ToolContext, args: dict) -> ToolResult:
+    silence_id = str(args.get("silence_id", "")).strip()
+    if not silence_id:
+        return ToolResult.text(
+            "notification_silence remove: 'silence_id' is required."
+        )
+    ok = await ctx.db.delete_silence(silence_id)
+    if not ok:
+        return ToolResult.text(f"No silence found with id {silence_id}.")
+    if ctx.notification_service:
+        ctx.notification_service.invalidate_silence_cache()
+    return ToolResult.text(f"Silence removed: {silence_id}.")
+
+
 async def react_handler(ctx: ToolContext, args: dict) -> ToolResult:
     if not ctx.engine:
         return ToolResult.text("Engine not available.")
@@ -294,6 +474,27 @@ PROPOSE_ACTION_SPEC = ToolSpec(
     handler=propose_action_handler,
 )
 
+NOTIFICATION_SILENCE_SPEC = ToolSpec(
+    name="notification_silence",
+    description=(
+        "Manage notification silence rules — deterministic, server-side "
+        "suppression of known-benign alert classes (the monitoring-system "
+        "'silence' pattern). A matching 'notify' is persisted but NOT "
+        "delivered; priority is never changed, and the sending agent is "
+        "told it was silenced (with reason + pattern) so it can re-send "
+        "with force=true if the match was wrong.\n"
+        "ops: 'add' (pattern [required] + reason [+ ttl_hours, example]), "
+        "'list' (active rules with hit/override counts — a non-zero "
+        "override count flags an over-broad pattern), 'remove' (silence_id).\n"
+        "CONTRACT: create a silence ONLY on explicit user instruction or a "
+        "recorded MEMORY ruling that an alert class is benign, and always "
+        "state the rule you created. Questions and approvals are never "
+        "silenced."
+    ),
+    input_schema=NOTIFICATION_SILENCE_SCHEMA,
+    handler=notification_silence_handler,
+)
+
 REACT_SPEC = ToolSpec(
     name="react",
     description=(
@@ -331,6 +532,7 @@ NOTIFICATION_SPECS = [
     NOTIFY_SPEC,
     ASK_USER_SPEC,
     PROPOSE_ACTION_SPEC,
+    NOTIFICATION_SILENCE_SPEC,
     REACT_SPEC,
     SEND_STICKER_SPEC,
     SEND_FILE_SPEC,

--- a/nerve/agent/tools/schemas.py
+++ b/nerve/agent/tools/schemas.py
@@ -648,6 +648,16 @@ NOTIFY_SCHEMA = {
             "description": "Priority level: 'low', 'normal', 'high', 'urgent'. Default: 'normal'",
             "default": "normal",
         },
+        "force": {
+            "type": "boolean",
+            "description": (
+                "Re-send a notification that was previously silenced. "
+                "Set true ONLY when you believe a silence rule matched this "
+                "notification incorrectly and it genuinely needs to reach the "
+                "user. Bypasses silence matching and delivers normally."
+            ),
+            "default": False,
+        },
     },
     "required": ["body"],
 }
@@ -734,6 +744,58 @@ PROPOSE_ACTION_SCHEMA = {
         },
     },
     "required": ["target_kind", "target_id", "title"],
+}
+
+NOTIFICATION_SILENCE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "op": {
+            "type": "string",
+            "description": (
+                "Operation: 'add' (create a rule), 'list' (show active "
+                "rules with hit/override counts), or 'remove' (delete by id)."
+            ),
+        },
+        "pattern": {
+            "type": "string",
+            "description": (
+                "For op=add (required): case-insensitive regex matched "
+                "against the notification's title + body. A matching "
+                "'notify' is suppressed (persisted, not delivered)."
+            ),
+            "default": "",
+        },
+        "reason": {
+            "type": "string",
+            "description": (
+                "For op=add (strongly encouraged): why this alert class is "
+                "benign. Surfaced to the agent on every match and override."
+            ),
+            "default": "",
+        },
+        "ttl_hours": {
+            "type": "number",
+            "description": (
+                "For op=add: hours until the rule auto-expires. "
+                "0 (default) = permanent."
+            ),
+            "default": 0,
+        },
+        "example": {
+            "type": "string",
+            "description": (
+                "For op=add (optional): sample notification text; the tool "
+                "test-matches the pattern against it and echoes the result."
+            ),
+            "default": "",
+        },
+        "silence_id": {
+            "type": "string",
+            "description": "For op=remove (required): the silence id (sil-xxxx) to delete.",
+            "default": "",
+        },
+    },
+    "required": ["op"],
 }
 
 REACT_SCHEMA = {

--- a/nerve/db/migrations/v035_notification_silences.py
+++ b/nerve/db/migrations/v035_notification_silences.py
@@ -1,0 +1,69 @@
+"""V35: Notification silences — deterministic suppression of known-benign alerts.
+
+Adds the ``notification_silences`` table: a small set of regex rules that
+the notification service consults before fanning a ``notify`` out to
+Telegram + web. A matched notification is persisted (``status='silenced'``)
+but **not delivered** — priority is never modified. The calling agent is
+told its notification was silenced (with the reason + pattern) and can
+re-send with ``force=true`` to override a match it judges incorrect.
+
+This is the monitoring-system "silence" pattern: you don't rely on the
+on-call engineer *remembering* an alert class is benign — you create a
+rule. It sits at the one chokepoint every notification flows through
+(``NotificationService.send_notification``), sibling to the source-level
+ingestion guardrails.
+
+Columns:
+
+- ``id``               TEXT PK: ``sil-<8hex>``.
+- ``pattern``          TEXT: case-insensitive regex, matched against
+  ``title + "\\n" + body``.
+- ``action``           TEXT: only ``silence`` is implemented; kept for
+  audit / forward-compat.
+- ``reason``           TEXT: why the rule exists; surfaced to the agent
+  on every match.
+- ``created_by``       TEXT: session_id that created it.
+- ``created_at``       TEXT: ISO-8601 UTC.
+- ``expires_at``       TEXT NULL: NULL = permanent (TTL support).
+- ``hit_count``        INTEGER: times it silenced a delivery.
+- ``last_hit_at``      TEXT NULL.
+- ``override_count``   INTEGER: times an agent force-sent over this rule
+  (a false-match signal — a climbing count means the pattern is too broad).
+- ``last_override_at`` TEXT NULL.
+- ``enabled``          INTEGER: 1 = active.
+
+No change to the ``notifications`` table: ``status`` is TEXT, so
+``'silenced'`` is just a new value.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+SQL = """
+CREATE TABLE IF NOT EXISTS notification_silences (
+    id               TEXT PRIMARY KEY,
+    pattern          TEXT NOT NULL,
+    action           TEXT NOT NULL DEFAULT 'silence',
+    reason           TEXT DEFAULT '',
+    created_by       TEXT DEFAULT '',
+    created_at       TEXT NOT NULL,
+    expires_at       TEXT,
+    hit_count        INTEGER DEFAULT 0,
+    last_hit_at      TEXT,
+    override_count   INTEGER DEFAULT 0,
+    last_override_at TEXT,
+    enabled          INTEGER DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_notification_silences_active
+    ON notification_silences(enabled, expires_at);
+"""
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.executescript(SQL)
+    logger.info("v035: created notification_silences table + index")

--- a/nerve/db/notifications.py
+++ b/nerve/db/notifications.py
@@ -22,6 +22,7 @@ class NotificationStore:
         metadata: dict | None = None,
         target_kind: str | None = None,
         target_id: str | None = None,
+        status: str | None = None,
     ) -> dict:
         """Insert a notification row.
 
@@ -30,14 +31,20 @@ class NotificationStore:
         via the handler registry). ``target_kind`` and ``target_id`` are
         only populated for ``approval`` rows; left NULL otherwise so the
         legacy answer path stays untouched.
+
+        ``status`` defaults to ``None`` → ``'pending'`` (identical to the
+        column default, so existing callers are unchanged). The silence
+        path passes ``status='silenced'`` to insert a suppressed row that
+        is persisted for audit but never fanned out to channels.
         """
         now = datetime.now(timezone.utc).isoformat()
         await self.db.execute(
             """INSERT INTO notifications
-               (id, session_id, type, title, body, priority, options,
+               (id, session_id, type, title, body, priority, status, options,
                 expires_at, metadata, created_at, target_kind, target_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (notification_id, session_id, type, title, body, priority,
+             status or "pending",
              json.dumps(options) if options else None,
              expires_at, json.dumps(metadata or {}), now,
              target_kind, target_id),
@@ -186,3 +193,126 @@ class NotificationStore:
             f"UPDATE notifications SET {sets} WHERE id = ?", tuple(vals),
         )
         await self.db.commit()
+
+    # ------------------------------------------------------------------ #
+    #  Notification silences (deterministic suppression rules)             #
+    # ------------------------------------------------------------------ #
+
+    async def create_silence(
+        self,
+        silence_id: str,
+        pattern: str,
+        reason: str = "",
+        action: str = "silence",
+        created_by: str = "",
+        expires_at: str | None = None,
+    ) -> dict:
+        """Insert a silence rule.
+
+        ``pattern`` is a case-insensitive regex the notification service
+        matches against ``title + "\\n" + body``. ``expires_at`` NULL =
+        permanent. Returns the freshly-inserted row.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        await self.db.execute(
+            """INSERT INTO notification_silences
+               (id, pattern, action, reason, created_by, created_at, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (silence_id, pattern, action, reason, created_by, now, expires_at),
+        )
+        await self.db.commit()
+        row = await self.get_silence(silence_id)
+        return row or {"id": silence_id, "pattern": pattern}
+
+    async def get_silence(self, silence_id: str) -> dict | None:
+        async with self.db.execute(
+            "SELECT * FROM notification_silences WHERE id = ?", (silence_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return dict(row) if row else None
+
+    async def list_silences(self, include_disabled: bool = False) -> list[dict]:
+        """Return silence rules, newest first.
+
+        ``include_disabled=False`` (default) returns only enabled rules;
+        ``True`` returns every row regardless of the ``enabled`` flag.
+        """
+        where = "" if include_disabled else "WHERE enabled = 1"
+        async with self.db.execute(
+            f"SELECT * FROM notification_silences {where} "
+            "ORDER BY created_at DESC",
+        ) as cursor:
+            return [dict(row) async for row in cursor]
+
+    async def get_active_silences(self) -> list[dict]:
+        """Return enabled, non-expired silence rules, oldest first.
+
+        Oldest-first ordering gives the service a stable "first rule wins"
+        precedence. Used to (re)build the in-memory matcher cache.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        async with self.db.execute(
+            """SELECT * FROM notification_silences
+               WHERE enabled = 1 AND (expires_at IS NULL OR expires_at > ?)
+               ORDER BY created_at ASC""",
+            (now,),
+        ) as cursor:
+            return [dict(row) async for row in cursor]
+
+    async def delete_silence(self, silence_id: str) -> bool:
+        """Hard-delete a silence rule. Returns False if it didn't exist."""
+        async with self._atomic():
+            async with self.db.execute(
+                "SELECT id FROM notification_silences WHERE id = ?",
+                (silence_id,),
+            ) as cursor:
+                if not await cursor.fetchone():
+                    return False
+            await self.db.execute(
+                "DELETE FROM notification_silences WHERE id = ?", (silence_id,),
+            )
+        return True
+
+    async def record_silence_hit(self, silence_id: str) -> int:
+        """Bump ``hit_count`` + stamp ``last_hit_at``; return the new count.
+
+        Called every time a silence suppresses a delivery, so the user can
+        see how often a rule is firing.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        async with self._atomic():
+            await self.db.execute(
+                """UPDATE notification_silences
+                   SET hit_count = hit_count + 1, last_hit_at = ?
+                   WHERE id = ?""",
+                (now, silence_id),
+            )
+            async with self.db.execute(
+                "SELECT hit_count FROM notification_silences WHERE id = ?",
+                (silence_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+        return row[0] if row else 0
+
+    async def record_silence_override(self, silence_id: str) -> int:
+        """Bump ``override_count`` + stamp ``last_override_at``; return count.
+
+        Called when an agent force-sends a notification over a matching
+        rule. A climbing override count is a false-match signal: the
+        pattern is catching alerts that genuinely need to reach the user.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        async with self._atomic():
+            await self.db.execute(
+                """UPDATE notification_silences
+                   SET override_count = override_count + 1,
+                       last_override_at = ?
+                   WHERE id = ?""",
+                (now, silence_id),
+            )
+            async with self.db.execute(
+                "SELECT override_count FROM notification_silences WHERE id = ?",
+                (silence_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+        return row[0] if row else 0

--- a/nerve/gateway/routes/notifications.py
+++ b/nerve/gateway/routes/notifications.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
@@ -13,6 +17,12 @@ router = APIRouter()
 
 class NotificationAnswerRequest(BaseModel):
     answer: str
+
+
+class SilenceCreateRequest(BaseModel):
+    pattern: str
+    reason: str = ""
+    ttl_hours: float = 0
 
 
 @router.get("/api/notifications")
@@ -33,6 +43,68 @@ async def list_notifications(
     )
     pending_count = await deps.db.count_pending_notifications(channel="web")
     return {"notifications": notifications, "pending_count": pending_count}
+
+
+# --------------------------------------------------------------------- #
+#  Silences (deterministic suppression rules)                            #
+#                                                                        #
+#  Declared BEFORE the ``/{notification_id}`` route so the literal       #
+#  ``/silences`` path is not captured as a notification id.              #
+# --------------------------------------------------------------------- #
+
+
+@router.get("/api/notifications/silences")
+async def list_silences(
+    include_disabled: bool = False,
+    user: dict = Depends(require_auth),
+):
+    deps = get_deps()
+    silences = await deps.db.list_silences(include_disabled=include_disabled)
+    return {"silences": silences}
+
+
+@router.post("/api/notifications/silences")
+async def create_silence(
+    req: SilenceCreateRequest,
+    user: dict = Depends(require_auth),
+):
+    pattern = (req.pattern or "").strip()
+    if not pattern:
+        raise HTTPException(status_code=400, detail="pattern is required")
+    try:
+        re.compile(pattern, re.IGNORECASE)
+    except re.error as exc:
+        raise HTTPException(status_code=400, detail=f"invalid regex: {exc}")
+
+    expires_at = None
+    if req.ttl_hours and req.ttl_hours > 0:
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(hours=req.ttl_hours)
+        ).isoformat()
+
+    deps = get_deps()
+    silence_id = f"sil-{uuid.uuid4().hex[:8]}"
+    row = await deps.db.create_silence(
+        silence_id=silence_id,
+        pattern=pattern,
+        reason=(req.reason or "").strip(),
+        created_by="web",
+        expires_at=expires_at,
+    )
+    if deps.notification_service:
+        deps.notification_service.invalidate_silence_cache()
+    return row
+
+
+@router.delete("/api/notifications/silences/{silence_id}")
+async def delete_silence(silence_id: str, user: dict = Depends(require_auth)):
+    deps = get_deps()
+    ok = await deps.db.delete_silence(silence_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Silence not found")
+    if deps.notification_service:
+        deps.notification_service.invalidate_silence_cache()
+    return {"silence_id": silence_id, "deleted": True}
 
 
 @router.get("/api/notifications/{notification_id}")

--- a/nerve/notifications/service.py
+++ b/nerve/notifications/service.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import uuid
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -98,10 +99,91 @@ class NotificationService:
         self.db = db
         self.engine = engine
         self._hide_session_label: set[str] = set()  # Session ID prefixes that suppress the label
+        # In-memory cache of active silence rules (compiled regexes).
+        # ``None`` = not loaded yet; rebuilt lazily and invalidated on any
+        # silence mutation (tool / API). Silences are few (tens), so a
+        # full reload on change is cheap.
+        self._silence_cache: list[dict] | None = None
+        self._silence_cache_lock = asyncio.Lock()
 
     def hide_session_label_for(self, session_prefix: str) -> None:
         """Register a session ID (or prefix) that should not show the session label."""
         self._hide_session_label.add(session_prefix)
+
+    # ------------------------------------------------------------------ #
+    #  Silence matching (deterministic, server-side alert suppression)     #
+    # ------------------------------------------------------------------ #
+
+    def invalidate_silence_cache(self) -> None:
+        """Drop the compiled-rule cache so the next match reloads from DB.
+
+        Called by the management tool and the REST routes after any
+        add/remove so a new rule takes effect immediately.
+        """
+        self._silence_cache = None
+
+    async def _get_silence_rules(self) -> list[dict]:
+        """Return the cached list of compiled silence rules, loading lazily.
+
+        Each entry is ``{id, pattern, regex, reason, action}``. A rule
+        whose pattern fails to compile is dropped (logged) — a bad regex
+        disables only that rule and never blocks delivery (fail-open).
+        """
+        if self._silence_cache is not None:
+            return self._silence_cache
+        async with self._silence_cache_lock:
+            # Re-check under the lock: another coroutine may have loaded it.
+            if self._silence_cache is not None:
+                return self._silence_cache
+            try:
+                rows = await self.db.get_active_silences()
+            except Exception as exc:  # defensive: never block delivery
+                logger.warning("silence cache load failed: %s", exc)
+                self._silence_cache = []
+                return self._silence_cache
+            compiled: list[dict] = []
+            for row in rows:
+                pattern = row.get("pattern") or ""
+                try:
+                    regex = re.compile(pattern, re.IGNORECASE)
+                except re.error as exc:
+                    logger.warning(
+                        "silence %s has invalid regex %r: %s — skipping",
+                        row.get("id"), pattern, exc,
+                    )
+                    continue
+                compiled.append({
+                    "id": row.get("id"),
+                    "pattern": pattern,
+                    "regex": regex,
+                    "reason": row.get("reason") or "",
+                    "action": row.get("action") or "silence",
+                })
+            self._silence_cache = compiled
+            return compiled
+
+    async def _match_silence(self, title: str, body: str) -> dict | None:
+        """Return the first active silence rule matching ``title``+``body``.
+
+        Matching is ``re.search`` (case-insensitive) over
+        ``f"{title}\\n{body}"``. First rule wins (oldest-first order).
+        Returns ``None`` if nothing matches. Never raises — a defensive
+        try/except keeps a pathological rule from blocking delivery.
+        """
+        rules = await self._get_silence_rules()
+        if not rules:
+            return None
+        haystack = f"{title}\n{body}"
+        for rule in rules:
+            try:
+                if rule["regex"].search(haystack):
+                    return rule
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "silence %s match raised: %s", rule.get("id"), exc,
+                )
+                continue
+        return None
 
     def _should_show_session_label(self, session_id: str) -> bool:
         """Check whether the session label should be appended to this notification."""
@@ -122,15 +204,66 @@ class NotificationService:
         priority: str = "normal",
         channels: list[str] | None = None,
         silent: bool = False,
+        force: bool = False,
     ) -> str:
         """Fire-and-forget notification. Returns notification_id.
+
+        Before delivery, the title+body is checked against active
+        **silence** rules (deterministic suppression of known-benign
+        alert classes — see :meth:`_match_silence`). A matched ``notify``
+        is persisted with ``status='silenced'`` and **not delivered**;
+        priority is never modified. The caller learns it was silenced via
+        the notification metadata (and the tool layer surfaces the reason
+        + pattern), and can re-send with ``force=True`` to bypass a match
+        it judges incorrect.
+
+        Silences apply to ``notify`` only — ``ask_question`` /
+        ``propose_action`` go through their own paths and are never
+        suppressed (a silenced question would hang its session forever).
 
         Args:
             channels: Override default notification channels (e.g. ["telegram"]).
             silent: If True, deliver without sound (Telegram disable_notification).
+            force: If True, bypass silence matching and deliver normally.
+                A forced send that *still* matched a rule is delivered but
+                stamped + counted as an override for audit.
         """
         notification_id = f"notif-{uuid.uuid4().hex[:8]}"
+        match = await self._match_silence(title, body)
 
+        if match and not force:
+            # --- SILENCE: record + persist, do NOT deliver ---
+            hit_count = await self.db.record_silence_hit(match["id"])
+            await self.db.create_notification(
+                notification_id=notification_id,
+                session_id=session_id,
+                type="notify",
+                title=title,
+                body=body,
+                priority=priority,            # priority UNCHANGED
+                status="silenced",
+                metadata={
+                    "silenced_by": match["id"],
+                    "silence_reason": match["reason"],
+                    "silence_action": match["action"],
+                    "silence_pattern": match["pattern"],
+                    "silence_hit_count": hit_count,
+                },
+            )
+            await self._broadcast_silenced_web(
+                notification_id, session_id, title, body, priority, match,
+            )
+            return notification_id  # no _fanout → no telegram ping
+
+        # --- DELIVER (normal, or force-override of a match) ---
+        extra_meta: dict[str, Any] = {}
+        if match and force:
+            override_count = await self.db.record_silence_override(match["id"])
+            extra_meta = {
+                "force_sent_over_silence": match["id"],
+                "force_override_count": override_count,
+                "silence_pattern": match["pattern"],
+            }
         await self.db.create_notification(
             notification_id=notification_id,
             session_id=session_id,
@@ -138,6 +271,7 @@ class NotificationService:
             title=title,
             body=body,
             priority=priority,
+            metadata=extra_meta or None,
         )
 
         await self._fanout(
@@ -621,6 +755,47 @@ class NotificationService:
         }
         if option_labels:
             message["option_labels"] = option_labels
+        await broadcaster.broadcast("__global__", message)
+
+    async def _broadcast_silenced_web(
+        self,
+        notification_id: str,
+        session_id: str,
+        title: str,
+        body: str,
+        priority: str,
+        match: dict | None = None,
+    ) -> None:
+        """Surface a silenced ``notify`` on the web UI without delivering it.
+
+        Reuses the ``__global__`` notification event shape but flags
+        ``silenced=True`` so the web client renders a greyed row and skips
+        the toast/sound. We also stamp ``channels_delivered=["web"]`` so
+        the row appears in the web notifications list (which filters by
+        the ``web`` channel) — the suppression must stay *visible*, only
+        the escalation is filtered.
+        """
+        from nerve.agent.streaming import broadcaster
+
+        await self.db.update_notification(
+            notification_id, channels_delivered=json.dumps(["web"]),
+        )
+
+        message: dict[str, Any] = {
+            "type": "notification",
+            "notification_id": notification_id,
+            "notification_type": "notify",
+            "session_id": session_id,
+            "title": title,
+            "body": body,
+            "priority": priority,
+            "options": None,
+            "silenced": True,
+        }
+        if match:
+            message["silence_reason"] = match.get("reason", "")
+            message["silence_pattern"] = match.get("pattern", "")
+            message["silenced_by"] = match.get("id", "")
         await broadcaster.broadcast("__global__", message)
 
     def _resolve_telegram_chat_id(self) -> int | None:

--- a/tests/test_notification_silences.py
+++ b/tests/test_notification_silences.py
@@ -1,0 +1,496 @@
+"""Tests for notification silences — deterministic alert suppression.
+
+Covers the v035 store, the service-level matcher + silence/force branches,
+the agent feedback loop on the ``notify`` tool, the ``notification_silence``
+management tool (+ cache invalidation), and the questions/approvals
+exemption.
+
+Runs against a fresh per-test SQLite (the shared ``db`` fixture) with the
+streaming broadcaster + agent engine stubbed so behavior is asserted in
+isolation. ``_fanout`` is mocked to detect (non-)delivery without touching
+any channel.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from nerve.agent.tools.handlers.notifications import (
+    notification_silence_handler,
+    notify_handler,
+)
+from nerve.agent.tools.registry import ToolContext
+from nerve.config import NerveConfig, NotificationsConfig
+from nerve.db import Database
+from nerve.notifications.service import NotificationService
+
+
+# ----------------------------------------------------------------------
+#  Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_config(tmp_path) -> NerveConfig:
+    cfg = NerveConfig()
+    cfg.workspace = tmp_path
+    cfg.notifications = NotificationsConfig(
+        channels=["web"],
+        telegram_chat_id=None,
+        default_expiry_hours=48,
+        priority_prefixes={"high": "", "urgent": ""},
+    )
+    return cfg
+
+
+@pytest.fixture
+def fake_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.sessions = MagicMock()
+    engine.sessions.is_running.return_value = False
+    engine.router = MagicMock()
+    engine.router.get_channel.return_value = None
+    engine.run = AsyncMock()
+    return engine
+
+
+@pytest.fixture
+def patch_broadcaster(monkeypatch) -> list:
+    captured: list = []
+
+    class _FakeBroadcaster:
+        async def broadcast(self, channel: str, message: dict) -> None:
+            captured.append((channel, message))
+
+    from nerve.agent import streaming
+    monkeypatch.setattr(streaming, "broadcaster", _FakeBroadcaster())
+    return captured
+
+
+@pytest_asyncio.fixture
+async def svc(db: Database, fake_config, fake_engine, patch_broadcaster):
+    await db.create_session("s1")
+    return NotificationService(fake_config, db, fake_engine)
+
+
+def _meta(notif: dict) -> dict:
+    raw = notif.get("metadata")
+    if not raw:
+        return {}
+    return raw if isinstance(raw, dict) else json.loads(raw)
+
+
+# ----------------------------------------------------------------------
+#  Schema / store
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSchemaAndStore:
+    async def test_v035_table_exists(self, db: Database):
+        async with db.db.execute(
+            "PRAGMA table_info(notification_silences)"
+        ) as cur:
+            cols = {row[1] async for row in cur}
+        for expected in (
+            "id", "pattern", "action", "reason", "created_by", "created_at",
+            "expires_at", "hit_count", "last_hit_at", "override_count",
+            "last_override_at", "enabled",
+        ):
+            assert expected in cols
+
+    async def test_create_and_get_silence(self, db: Database):
+        row = await db.create_silence(
+            silence_id="sil-1", pattern="foo", reason="benign",
+            created_by="s1",
+        )
+        assert row["id"] == "sil-1"
+        assert row["pattern"] == "foo"
+        assert row["hit_count"] == 0
+        assert row["override_count"] == 0
+        assert row["enabled"] == 1
+        assert row["expires_at"] is None
+
+    async def test_record_hit_returns_postincrement(self, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="x")
+        assert await db.record_silence_hit("sil-1") == 1
+        assert await db.record_silence_hit("sil-1") == 2
+        row = await db.get_silence("sil-1")
+        assert row["hit_count"] == 2
+        assert row["last_hit_at"] is not None
+
+    async def test_record_override_returns_postincrement(self, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="x")
+        assert await db.record_silence_override("sil-1") == 1
+        row = await db.get_silence("sil-1")
+        assert row["override_count"] == 1
+        assert row["last_override_at"] is not None
+
+    async def test_delete_silence(self, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="x")
+        assert await db.delete_silence("sil-1") is True
+        assert await db.get_silence("sil-1") is None
+        assert await db.delete_silence("sil-1") is False
+
+    async def test_get_active_skips_expired_and_disabled(self, db: Database):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        await db.create_silence(silence_id="sil-live", pattern="a")
+        await db.create_silence(
+            silence_id="sil-expired", pattern="b", expires_at=past,
+        )
+        await db.create_silence(silence_id="sil-off", pattern="c")
+        await db.db.execute(
+            "UPDATE notification_silences SET enabled = 0 WHERE id = ?",
+            ("sil-off",),
+        )
+        await db.db.commit()
+        active = {r["id"] for r in await db.get_active_silences()}
+        assert active == {"sil-live"}
+
+    async def test_create_notification_status_default_is_pending(self, db: Database):
+        await db.create_session("s2")
+        await db.create_notification(
+            notification_id="n1", session_id="s2", type="notify", title="t",
+        )
+        notif = await db.get_notification("n1")
+        assert notif["status"] == "pending"
+
+    async def test_create_notification_explicit_status(self, db: Database):
+        await db.create_session("s2")
+        await db.create_notification(
+            notification_id="n1", session_id="s2", type="notify", title="t",
+            status="silenced",
+        )
+        notif = await db.get_notification("n1")
+        assert notif["status"] == "silenced"
+
+
+# ----------------------------------------------------------------------
+#  Matcher
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestMatcher:
+    async def test_case_insensitive(self, svc, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        match = await svc._match_silence("WIDGET alert", "")
+        assert match is not None
+        assert match["id"] == "sil-1"
+
+    async def test_matches_body_not_just_title(self, svc, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="staging")
+        assert await svc._match_silence("sign-in", "device from staging") is not None
+
+    async def test_no_match_returns_none(self, svc, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        assert await svc._match_silence("payment failed", "urgent") is None
+
+    async def test_first_rule_wins(self, svc, db: Database):
+        # sil-a created first → oldest-first precedence → it wins.
+        await db.create_silence(silence_id="sil-a", pattern="alpha")
+        await db.create_silence(silence_id="sil-b", pattern="alpha.*beta")
+        match = await svc._match_silence("alpha beta", "")
+        assert match["id"] == "sil-a"
+
+    async def test_expired_rule_not_matched(self, svc, db: Database):
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        await db.create_silence(
+            silence_id="sil-1", pattern="widget", expires_at=past,
+        )
+        assert await svc._match_silence("widget", "") is None
+
+    async def test_invalid_regex_fails_open(self, svc, db: Database):
+        # A pattern that fails to compile is dropped, never blocks delivery.
+        await db.create_silence(silence_id="sil-bad", pattern="(unclosed")
+        await db.create_silence(silence_id="sil-ok", pattern="widget")
+        match = await svc._match_silence("widget", "")
+        assert match is not None
+        assert match["id"] == "sil-ok"
+
+    async def test_cache_invalidation(self, svc, db: Database):
+        # Prime the (empty) cache, then add a rule + invalidate.
+        assert await svc._match_silence("widget", "") is None
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        # Stale cache: still no match until invalidated.
+        assert await svc._match_silence("widget", "") is None
+        svc.invalidate_silence_cache()
+        assert await svc._match_silence("widget", "") is not None
+
+
+# ----------------------------------------------------------------------
+#  Silence path (force=False, match)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSilencePath:
+    async def test_silenced_row_persisted_not_delivered(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(
+            silence_id="sil-1", pattern="widget", reason="known benign",
+        )
+        svc._fanout = AsyncMock()
+        nid = await svc.send_notification(
+            session_id="s1", title="Widget alert", body="from staging",
+            priority="high",
+        )
+        notif = await db.get_notification(nid)
+        assert notif["status"] == "silenced"
+        # priority is NEVER modified
+        assert notif["priority"] == "high"
+        # not delivered: _fanout never invoked
+        svc._fanout.assert_not_called()
+        # metadata carries the full match context
+        meta = _meta(notif)
+        assert meta["silenced_by"] == "sil-1"
+        assert meta["silence_reason"] == "known benign"
+        assert meta["silence_action"] == "silence"
+        assert meta["silence_pattern"] == "widget"
+        assert meta["silence_hit_count"] == 1
+
+    async def test_hit_count_increments(self, svc, db: Database, patch_broadcaster):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc._fanout = AsyncMock()
+        await svc.send_notification(session_id="s1", title="widget", body="")
+        n2 = await svc.send_notification(session_id="s1", title="widget x", body="")
+        assert _meta(await db.get_notification(n2))["silence_hit_count"] == 2
+        assert (await db.get_silence("sil-1"))["hit_count"] == 2
+
+    async def test_web_broadcast_emitted_silenced(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(silence_id="sil-1", pattern="widget", reason="r")
+        svc._fanout = AsyncMock()
+        nid = await svc.send_notification(session_id="s1", title="widget", body="")
+        msgs = [m for _, m in patch_broadcaster if m.get("type") == "notification"]
+        assert msgs
+        assert msgs[0]["silenced"] is True
+        assert msgs[0]["notification_id"] == nid
+        assert msgs[0]["silence_reason"] == "r"
+        # marked delivered to web so the row appears in the web list
+        row = await db.get_notification(nid)
+        assert json.loads(row["channels_delivered"]) == ["web"]
+
+
+# ----------------------------------------------------------------------
+#  Force path (force=True)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestForcePath:
+    async def test_force_delivers_over_match(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc._fanout = AsyncMock()
+        nid = await svc.send_notification(
+            session_id="s1", title="widget", body="", force=True,
+        )
+        notif = await db.get_notification(nid)
+        # delivered (not silenced)
+        assert notif["status"] != "silenced"
+        svc._fanout.assert_called_once()
+        # override recorded + stamped
+        meta = _meta(notif)
+        assert meta["force_sent_over_silence"] == "sil-1"
+        assert meta["force_override_count"] == 1
+        assert (await db.get_silence("sil-1"))["override_count"] == 1
+
+    async def test_force_no_match_no_override(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc._fanout = AsyncMock()
+        nid = await svc.send_notification(
+            session_id="s1", title="payment failed", body="", force=True,
+        )
+        notif = await db.get_notification(nid)
+        assert notif["status"] != "silenced"
+        svc._fanout.assert_called_once()
+        assert _meta(notif) == {}
+        assert (await db.get_silence("sil-1"))["override_count"] == 0
+
+    async def test_normal_send_no_match_delivers(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        svc._fanout = AsyncMock()
+        nid = await svc.send_notification(session_id="s1", title="hello", body="")
+        notif = await db.get_notification(nid)
+        assert notif["status"] == "pending"
+        svc._fanout.assert_called_once()
+
+
+# ----------------------------------------------------------------------
+#  Exemptions: questions / approvals are never silenced
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestExemptions:
+    async def test_question_not_silenced(self, svc, db: Database, patch_broadcaster):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc._fanout = AsyncMock()
+        result = await svc.ask_question(
+            session_id="s1", title="widget?", body="confirm",
+        )
+        notif = await db.get_notification(result["notification_id"])
+        assert notif["type"] == "question"
+        assert notif["status"] == "pending"
+        svc._fanout.assert_called_once()
+
+    async def test_approval_not_silenced(self, svc, db: Database, patch_broadcaster):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc._fanout = AsyncMock()
+        result = await svc.propose_action(
+            session_id="s1", target_kind="mechanical-action",
+            target_id="t-1", title="widget",
+        )
+        notif = await db.get_notification(result["notification_id"])
+        assert notif["type"] == "approval"
+        assert notif["status"] == "pending"
+        svc._fanout.assert_called_once()
+
+
+# ----------------------------------------------------------------------
+#  notify tool: agent feedback loop
+# ----------------------------------------------------------------------
+
+
+def _ctx(svc, db) -> ToolContext:
+    return ToolContext(session_id="s1", db=db, notification_service=svc)
+
+
+def _text(result) -> str:
+    return result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+class TestNotifyToolFeedback:
+    async def test_plain_send_returns_sent(self, svc, db: Database, patch_broadcaster):
+        svc._fanout = AsyncMock()
+        result = await notify_handler(_ctx(svc, db), {"body": "all good"})
+        assert "Notification sent" in _text(result)
+        assert "SILENCED" not in _text(result)
+
+    async def test_silenced_send_returns_force_instruction(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(
+            silence_id="sil-1", pattern="widget", reason="known benign",
+        )
+        svc._fanout = AsyncMock()
+        result = await notify_handler(
+            _ctx(svc, db), {"title": "Widget alert", "body": "staging"},
+        )
+        text = _text(result)
+        assert "SILENCED" in text
+        assert "sil-1" in text
+        assert "known benign" in text
+        assert "widget" in text
+        assert "force=true" in text
+
+    async def test_force_over_match_returns_override_confirmation(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc._fanout = AsyncMock()
+        result = await notify_handler(
+            _ctx(svc, db),
+            {"title": "widget", "body": "x", "force": True},
+        )
+        text = _text(result)
+        assert "force-delivered over silence sil-1" in text
+        assert "override #1" in text
+
+
+# ----------------------------------------------------------------------
+#  notification_silence management tool (+ cache invalidation)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSilenceTool:
+    async def test_add_creates_rule_and_invalidates_cache(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        # Prime cache empty.
+        assert await svc._match_silence("widget", "") is None
+        result = await notification_silence_handler(
+            _ctx(svc, db),
+            {"op": "add", "pattern": "widget", "reason": "benign"},
+        )
+        assert "Silence created" in _text(result)
+        # Cache invalidated by the tool → rule effective immediately.
+        assert await svc._match_silence("widget", "") is not None
+        assert len(await db.list_silences()) == 1
+
+    async def test_add_rejects_invalid_regex(self, svc, db: Database):
+        result = await notification_silence_handler(
+            _ctx(svc, db), {"op": "add", "pattern": "(unclosed"},
+        )
+        assert "invalid regex" in _text(result)
+        assert await db.list_silences() == []
+
+    async def test_add_requires_pattern(self, svc, db: Database):
+        result = await notification_silence_handler(
+            _ctx(svc, db), {"op": "add", "pattern": ""},
+        )
+        assert "required" in _text(result)
+
+    async def test_add_with_ttl_sets_expiry(self, svc, db: Database):
+        await notification_silence_handler(
+            _ctx(svc, db),
+            {"op": "add", "pattern": "x", "ttl_hours": 5},
+        )
+        rows = await db.list_silences()
+        assert rows[0]["expires_at"] is not None
+
+    async def test_add_example_echo(self, svc, db: Database):
+        result = await notification_silence_handler(
+            _ctx(svc, db),
+            {"op": "add", "pattern": "widget", "example": "Widget alert"},
+        )
+        assert "WOULD match" in _text(result)
+
+    async def test_list_shows_counts(self, svc, db: Database):
+        await db.create_silence(silence_id="sil-1", pattern="widget", reason="r")
+        await db.record_silence_hit("sil-1")
+        result = await notification_silence_handler(_ctx(svc, db), {"op": "list"})
+        text = _text(result)
+        assert "sil-1" in text
+        assert "widget" in text
+        assert "1 hits" in text
+
+    async def test_list_empty(self, svc, db: Database):
+        result = await notification_silence_handler(_ctx(svc, db), {"op": "list"})
+        assert "No active notification silences" in _text(result)
+
+    async def test_remove_deletes_and_invalidates(
+        self, svc, db: Database, patch_broadcaster,
+    ):
+        await db.create_silence(silence_id="sil-1", pattern="widget")
+        svc.invalidate_silence_cache()
+        assert await svc._match_silence("widget", "") is not None
+        result = await notification_silence_handler(
+            _ctx(svc, db), {"op": "remove", "silence_id": "sil-1"},
+        )
+        assert "Silence removed" in _text(result)
+        assert await svc._match_silence("widget", "") is None
+
+    async def test_remove_unknown_id(self, svc, db: Database):
+        result = await notification_silence_handler(
+            _ctx(svc, db), {"op": "remove", "silence_id": "sil-nope"},
+        )
+        assert "No silence found" in _text(result)
+
+    async def test_unknown_op(self, svc, db: Database):
+        result = await notification_silence_handler(_ctx(svc, db), {"op": "frob"})
+        assert "must be one of" in _text(result)

--- a/tests/test_session_mcp.py
+++ b/tests/test_session_mcp.py
@@ -49,6 +49,9 @@ class TestSessionMCPIsolation:
         """_notify_impl forwards the given session_id to the notification service."""
         mock_service = AsyncMock()
         mock_service.send_notification = AsyncMock(return_value="notif-abc")
+        # The handler reads the row back to detect silenced/force outcomes;
+        # a plain None keeps it on the "sent" path for this unit test.
+        mock_service.db.get_notification = AsyncMock(return_value=None)
 
         with patch("nerve.agent.tools._notification_service", mock_service):
             result = await _notify_impl(
@@ -61,6 +64,7 @@ class TestSessionMCPIsolation:
             title="Test",
             body="hello",
             priority="normal",
+            force=False,
         )
         assert "notif-abc" in result["content"][0]["text"]
 
@@ -99,6 +103,7 @@ class TestSessionMCPIsolation:
 
         mock_service = AsyncMock()
         mock_service.send_notification = AsyncMock(side_effect=fake_send_notification)
+        mock_service.db.get_notification = AsyncMock(return_value=None)
 
         with patch("nerve.agent.tools._notification_service", mock_service):
             # Both sessions call notify concurrently

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -273,6 +273,9 @@ class TestConcurrentSessionIsolation:
 
         mock_service = AsyncMock()
         mock_service.send_notification = AsyncMock(side_effect=fake_send_notification)
+        # The notify handler reads the row back to detect silenced/force
+        # outcomes; None keeps it on the plain "sent" path for this test.
+        mock_service.db.get_notification = AsyncMock(return_value=None)
 
         ctx_a = ToolContext(session_id="session-A", notification_service=mock_service)
         ctx_b = ToolContext(session_id="session-B", notification_service=mock_service)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -342,6 +342,17 @@ export const api = {
   dismissAllNotifications: () =>
     request<{ dismissed: number }>('/notifications/dismiss-all', { method: 'POST' }),
 
+  // Notification silences (deterministic suppression rules)
+  listSilences: () =>
+    request<{ silences: any[] }>('/notifications/silences'),
+  createSilence: (pattern: string, reason: string, ttl_hours: number) =>
+    request<any>('/notifications/silences', {
+      method: 'POST',
+      body: JSON.stringify({ pattern, reason, ttl_hours }),
+    }),
+  deleteSilence: (id: string) =>
+    request<any>(`/notifications/silences/${id}`, { method: 'DELETE' }),
+
   // houseofagents
   getHoaStatus: () =>
     request<{ enabled: boolean; available: boolean; version: string | null; default_mode: string; default_agents: string[] }>('/houseofagents/status'),

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -19,7 +19,7 @@ export type WSMessage =
   | { type: 'subagent_start'; session_id: string; tool_use_id: string; subagent_type: string; description: string; model?: string }
   | { type: 'subagent_complete'; session_id: string; tool_use_id: string; duration_ms: number; is_error?: boolean }
   | { type: 'file_changed'; session_id: string; path: string; operation: string; tool_use_id: string }
-  | { type: 'notification'; notification_id: string; notification_type: 'notify' | 'question' | 'approval'; session_id: string; title: string; body: string; priority: string; options: string[] | null; option_labels?: Record<string, string>; target_kind?: string; target_id?: string }
+  | { type: 'notification'; notification_id: string; notification_type: 'notify' | 'question' | 'approval'; session_id: string; title: string; body: string; priority: string; options: string[] | null; option_labels?: Record<string, string>; target_kind?: string; target_id?: string; silenced?: boolean; silence_reason?: string; silence_pattern?: string; silenced_by?: string }
   | { type: 'notification_answered'; notification_id: string; session_id: string; answer: string; answered_by: string; approval_status?: 'answered' | 'snoozed'; dispatch_ok?: boolean }
   | { type: 'answer_injected'; session_id: string; notification_id: string; title: string; answer: string; answered_by: string; content: string }
   | { type: 'session_running'; session_id: string; is_running: boolean }

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Bell, X, CheckCheck, EyeOff, Check, XCircle, Moon } from 'lucide-react';
-import { useNotificationStore, type Notification } from '../stores/notificationStore';
+import { Bell, X, CheckCheck, EyeOff, Check, XCircle, Moon, BellOff, Trash2, Plus } from 'lucide-react';
+import { useNotificationStore, type Notification, type Silence } from '../stores/notificationStore';
 
 const STATUS_STYLES: Record<string, string> = {
   pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
   answered: 'bg-emerald-400/10 text-hue-emerald border-emerald-400/20',
   expired: 'bg-border-subtle/50 text-text-muted border-border-subtle',
   dismissed: 'bg-border-subtle/50 text-text-dim border-border-subtle',
+  silenced: 'bg-border-subtle/50 text-text-dim border-border-subtle',
 };
 
 const PRIORITY_DOTS: Record<string, string> = {
@@ -28,6 +29,7 @@ const STATUS_FILTERS = [
   { label: 'Pending', value: 'pending' },
   { label: 'Answered', value: 'answered' },
   { label: 'Expired', value: 'expired' },
+  { label: 'Silenced', value: 'silenced' },
 ];
 
 const TYPE_FILTERS = [
@@ -89,6 +91,31 @@ function parseOptionLabels(notif: Notification): Record<string, string> | null {
     // Malformed JSON: just fall back to defaults.
   }
   return null;
+}
+
+interface SilenceInfo {
+  silenced_by?: string;
+  silence_reason?: string;
+  silence_pattern?: string;
+  silence_hit_count?: number;
+}
+
+function parseSilenceInfo(notif: Notification): SilenceInfo | null {
+  if (!notif.metadata) return null;
+  try {
+    const meta = typeof notif.metadata === 'string' ? JSON.parse(notif.metadata) : notif.metadata;
+    if (meta && typeof meta === 'object' && 'silenced_by' in meta) {
+      return meta as SilenceInfo;
+    }
+  } catch {
+    // Malformed JSON: nothing to surface.
+  }
+  return null;
+}
+
+function formatExpiry(expiresAt: string | null): string {
+  if (!expiresAt) return 'permanent';
+  return `expires ${expiresAt.slice(0, 16).replace('T', ' ')}`;
 }
 
 function FreeTextInput({ onSubmit }: { onSubmit: (text: string) => void }) {
@@ -247,6 +274,140 @@ function NotificationCard({ notif }: { notif: Notification }) {
           <span className="text-text-faint">(via {notif.answered_by})</span>
         </div>
       )}
+
+      {/* Silence context: why this was suppressed and not delivered */}
+      {notif.status === 'silenced' && (() => {
+        const info = parseSilenceInfo(notif);
+        return (
+          <div className="mt-2 flex items-start gap-1.5 text-[12px] text-text-dim">
+            <BellOff size={12} className="mt-0.5 shrink-0" />
+            <div className="min-w-0">
+              <span>Silenced{info?.silenced_by ? ` by ${info.silenced_by}` : ''} — not delivered.</span>
+              {info?.silence_reason && (
+                <span className="text-text-muted"> {info.silence_reason}</span>
+              )}
+              {info?.silence_pattern && (
+                <span className="ml-1 font-mono text-text-faint">[{info.silence_pattern}]</span>
+              )}
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}
+
+function SilenceRow({ s, onRemove }: { s: Silence; onRemove: () => void }) {
+  const overridden = s.override_count > 0;
+  return (
+    <div className="flex items-center gap-3 px-3 py-2 bg-surface-raised border border-border-subtle rounded-lg text-[12px]">
+      <code className="font-mono text-text-muted shrink-0">{s.id}</code>
+      <code className="font-mono text-accent truncate flex-1 min-w-0">{s.pattern}</code>
+      <span className="text-text-muted shrink-0">
+        {s.hit_count} hits
+        {overridden ? `, ${s.override_count} override${s.override_count !== 1 ? 's' : ''}` : ''}
+      </span>
+      <span className="text-text-faint shrink-0">{formatExpiry(s.expires_at)}</span>
+      {s.reason && (
+        <span className="text-text-dim truncate hidden md:block max-w-[14rem]" title={s.reason}>
+          {s.reason}
+        </span>
+      )}
+      {overridden && (
+        <span className="text-hue-yellow shrink-0" title="Force-overridden — this pattern may be too broad">⚠</span>
+      )}
+      <button
+        onClick={onRemove}
+        className="text-text-dim hover:text-hue-red cursor-pointer shrink-0"
+        title="Remove silence"
+      >
+        <Trash2 size={13} />
+      </button>
+    </div>
+  );
+}
+
+function SilencesPanel() {
+  const { silences, loadSilences, addSilence, removeSilence } = useNotificationStore();
+  const [pattern, setPattern] = useState('');
+  const [reason, setReason] = useState('');
+  const [ttlHours, setTtlHours] = useState('');
+  const [error, setError] = useState('');
+  const [adding, setAdding] = useState(false);
+
+  useEffect(() => { loadSilences(); }, []);
+
+  const submit = async () => {
+    const p = pattern.trim();
+    if (!p) { setError('Pattern is required'); return; }
+    try { new RegExp(p); } catch { setError('Invalid regex'); return; }
+    setAdding(true);
+    setError('');
+    try {
+      await addSilence(p, reason.trim(), Number(ttlHours) || 0);
+      setPattern(''); setReason(''); setTtlHours('');
+    } catch (e: any) {
+      setError(e?.message || 'Failed to create silence');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto mb-4 p-4 bg-surface border border-border-subtle rounded-lg">
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <BellOff size={15} className="text-text-muted" />
+        <h2 className="text-sm font-semibold text-text">Silences</h2>
+        <span className="text-[12px] text-text-faint">
+          Suppress known-benign alert classes — matched notifications are recorded but not delivered (priority unchanged).
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <input
+          type="text"
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+          placeholder="Regex pattern (matches title + body)"
+          className="flex-1 min-w-[14rem] bg-surface-raised border border-border-subtle rounded-lg px-3 py-1.5 text-sm text-text outline-none focus:border-accent font-mono"
+        />
+        <input
+          type="text"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+          placeholder="Reason"
+          className="flex-1 min-w-[10rem] bg-surface-raised border border-border-subtle rounded-lg px-3 py-1.5 text-sm text-text outline-none focus:border-accent"
+        />
+        <input
+          type="number"
+          min="0"
+          value={ttlHours}
+          onChange={(e) => setTtlHours(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+          placeholder="TTL h (0=∞)"
+          className="w-28 bg-surface-raised border border-border-subtle rounded-lg px-3 py-1.5 text-sm text-text outline-none focus:border-accent"
+        />
+        <button
+          onClick={submit}
+          disabled={adding}
+          className="flex items-center gap-1 px-3 py-1.5 bg-accent/15 text-accent rounded-lg text-sm border border-accent/30 hover:bg-accent/25 cursor-pointer disabled:opacity-50"
+        >
+          <Plus size={14} /> Add
+        </button>
+      </div>
+      {error && <div className="text-[12px] text-hue-red mb-2">{error}</div>}
+
+      {silences.length === 0 ? (
+        <div className="text-[12px] text-text-faint">No silences configured.</div>
+      ) : (
+        <div className="space-y-1.5">
+          {silences.map((s) => (
+            <SilenceRow key={s.id} s={s} onRemove={() => removeSilence(s.id)} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -256,6 +417,7 @@ export function NotificationsPage() {
     notifications, pendingCount, filter, typeFilter, loading,
     loadNotifications, setFilter, setTypeFilter, dismissAll,
   } = useNotificationStore();
+  const [showSilences, setShowSilences] = useState(false);
 
   useEffect(() => { loadNotifications(); }, []);
 
@@ -299,11 +461,24 @@ export function NotificationsPage() {
           ))}
         </div>
 
+        {/* Silences toggle */}
+        <button
+          onClick={() => setShowSilences(v => !v)}
+          className={`ml-auto flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border cursor-pointer transition-colors
+            ${showSilences
+              ? 'bg-accent/15 text-accent border-accent/30'
+              : 'border-border text-text-muted hover:text-text-secondary hover:bg-surface-raised'
+            }`}
+        >
+          <BellOff size={13} />
+          Silences
+        </button>
+
         {/* Dismiss All */}
         {pendingCount > 0 && (
           <button
             onClick={dismissAll}
-            className="ml-auto flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border border-border text-text-muted hover:text-text-secondary hover:border-border hover:bg-surface-raised cursor-pointer transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border border-border text-text-muted hover:text-text-secondary hover:border-border hover:bg-surface-raised cursor-pointer transition-colors"
           >
             <CheckCheck size={13} />
             Dismiss All
@@ -312,6 +487,7 @@ export function NotificationsPage() {
       </div>
 
       <div className="flex-1 overflow-y-auto p-6">
+        {showSilences && <SilencesPanel />}
         {loading ? (
           <div className="text-text-faint text-center py-10">Loading...</div>
         ) : notifications.length === 0 ? (

--- a/web/src/stores/notificationStore.ts
+++ b/web/src/stores/notificationStore.ts
@@ -24,6 +24,23 @@ export interface Notification {
   metadata?: string | Record<string, unknown> | null;
 }
 
+// A deterministic suppression rule. Matched notify's are persisted as
+// status='silenced' and not delivered; priority is never changed.
+export interface Silence {
+  id: string;
+  pattern: string;
+  action: string;
+  reason: string;
+  created_by: string;
+  created_at: string;
+  expires_at: string | null;
+  hit_count: number;
+  last_hit_at: string | null;
+  override_count: number;
+  last_override_at: string | null;
+  enabled: number;
+}
+
 interface NotificationState {
   notifications: Notification[];
   pendingCount: number;
@@ -31,6 +48,7 @@ interface NotificationState {
   typeFilter: string;
   loading: boolean;
   toastQueue: Notification[];
+  silences: Silence[];
 
   loadNotifications: () => Promise<void>;
   setFilter: (f: string) => void;
@@ -41,6 +59,9 @@ interface NotificationState {
   handleWSNotification: (data: any) => void;
   handleWSNotificationAnswered: (data: any) => void;
   dismissToast: (id: string) => void;
+  loadSilences: () => Promise<void>;
+  addSilence: (pattern: string, reason: string, ttlHours: number) => Promise<void>;
+  removeSilence: (id: string) => Promise<void>;
 }
 
 export const useNotificationStore = create<NotificationState>((set, get) => ({
@@ -50,6 +71,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   typeFilter: '',
   loading: true,
   toastQueue: [],
+  silences: [],
 
   loadNotifications: async () => {
     try {
@@ -104,6 +126,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   },
 
   handleWSNotification: (data: any) => {
+    const silenced = data.silenced === true;
     const notif: Notification = {
       id: data.notification_id,
       session_id: data.session_id,
@@ -112,7 +135,7 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
       title: data.title,
       body: data.body,
       priority: data.priority,
-      status: 'pending',
+      status: silenced ? 'silenced' : 'pending',
       options: data.options,
       answer: null,
       answered_by: null,
@@ -122,12 +145,23 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
       target_kind: data.target_kind ?? null,
       target_id: data.target_id ?? null,
       option_labels: data.option_labels ?? null,
+      // Carry the silence context inline so the greyed row can render
+      // the reason/pattern without a metadata round-trip.
+      metadata: silenced
+        ? {
+            silenced_by: data.silenced_by ?? null,
+            silence_reason: data.silence_reason ?? '',
+            silence_pattern: data.silence_pattern ?? '',
+          }
+        : null,
     };
 
     set(s => ({
       notifications: [notif, ...s.notifications],
-      pendingCount: s.pendingCount + 1,
-      toastQueue: [...s.toastQueue, notif],
+      // A silenced notification was NOT delivered/escalated — it does not
+      // count as pending and never raises a toast/sound.
+      pendingCount: silenced ? s.pendingCount : s.pendingCount + 1,
+      toastQueue: silenced ? s.toastQueue : [...s.toastQueue, notif],
     }));
   },
 
@@ -144,5 +178,33 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
 
   dismissToast: (id: string) => {
     set(s => ({ toastQueue: s.toastQueue.filter(n => n.id !== id) }));
+  },
+
+  loadSilences: async () => {
+    try {
+      const data = await api.listSilences();
+      set({ silences: data.silences });
+    } catch (e) {
+      console.error('Failed to load silences:', e);
+    }
+  },
+
+  addSilence: async (pattern: string, reason: string, ttlHours: number) => {
+    try {
+      await api.createSilence(pattern, reason, ttlHours);
+      get().loadSilences();
+    } catch (e) {
+      console.error('Failed to create silence:', e);
+      throw e;
+    }
+  },
+
+  removeSilence: async (id: string) => {
+    try {
+      await api.deleteSilence(id);
+      get().loadSilences();
+    } catch (e) {
+      console.error('Failed to delete silence:', e);
+    }
   },
 }));


### PR DESCRIPTION
## Summary

Adds **notification silences** — deterministic, server-side suppression of known-benign alert classes, modeled on monitoring-system silences. Today whether a benign alert (e.g. a recurring vendor dunning email, an expected sign-in) fires depends on each cron session re-deciding its priority every run; there is no way to say "never escalate this class again." This adds that guardrail at the one chokepoint every notification flows through: `NotificationService.send_notification`.

A silence is a regex rule (`pattern` + `reason` + optional TTL). When a `notify`'s `title + "\n" + body` matches an active rule, the notification is **persisted with `status='silenced'` and not delivered** — **priority is never modified**, and the suppression stays fully visible/auditable. The sending agent is told it was silenced (with the reason + pattern) and can re-send with `force=true` to override a wrong match; a forced send that still matches is delivered but counted as an override, so over-broad patterns surface themselves.

Questions (`ask_user`) and approvals (`propose_action`) are **exempt** — a silenced question would hang its session, and approvals must always be seen.

## How it works

- **Match:** `re.search` (case-insensitive) over `title + "\n" + body`; first rule wins (oldest-first). Compiled rules are cached in-memory and invalidated on any add/remove. A pattern that fails to compile is dropped and logged — it never blocks delivery (**fail-open**).
- **Silenced path:** record hit → persist `status='silenced'` with `{silenced_by, silence_reason, silence_action, silence_pattern, silence_hit_count}` → web broadcast (greyed row, no toast/sound) → **no fan-out**.
- **Force path:** matcher still runs for audit; delivery proceeds and an override is recorded/stamped.
- **Agent feedback:** the `notify` tool reads the row back and returns either plain "sent", a "SILENCED — re-send with force=true" message (with reason + pattern), or a "force-delivered over silence (override #N)" confirmation.

## Changes

- `nerve/db/migrations/v035_notification_silences.py` — `notification_silences` table + index
- `nerve/db/notifications.py` — silence CRUD, `get_active_silences`, hit/override counters; optional `status` arg on `create_notification`
- `nerve/notifications/service.py` — compiled-regex matcher + cache, silence/force branches, silenced web broadcast
- `nerve/agent/tools/schemas.py` + `handlers/notifications.py` — `force` flag on `notify` + outcome feedback; new `notification_silence` (add/list/remove) tool
- `nerve/gateway/routes/notifications.py` — `GET/POST/DELETE /api/notifications/silences` (declared before `/{notification_id}`)
- `web/` — Notifications page Silences panel (add/list/remove, hit/override counts, expiry), silenced-row rendering, WS `silenced` handling
- `tests/test_notification_silences.py` — store, matcher, silence/force paths, exemptions, tool feedback, management tool + cache invalidation

## Test plan

- [x] `pytest tests/` — full backend suite **1145 passed**
- [x] `pytest tests/test_notification_silences.py -W error::RuntimeWarning` — **36 passed** (warnings as errors)
- [x] `npm run build` — clean (`tsc -b` typecheck + Vite bundle)
- [x] After merge: seed the two agreed silences (with confirmation) and watch `op=list` hit/override counts

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*