### PR TITLE
Add nerve backup/restore for disaster recovery

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -84,6 +84,22 @@ cron:
   system_file: ~/.nerve/cron/system.yaml   # Managed by 'nerve init' — system crons
   jobs_file: ~/.nerve/cron/jobs.yaml       # Your custom crons — never touched by Nerve
 
+# Backup (optional) — scheduled, verified snapshots of Nerve state into a
+# single portable bundle (nerve-backup-<host>-<ts>.tar.zst). Off by default.
+# Point target_dir at an external mount or a synced directory — the OFF-BOX
+# copy is what protects against a disk failure. The SQLite DBs are snapshotted
+# with the online-backup API, so bundles are consistent even while Nerve runs.
+# Manual use: `nerve backup` / `nerve restore BUNDLE` (no running server needed).
+# backup:
+#   enabled: false
+#   target_dir: ""              # e.g. /mnt/backup/nerve  (REQUIRED when enabled)
+#   interval_hours: 24          # scheduled cadence (an hourly tick fires when due)
+#   retention_count: 7          # keep the newest N bundles; prune older ones
+#   include_workspace: true     # include the workspace BRAIN (*.md, memory/, scripts/, skills/)
+#   workspace_excludes: []      # extra glob patterns to skip, e.g. ["*.png", "drafts"]
+#   notify_on_failure: true     # high-priority notify if a scheduled backup fails
+#   notify_on_success: false    # low-priority digest line on success
+
 # External MCP server (optional) — expose Nerve's tool registry to
 # external MCP clients (Codex, Claude Code, Cursor) over Streamable HTTP.
 # Off by default. Authentication reuses the gateway JWT

--- a/nerve/backup.py
+++ b/nerve/backup.py
@@ -1,0 +1,941 @@
+"""Backup and restore for Nerve state.
+
+Produces a single portable bundle — ``nerve-backup-<host>-<ts>.tar.zst``
+(or ``.tar.gz`` when zstandard is unavailable) — containing a consistent
+snapshot of everything that makes a Nerve instance *this* instance:
+
+- ``nerve.db``   — sessions, messages, tasks index, notifications, plans, usage
+- ``memu.sqlite`` — the entire long-term memory
+- the memU sidecar dirs (``memu-conversations/``, ``memu-manual/``, ``memu-resources/``)
+- secrets (``certs/``, ``mcp-token``, ``telegram_sync.session``, ``config.local.yaml``)
+- cron jobs (``cron/``) and the config-dir pointer
+- the workspace "BRAIN" (identity markdown, ``memory/``, ``scripts/``, ``skills/``)
+
+The databases run in **WAL mode**, so a naive ``cp`` of the live files can
+capture a torn snapshot. We use SQLite's online backup API
+(:meth:`sqlite3.Connection.backup`) which produces a transactionally
+consistent copy while writers continue — the core correctness win over a
+file copy (the June-2026 box migration only worked because the service was
+stopped first; an automated backup can't rely on that).
+
+Design:
+
+- **Local-dir targets only** in v1 — an external mount or a synced dir
+  covers the off-box requirement. Cloud upload is a follow-up.
+- **Verified restore** — checksums vs. manifest, ``PRAGMA integrity_check``
+  on both DBs, and a schema-version guard so a newer-schema bundle never
+  lands on older code.
+- **Loud failures** — the scheduled job notifies on failure (silent
+  backups that fail are worse than none).
+- **Trash over rm** — ``restore --force`` relocates the old state dir to
+  ``~/.nerve.pre-restore-<ts>`` rather than deleting it, and refuses to
+  run against a live daemon (no override — stop it first).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import sqlite3
+import subprocess
+import tarfile
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+logger = logging.getLogger(__name__)
+
+# Bundle format revision — bump if the on-disk layout changes incompatibly.
+FORMAT_VERSION = 1
+
+# --- What goes in state/ (everything under ~/.nerve worth keeping) --------- #
+# The two databases are snapshotted via the online-backup API (below); the
+# rest are plain file/dir copies. Anything not named here is excluded by
+# construction — that intentionally drops nerve.log, nerve.pid, the
+# *-wal/-shm sidecars (folded into the snapshot), bin/, .crates*, and the
+# stale memu.backup*.sqlite copies.
+STATE_DB_FILES: tuple[str, ...] = ("nerve.db", "memu.sqlite")
+STATE_DIRS: tuple[str, ...] = (
+    "memu-conversations",
+    "memu-manual",
+    "memu-resources",
+    "cron",
+    "certs",
+)
+STATE_FILES: tuple[str, ...] = (
+    "config_dir",
+    "mcp-token",
+    "telegram_sync.session",
+)
+
+# Secret members (relative to the bundle root) — omitted with --no-secrets
+# and re-chmod'd to 0600 on restore.
+SECRET_MEMBERS: frozenset[str] = frozenset({
+    "state/certs",
+    "state/mcp-token",
+    "state/telegram_sync.session",
+    "config/config.local.yaml",
+})
+# Files within the bundle whose mode must be 0600 after restore.
+SECRET_FILE_MODE = 0o600
+_SECRET_RESTORE_PATHS: tuple[str, ...] = (
+    "mcp-token",
+    "telegram_sync.session",
+)
+
+# --- Workspace BRAIN allowlist --------------------------------------------- #
+# The workspace is typically buried in tens of GB of repo/build junk, so we
+# take an *allowlist* of the small, irreplaceable "brain": identity markdown
+# at the root plus a few known directories. Extra excludes from config are
+# applied *within* these.
+WORKSPACE_INCLUDE_DIRS: tuple[str, ...] = ("memory", "scripts", "skills")
+WORKSPACE_INCLUDE_FILE_GLOBS: tuple[str, ...] = ("*.md",)
+
+# Directory names always pruned while walking the included workspace dirs.
+_PRUNE_DIR_NAMES: frozenset[str] = frozenset({
+    ".git", "node_modules", ".venv", "venv", "__pycache__",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache",
+})
+
+# Warn if the workspace payload exceeds this — a sign the junk exclusion
+# missed something (e.g. a build artifact landed under memory/).
+WORKSPACE_WARN_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB
+
+# Retention prune only ever touches files matching this exact pattern, so it
+# can never delete an unrelated file that happens to share the directory.
+# An optional ``-<n>`` disambiguates bundles created within the same second.
+BUNDLE_RE = re.compile(r"^nerve-backup-.+-\d{8}-\d{6}(-\d+)?\.tar\.(zst|gz)$")
+
+
+class BackupError(Exception):
+    """Raised when a backup or restore operation cannot proceed safely."""
+
+
+# --------------------------------------------------------------------------- #
+#  Results                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class BackupResult:
+    path: Path
+    size: int
+    compression: str
+    counts: dict
+    file_count: int
+    include_secrets: bool
+    include_workspace: bool
+    workspace_bytes: int
+
+
+@dataclass
+class VerifyReport:
+    ok: bool
+    manifest: dict
+    counts: dict
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        c = self.counts
+        parts = [
+            f"sessions={c.get('sessions', '?')}",
+            f"messages={c.get('messages', '?')}",
+            f"tasks={c.get('tasks', '?')}",
+            f"memU items={c.get('memu_items', '?')}",
+        ]
+        return ", ".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+#  Low-level helpers                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def _now_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+
+def _hostname() -> str:
+    try:
+        return socket.gethostname() or "unknown-host"
+    except Exception:
+        return "unknown-host"
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _nerve_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("nerve")
+    except Exception:
+        return "unknown"
+
+
+def _git_sha() -> str:
+    """Best-effort git SHA of the installed source checkout."""
+    try:
+        source_root = Path(__file__).resolve().parent.parent
+        if not (source_root / ".git").exists():
+            return ""
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=source_root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def _unique_bundle_path(
+    output_dir: Path, host: str, stamp: str, ext: str,
+) -> Path:
+    """Pick a non-colliding bundle path.
+
+    The second-resolution timestamp can collide when two backups land in the
+    same second (rapid manual runs, tests). Append ``-2``, ``-3``, … until the
+    name (and its ``.tmp`` sibling) is free.
+    """
+    base = f"nerve-backup-{host}-{stamp}"
+    candidate = output_dir / f"{base}.{ext}"
+    n = 2
+    while candidate.exists() or (output_dir / (candidate.name + ".tmp")).exists():
+        candidate = output_dir / f"{base}-{n}.{ext}"
+        n += 1
+    return candidate
+
+
+def _zstd_available() -> bool:
+    try:
+        import zstandard  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _snapshot_db(src: Path, dst: Path) -> None:
+    """Copy a (possibly live, WAL-mode) SQLite DB consistently.
+
+    Uses the online-backup API so writers are never blocked and the copy is
+    transactionally consistent — including any pages still living in the WAL.
+    Verifies the copy with ``PRAGMA integrity_check`` and raises
+    :class:`BackupError` on any inconsistency.
+    """
+    if not src.exists():
+        raise BackupError(f"database not found: {src}")
+
+    source = sqlite3.connect(str(src))
+    try:
+        dest = sqlite3.connect(str(dst))
+        try:
+            # pages>0 copies incrementally, retrying pages dirtied by a
+            # concurrent writer rather than holding a long read lock.
+            source.backup(dest, pages=4096)
+        finally:
+            dest.close()
+    finally:
+        source.close()
+
+    check = sqlite3.connect(str(dst))
+    try:
+        row = check.execute("PRAGMA integrity_check").fetchone()
+    finally:
+        check.close()
+    if not row or row[0] != "ok":
+        raise BackupError(
+            f"integrity_check failed for snapshot of {src.name}: {row!r}"
+        )
+
+
+def _db_schema_version(db_path: Path) -> int:
+    """Read the persisted schema version from a nerve.db (0 if absent)."""
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+        finally:
+            conn.close()
+    except Exception:
+        return 0
+
+
+def _count(db_path: Path, table: str) -> int | None:
+    """COUNT(*) of a table, or None when the DB/table is unavailable."""
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+            return int(row[0]) if row else None
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+
+def _parity_counts(nerve_db: Path, memu_db: Path) -> dict:
+    """Row counts that codify the migration parity-diff UX."""
+    return {
+        "sessions": _count(nerve_db, "sessions"),
+        "messages": _count(nerve_db, "messages"),
+        "tasks": _count(nerve_db, "tasks"),
+        "memu_items": _count(memu_db, "memu_memory_items"),
+    }
+
+
+# --- tar (de)compression context managers ---------------------------------- #
+
+
+@contextmanager
+def _tar_writer(path: Path, compression: str) -> Iterator[tarfile.TarFile]:
+    """Open a streaming tar for writing, zstd or gzip."""
+    if compression == "zstd":
+        import zstandard
+
+        cctx = zstandard.ZstdCompressor(level=10, threads=-1)
+        fh = open(path, "wb")
+        comp = cctx.stream_writer(fh)
+        tar = tarfile.open(mode="w|", fileobj=comp)
+        try:
+            yield tar
+        finally:
+            tar.close()
+            comp.close()  # flush the zstd frame
+            fh.close()
+    else:
+        tar = tarfile.open(path, mode="w:gz")
+        try:
+            yield tar
+        finally:
+            tar.close()
+
+
+@contextmanager
+def _tar_reader(path: Path, compression: str) -> Iterator[tarfile.TarFile]:
+    """Open a streaming tar for reading, zstd or gzip."""
+    if compression == "zstd":
+        import zstandard
+
+        dctx = zstandard.ZstdDecompressor()
+        fh = open(path, "rb")
+        reader = dctx.stream_reader(fh)
+        tar = tarfile.open(mode="r|", fileobj=reader)
+        try:
+            yield tar
+        finally:
+            tar.close()
+            reader.close()
+            fh.close()
+    else:
+        tar = tarfile.open(path, mode="r:gz")
+        try:
+            yield tar
+        finally:
+            tar.close()
+
+
+def _compression_for(path: Path) -> str:
+    """Infer the compression of an existing bundle from its name."""
+    name = path.name
+    if name.endswith(".tar.zst"):
+        return "zstd"
+    if name.endswith(".tar.gz"):
+        return "gzip"
+    raise BackupError(
+        f"unrecognized bundle extension: {path.name} "
+        "(expected .tar.zst or .tar.gz)"
+    )
+
+
+# --- workspace walk -------------------------------------------------------- #
+
+
+def _norm_excludes(extra: list[str] | None) -> list[str]:
+    return [e for e in (extra or []) if e]
+
+
+def _excluded_by_user(rel_posix: str, name: str, globs: list[str]) -> bool:
+    import fnmatch
+
+    for pat in globs:
+        if fnmatch.fnmatch(rel_posix, pat) or fnmatch.fnmatch(name, pat):
+            return True
+    return False
+
+
+def _collect_workspace_files(
+    workspace: Path, extra_excludes: list[str] | None,
+) -> list[tuple[Path, str]]:
+    """Return ``(abs_path, arcname)`` pairs for the workspace BRAIN.
+
+    ``arcname`` is relative to the bundle's ``workspace/`` root. Root-level
+    files matching :data:`WORKSPACE_INCLUDE_FILE_GLOBS` plus the contents of
+    :data:`WORKSPACE_INCLUDE_DIRS` are collected; junk dirs and any
+    ``extra_excludes`` globs are pruned.
+    """
+    import fnmatch
+
+    globs = _norm_excludes(extra_excludes)
+    out: list[tuple[Path, str]] = []
+    if not workspace.exists():
+        return out
+
+    # Root-level markdown (identity + work notes).
+    for entry in sorted(workspace.iterdir()):
+        if not entry.is_file():
+            continue
+        if any(fnmatch.fnmatch(entry.name, g) for g in WORKSPACE_INCLUDE_FILE_GLOBS):
+            if _excluded_by_user(entry.name, entry.name, globs):
+                continue
+            out.append((entry, entry.name))
+
+    # Known directories, walked with junk pruning.
+    for dname in WORKSPACE_INCLUDE_DIRS:
+        droot = workspace / dname
+        if not droot.is_dir():
+            continue
+        for root, dirs, files in os.walk(droot):
+            root_path = Path(root)
+            rel_root = root_path.relative_to(workspace)
+            # Prune junk + user-excluded dirs in place.
+            kept: list[str] = []
+            for d in sorted(dirs):
+                if d in _PRUNE_DIR_NAMES:
+                    continue
+                rel = (rel_root / d).as_posix()
+                if _excluded_by_user(rel, d, globs):
+                    continue
+                kept.append(d)
+            dirs[:] = kept
+            for f in sorted(files):
+                fp = root_path / f
+                if fp.is_symlink() or not fp.is_file():
+                    continue
+                rel = (rel_root / f).as_posix()
+                if _excluded_by_user(rel, f, globs):
+                    continue
+                out.append((fp, rel))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+#  Create                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def create_backup(
+    nerve_dir: Path,
+    workspace: Path,
+    output_dir: Path,
+    *,
+    config_dir: Path | None = None,
+    include_workspace: bool = True,
+    include_secrets: bool = True,
+    state_only: bool = False,
+    workspace_excludes: list[str] | None = None,
+    compression: str | None = None,
+) -> BackupResult:
+    """Create a backup bundle and return a :class:`BackupResult`.
+
+    Synchronous (the scheduled task wraps this in ``asyncio.to_thread``).
+    Staging happens on the *output* filesystem so disk-space failures surface
+    on the target, and the final bundle is renamed into place atomically.
+    """
+    nerve_dir = Path(nerve_dir).expanduser()
+    workspace = Path(workspace).expanduser()
+    output_dir = Path(output_dir).expanduser()
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
+    if not output_dir.is_dir():
+        raise BackupError(f"output dir is not a directory: {output_dir}")
+
+    if state_only:
+        include_workspace = False
+
+    if compression is None:
+        compression = "zstd" if _zstd_available() else "gzip"
+    if compression == "zstd" and not _zstd_available():
+        logger.warning("zstandard unavailable — falling back to gzip")
+        compression = "gzip"
+
+    ext = "tar.zst" if compression == "zstd" else "tar.gz"
+    host = _hostname()
+    stamp = _now_stamp()
+    final_path = _unique_bundle_path(output_dir, host, stamp, ext)
+    final_name = final_path.name
+
+    stage = Path(tempfile.mkdtemp(prefix=".nerve-backup-stage-", dir=output_dir))
+    workspace_bytes = 0
+    try:
+        state_dir = stage / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        # 1. Consistent DB snapshots.
+        for db_name in STATE_DB_FILES:
+            src = nerve_dir / db_name
+            if src.exists():
+                _snapshot_db(src, state_dir / db_name)
+            else:
+                logger.warning("state DB missing, skipping: %s", src)
+
+        # 2. State directories (memU sidecars, cron, certs).
+        for dname in STATE_DIRS:
+            src = nerve_dir / dname
+            if not src.is_dir():
+                continue
+            if not include_secrets and f"state/{dname}" in SECRET_MEMBERS:
+                continue
+            shutil.copytree(src, state_dir / dname, symlinks=True)
+
+        # 3. State files.
+        for fname in STATE_FILES:
+            src = nerve_dir / fname
+            if not src.is_file():
+                continue
+            if not include_secrets and f"state/{fname}" in SECRET_MEMBERS:
+                continue
+            shutil.copy2(src, state_dir / fname)
+
+        # 4. config.local.yaml (secret) → config/.
+        if include_secrets and config_dir is not None:
+            local_cfg = Path(config_dir).expanduser() / "config.local.yaml"
+            if local_cfg.is_file():
+                cfg_dir = stage / "config"
+                cfg_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(local_cfg, cfg_dir / "config.local.yaml")
+
+        # 5. Workspace BRAIN.
+        if include_workspace:
+            ws_files = _collect_workspace_files(workspace, workspace_excludes)
+            ws_root = stage / "workspace"
+            for src, arc in ws_files:
+                dst = ws_root / arc
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+                try:
+                    workspace_bytes += src.stat().st_size
+                except OSError:
+                    pass
+            if workspace_bytes > WORKSPACE_WARN_BYTES:
+                logger.warning(
+                    "workspace payload is %.1f GB — junk exclusion may have "
+                    "missed something (check workspace_excludes)",
+                    workspace_bytes / (1024 ** 3),
+                )
+
+        # 6. Checksums for every staged file (manifest written last).
+        files_meta: dict[str, dict] = {}
+        for p in sorted(stage.rglob("*")):
+            if not p.is_file():
+                continue
+            arc = p.relative_to(stage).as_posix()
+            files_meta[arc] = {"sha256": _sha256(p), "size": p.stat().st_size}
+
+        # 7. Parity counts from the *snapshot* (not the live DB).
+        counts = _parity_counts(
+            state_dir / "nerve.db", state_dir / "memu.sqlite",
+        )
+
+        manifest = {
+            "format_version": FORMAT_VERSION,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "host": host,
+            "nerve_version": _nerve_version(),
+            "git_sha": _git_sha(),
+            "schema_version": _db_schema_version(state_dir / "nerve.db"),
+            "code_schema_version": _code_schema_version(),
+            "compression": compression,
+            "flags": {
+                "include_secrets": include_secrets,
+                "include_workspace": include_workspace,
+                "state_only": state_only,
+            },
+            "nerve_dir": str(nerve_dir),
+            "workspace": str(workspace),
+            "config_dir": str(config_dir) if config_dir else "",
+            "counts": counts,
+            "files": files_meta,
+        }
+        (stage / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8",
+        )
+
+        # 8. Build the tar (manifest first for cheap inspection).
+        tmp_bundle = output_dir / (final_name + ".tmp")
+        if tmp_bundle.exists():
+            tmp_bundle.unlink()
+        with _tar_writer(tmp_bundle, compression) as tar:
+            tar.add(stage / "manifest.json", arcname="manifest.json")
+            for sub in ("config", "state", "workspace"):
+                p = stage / sub
+                if p.exists():
+                    tar.add(p, arcname=sub)
+        os.replace(tmp_bundle, final_path)
+
+        size = final_path.stat().st_size
+        logger.info(
+            "Backup created: %s (%.1f MB, %d files, %s)",
+            final_path, size / (1024 ** 2), len(files_meta), compression,
+        )
+        return BackupResult(
+            path=final_path,
+            size=size,
+            compression=compression,
+            counts=counts,
+            file_count=len(files_meta),
+            include_secrets=include_secrets,
+            include_workspace=include_workspace,
+            workspace_bytes=workspace_bytes,
+        )
+    finally:
+        shutil.rmtree(stage, ignore_errors=True)
+
+
+def _code_schema_version() -> int:
+    """Current migration-head schema version of this codebase."""
+    try:
+        from nerve.db import SCHEMA_VERSION
+
+        return int(SCHEMA_VERSION)
+    except Exception:
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+#  Verify                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _extract_bundle(path: Path, dest: Path) -> dict:
+    """Extract a bundle to ``dest`` and return its manifest dict."""
+    compression = _compression_for(path)
+    with _tar_reader(path, compression) as tar:
+        # ``filter='data'`` (py3.12+) blocks path traversal / absolute paths.
+        try:
+            tar.extractall(dest, filter="data")
+        except TypeError:  # pragma: no cover - older Python without filter
+            tar.extractall(dest)
+    manifest_path = dest / "manifest.json"
+    if not manifest_path.is_file():
+        raise BackupError("bundle is missing manifest.json")
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise BackupError(f"corrupt manifest.json: {e}") from e
+
+
+def verify_bundle(path: Path, extract_to: Path | None = None) -> VerifyReport:
+    """Verify a bundle's integrity without installing it.
+
+    Extracts (to ``extract_to`` or a temp dir), checks every file's sha256
+    against the manifest, runs ``PRAGMA integrity_check`` on both DBs, and
+    guards the schema version. Returns a :class:`VerifyReport`; never raises
+    for *verification* failures (only for an unreadable/corrupt bundle).
+    """
+    path = Path(path).expanduser()
+    if not path.is_file():
+        raise BackupError(f"bundle not found: {path}")
+
+    own_tmp = extract_to is None
+    work = Path(extract_to) if extract_to else Path(
+        tempfile.mkdtemp(prefix=".nerve-verify-")
+    )
+    errors: list[str] = []
+    warnings: list[str] = []
+    manifest: dict = {}
+    counts: dict = {}
+    try:
+        manifest = _extract_bundle(path, work)
+        counts = manifest.get("counts", {}) or {}
+
+        # Checksums.
+        files_meta = manifest.get("files", {}) or {}
+        for arc, meta in files_meta.items():
+            fp = work / arc
+            if not fp.is_file():
+                errors.append(f"missing file in bundle: {arc}")
+                continue
+            actual = _sha256(fp)
+            if actual != meta.get("sha256"):
+                errors.append(f"checksum mismatch: {arc}")
+
+        # DB integrity.
+        for db_name in STATE_DB_FILES:
+            fp = work / "state" / db_name
+            if not fp.is_file():
+                # memu.sqlite may legitimately be absent only on a broken box;
+                # treat a missing nerve.db as an error, memu as a warning.
+                (errors if db_name == "nerve.db" else warnings).append(
+                    f"{db_name} not present in bundle"
+                )
+                continue
+            try:
+                conn = sqlite3.connect(str(fp))
+                try:
+                    row = conn.execute("PRAGMA integrity_check").fetchone()
+                finally:
+                    conn.close()
+                if not row or row[0] != "ok":
+                    errors.append(f"integrity_check failed: {db_name} ({row!r})")
+            except Exception as e:
+                errors.append(f"cannot open {db_name}: {e}")
+
+        # Schema guard — restoring a newer-schema bundle onto older code
+        # would break at startup; flag it here.
+        bundle_schema = int(manifest.get("schema_version", 0) or 0)
+        code_schema = _code_schema_version()
+        if bundle_schema > code_schema:
+            errors.append(
+                f"bundle schema v{bundle_schema} is newer than this code "
+                f"(v{code_schema}) — upgrade Nerve before restoring"
+            )
+
+        ok = not errors
+        return VerifyReport(
+            ok=ok, manifest=manifest, counts=counts,
+            errors=errors, warnings=warnings,
+        )
+    finally:
+        if own_tmp:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+#  Restore                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _pid_is_alive(pid_file: Path) -> int | None:
+    """Return the live PID if the daemon is running, else None."""
+    try:
+        pid = int(pid_file.read_text().strip())
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+    try:
+        os.kill(pid, 0)
+        return pid
+    except ProcessLookupError:
+        return None
+    except PermissionError:
+        return pid  # exists but not ours to signal
+
+
+def _dir_nonempty(d: Path) -> bool:
+    try:
+        return d.is_dir() and any(d.iterdir())
+    except OSError:
+        return False
+
+
+def restore_bundle(
+    path: Path,
+    nerve_dir: Path,
+    workspace: Path,
+    *,
+    config_dir: Path | None = None,
+    force: bool = False,
+) -> VerifyReport:
+    """Restore a bundle into ``nerve_dir`` + ``workspace``.
+
+    Safety rails:
+
+    - **Refuses while the daemon is alive** (no override — stop it first).
+      Restoring under a running process would corrupt the live WAL DBs.
+    - **Refuses to overwrite a non-empty** ``nerve_dir`` without ``force``.
+      With ``force`` the existing dir is *relocated* to
+      ``<nerve_dir>.pre-restore-<ts>`` (trash over rm), never deleted.
+    - **Verifies before installing** — a bundle that fails verification is
+      never unpacked into place.
+
+    Returns the :class:`VerifyReport` produced during the install.
+    """
+    path = Path(path).expanduser()
+    nerve_dir = Path(nerve_dir).expanduser()
+    workspace = Path(workspace).expanduser()
+
+    pid_file = nerve_dir / "nerve.pid"
+    live = _pid_is_alive(pid_file)
+    if live is not None:
+        raise BackupError(
+            f"Nerve daemon appears to be running (PID {live}). "
+            "Stop it first ('nerve stop') — restore will not run against a "
+            "live process."
+        )
+
+    if _dir_nonempty(nerve_dir) and not force:
+        raise BackupError(
+            f"{nerve_dir} is not empty. Re-run with --force to relocate the "
+            f"existing state to {nerve_dir}.pre-restore-<ts> and restore."
+        )
+
+    # Verify into a staging dir we then install from (extract once).
+    staging = Path(tempfile.mkdtemp(prefix=".nerve-restore-"))
+    try:
+        report = verify_bundle(path, extract_to=staging)
+        if not report.ok:
+            raise BackupError(
+                "bundle failed verification; refusing to restore:\n  - "
+                + "\n  - ".join(report.errors)
+            )
+
+        # Relocate the old state dir if forcing over a non-empty target.
+        if _dir_nonempty(nerve_dir):
+            relocated = nerve_dir.with_name(
+                nerve_dir.name + f".pre-restore-{_now_stamp()}"
+            )
+            os.replace(nerve_dir, relocated)
+            logger.info("Relocated existing state dir to %s", relocated)
+        nerve_dir.mkdir(parents=True, exist_ok=True)
+
+        # Install state/.
+        staged_state = staging / "state"
+        if staged_state.is_dir():
+            for entry in sorted(staged_state.iterdir()):
+                dst = nerve_dir / entry.name
+                if entry.is_dir():
+                    shutil.copytree(entry, dst, symlinks=True, dirs_exist_ok=True)
+                else:
+                    shutil.copy2(entry, dst)
+
+        # Re-tighten secret file modes.
+        for secret in _SECRET_RESTORE_PATHS:
+            sp = nerve_dir / secret
+            if sp.is_file():
+                try:
+                    os.chmod(sp, SECRET_FILE_MODE)
+                except OSError:
+                    pass
+        certs_dir = nerve_dir / "certs"
+        if certs_dir.is_dir():
+            for f in certs_dir.rglob("*"):
+                if f.is_file():
+                    try:
+                        os.chmod(f, SECRET_FILE_MODE)
+                    except OSError:
+                        pass
+
+        # Install config.local.yaml next to where the pointer says config lives.
+        staged_cfg = staging / "config" / "config.local.yaml"
+        if staged_cfg.is_file():
+            dest_cfg_dir = _resolve_restore_config_dir(
+                config_dir, nerve_dir, staging,
+            )
+            try:
+                dest_cfg_dir.mkdir(parents=True, exist_ok=True)
+                dest = dest_cfg_dir / "config.local.yaml"
+                shutil.copy2(staged_cfg, dest)
+                os.chmod(dest, SECRET_FILE_MODE)
+                logger.info("Restored config.local.yaml to %s", dest)
+            except OSError as e:
+                logger.warning("Could not restore config.local.yaml: %s", e)
+
+        # Install workspace BRAIN (overlay; never relocates the workspace).
+        staged_ws = staging / "workspace"
+        if staged_ws.is_dir():
+            workspace.mkdir(parents=True, exist_ok=True)
+            for src in sorted(staged_ws.rglob("*")):
+                if not src.is_file():
+                    continue
+                rel = src.relative_to(staged_ws)
+                dst = workspace / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+
+        logger.info("Restore complete: %s → %s", path.name, nerve_dir)
+        return report
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def _resolve_restore_config_dir(
+    config_dir: Path | None, nerve_dir: Path, staging: Path,
+) -> Path:
+    """Decide where config.local.yaml should land on restore.
+
+    Priority: an explicit ``config_dir`` arg, then the restored
+    ``state/config_dir`` pointer (the original install location), then
+    ``nerve_dir`` itself as a safe fallback.
+    """
+    if config_dir is not None:
+        return Path(config_dir).expanduser()
+    pointer = staging / "state" / "config_dir"
+    if pointer.is_file():
+        try:
+            raw = pointer.read_text(encoding="utf-8").strip()
+            if raw:
+                return Path(raw).expanduser()
+        except OSError:
+            pass
+    return nerve_dir
+
+
+# --------------------------------------------------------------------------- #
+#  Retention                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def list_bundles(target_dir: Path) -> list[Path]:
+    """Return existing bundles in ``target_dir``, newest first."""
+    target_dir = Path(target_dir).expanduser()
+    if not target_dir.is_dir():
+        return []
+    bundles = [
+        p for p in target_dir.iterdir()
+        if p.is_file() and BUNDLE_RE.match(p.name)
+    ]
+    bundles.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return bundles
+
+
+def prune(target_dir: Path, keep_n: int) -> list[Path]:
+    """Delete all but the newest ``keep_n`` bundles. Returns deleted paths.
+
+    Only ever touches files whose name matches :data:`BUNDLE_RE`, so an
+    unrelated file sharing the directory is never at risk.
+    """
+    if keep_n < 0:
+        return []
+    bundles = list_bundles(target_dir)
+    to_delete = bundles[keep_n:]
+    deleted: list[Path] = []
+    for p in to_delete:
+        try:
+            p.unlink()
+            deleted.append(p)
+        except OSError as e:
+            logger.warning("Could not prune %s: %s", p, e)
+    if deleted:
+        logger.info("Pruned %d old backup(s) in %s", len(deleted), target_dir)
+    return deleted
+
+
+def latest_bundle_age_seconds(target_dir: Path) -> float | None:
+    """Age (seconds) of the newest bundle, or None if there are none."""
+    bundles = list_bundles(target_dir)
+    if not bundles:
+        return None
+    import time
+
+    return time.time() - bundles[0].stat().st_mtime

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -917,6 +917,49 @@ def doctor_report(config, config_source: str = "", check_api: bool = False) -> s
         if config.cron.jobs_file.exists():
             lines.append(f"[OK] User crons: {config.cron.jobs_file}")
 
+    # Check backups
+    backup_cfg = getattr(config, "backup", None)
+    if backup_cfg is not None and backup_cfg.enabled:
+        if not backup_cfg.target_dir:
+            warnings.append(
+                "[WARN] backup.enabled is true but backup.target_dir is empty "
+                "— no backups will run"
+            )
+        else:
+            try:
+                from nerve import backup as _backup_mod
+
+                target = Path(backup_cfg.target_dir).expanduser()
+                age = _backup_mod.latest_bundle_age_seconds(target)
+                kept = len(_backup_mod.list_bundles(target))
+                stale_after = 2 * max(1, backup_cfg.interval_hours) * 3600
+                if age is None:
+                    warnings.append(
+                        f"[WARN] Backups enabled but none found in {target}"
+                    )
+                else:
+                    age_h = age / 3600
+                    age_str = (
+                        f"{age_h:.1f}h" if age_h < 48 else f"{age_h / 24:.1f}d"
+                    )
+                    if age > stale_after:
+                        warnings.append(
+                            f"[WARN] Last backup is {age_str} old "
+                            f"(> 2× interval of {backup_cfg.interval_hours}h) "
+                            f"— check the scheduled job ({target})"
+                        )
+                    else:
+                        lines.append(
+                            f"[OK] Backups: last {age_str} ago, {kept} kept in {target}"
+                        )
+            except Exception as e:
+                warnings.append(f"[WARN] Backup check failed: {e}")
+    else:
+        lines.append(
+            "[--] Backups not configured — set backup.target_dir + enabled to "
+            "protect ~/.nerve against disk loss"
+        )
+
     # Check external tools
     import shutil
     for tool_name in ["gog", "gh"]:
@@ -1141,6 +1184,144 @@ def cron(ctx: click.Context, job_id: str) -> None:
             await close_db()
 
     asyncio.run(_run())
+
+
+@main.command()
+@click.option("--output", "-o", default=None, help="Target directory (default: backup.target_dir from config)")
+@click.option("--state-only", is_flag=True, help="Back up ~/.nerve state only (skip workspace BRAIN)")
+@click.option("--no-secrets", is_flag=True, help="Omit secrets (mcp-token, telegram session, certs, config.local.yaml)")
+@click.option("--quiet", "-q", is_flag=True, help="Only print errors")
+@click.pass_context
+def backup(ctx: click.Context, output: str | None, state_only: bool, no_secrets: bool, quiet: bool) -> None:
+    """Create a portable backup bundle of Nerve state.
+
+    Snapshots the SQLite DBs (consistent even while Nerve runs), the memU
+    sidecars, secrets, cron jobs, and the workspace BRAIN into a single
+    ``nerve-backup-<host>-<ts>.tar.zst`` file. Works without a running server.
+    """
+    from nerve import backup as backup_mod
+
+    config = ctx.obj["config"]
+    config_dir = Path(ctx.obj["config_dir"])
+
+    target = output or config.backup.target_dir
+    if not target:
+        raise click.ClickException(
+            "No target directory. Pass --output DIR, or set backup.target_dir "
+            "in config.yaml (an external mount or synced dir is recommended)."
+        )
+
+    nerve_dir = PID_DIR
+    include_workspace = config.backup.include_workspace and not state_only
+
+    if not quiet:
+        click.echo(f"Backing up to {target} ...")
+    try:
+        result = backup_mod.create_backup(
+            nerve_dir=nerve_dir,
+            workspace=config.workspace,
+            output_dir=Path(target).expanduser(),
+            config_dir=config_dir,
+            include_workspace=include_workspace,
+            include_secrets=not no_secrets,
+            state_only=state_only,
+            workspace_excludes=config.backup.workspace_excludes,
+        )
+    except backup_mod.BackupError as e:
+        raise click.ClickException(str(e))
+
+    if not quiet:
+        c = result.counts
+        click.echo(f"  Bundle:   {result.path}")
+        click.echo(f"  Size:     {result.size / (1024 ** 2):.1f} MB ({result.compression})")
+        click.echo(f"  Files:    {result.file_count}")
+        click.echo(
+            f"  Parity:   sessions={c.get('sessions')}, messages={c.get('messages')}, "
+            f"tasks={c.get('tasks')}, memU={c.get('memu_items')}"
+        )
+        if not result.include_secrets:
+            click.echo("  Secrets:  OMITTED (--no-secrets) — re-provision on restore")
+        if not result.include_workspace:
+            click.echo("  Workspace: skipped (state-only)")
+
+    # Apply retention when writing to the configured target.
+    if config.backup.retention_count and target == config.backup.target_dir:
+        deleted = backup_mod.prune(Path(target).expanduser(), config.backup.retention_count)
+        if deleted and not quiet:
+            click.echo(f"  Pruned:   {len(deleted)} old bundle(s) (keep {config.backup.retention_count})")
+
+
+@main.command()
+@click.argument("bundle")
+@click.option("--verify-only", is_flag=True, help="Check integrity without installing")
+@click.option("--force", is_flag=True, help="Relocate a non-empty ~/.nerve and restore over it")
+@click.pass_context
+def restore(ctx: click.Context, bundle: str, verify_only: bool, force: bool) -> None:
+    """Verify and restore a backup bundle.
+
+    Refuses to run against a live daemon (stop it first) and refuses to
+    overwrite a non-empty ~/.nerve without --force (which relocates the old
+    dir to ~/.nerve.pre-restore-<ts> rather than deleting it).
+    """
+    from nerve import backup as backup_mod
+
+    config = ctx.obj["config"]
+    bundle_path = Path(bundle).expanduser()
+    if not bundle_path.is_file():
+        raise click.ClickException(f"Bundle not found: {bundle_path}")
+
+    nerve_dir = PID_DIR
+
+    if verify_only:
+        try:
+            report = backup_mod.verify_bundle(bundle_path)
+        except backup_mod.BackupError as e:
+            raise click.ClickException(str(e))
+        m = report.manifest
+        click.echo(f"Bundle:   {bundle_path.name}")
+        click.echo(f"Created:  {m.get('created_at', '?')} on {m.get('host', '?')}")
+        click.echo(f"Nerve:    v{m.get('nerve_version', '?')} (schema v{m.get('schema_version', '?')}, git {m.get('git_sha', '')[:8] or '?'})")
+        click.echo(f"Parity:   {report.summary()}")
+        flags = m.get("flags", {})
+        click.echo(f"Flags:    secrets={flags.get('include_secrets')}, workspace={flags.get('include_workspace')}")
+        for w in report.warnings:
+            click.echo(f"  [WARN] {w}")
+        if report.ok:
+            click.echo("\n[OK] Bundle verified — safe to restore.")
+        else:
+            for e in report.errors:
+                click.echo(f"  [ERR] {e}")
+            click.echo(f"\n{len(report.errors)} error(s) — restore would be refused.")
+            ctx.exit(1)
+        return
+
+    # Only override the bundle's recorded config path when this box actually
+    # has a resolved config (otherwise let the bundle pointer decide — a
+    # faithful disaster-recovery restore).
+    cfg_dir = None
+    if ctx.obj.get("config_source") not in (None, "", "default"):
+        cfg_dir = Path(ctx.obj["config_dir"])
+
+    click.echo(f"Restoring {bundle_path.name} → {nerve_dir} ...")
+    try:
+        report = backup_mod.restore_bundle(
+            bundle_path,
+            nerve_dir=nerve_dir,
+            workspace=config.workspace,
+            config_dir=cfg_dir,
+            force=force,
+        )
+    except backup_mod.BackupError as e:
+        raise click.ClickException(str(e))
+
+    click.echo(f"  Parity:   {report.summary()}")
+    flags = report.manifest.get("flags", {})
+    if not flags.get("include_secrets", True):
+        click.echo(
+            "  [WARN] This bundle had NO secrets — re-provision mcp-token, the "
+            "Telegram session, certs, and config.local.yaml before starting."
+        )
+    click.echo("\nRestore complete. Run 'nerve doctor' to verify, then 'nerve start'.")
 
 
 @main.command("migrate-openclaw")

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -479,6 +479,40 @@ class CronConfig:
 
 
 @dataclass
+class BackupConfig:
+    """Scheduled backup of Nerve state to a local directory.
+
+    Opt-in: set ``target_dir`` to an external mount or a synced directory
+    (the off-box copy is what protects against a disk failure) and flip
+    ``enabled`` on. A bundle is a single ``nerve-backup-<host>-<ts>.tar.zst``
+    file produced by :mod:`nerve.backup`. The scheduled task notifies on
+    failure (silent backups that fail are worse than none).
+    """
+
+    enabled: bool = False            # opt-in; set target_dir first
+    target_dir: str = ""             # e.g. /mnt/backup/nerve or a synced dir
+    interval_hours: int = 24
+    retention_count: int = 7
+    include_workspace: bool = True
+    workspace_excludes: list[str] = field(default_factory=list)  # extra globs
+    notify_on_failure: bool = True   # high-priority notify
+    notify_on_success: bool = False  # low-priority digest line
+
+    @classmethod
+    def from_dict(cls, d: dict) -> BackupConfig:
+        return cls(
+            enabled=bool(d.get("enabled", False)),
+            target_dir=d.get("target_dir", ""),
+            interval_hours=int(d.get("interval_hours", 24)),
+            retention_count=int(d.get("retention_count", 7)),
+            include_workspace=bool(d.get("include_workspace", True)),
+            workspace_excludes=list(d.get("workspace_excludes", []) or []),
+            notify_on_failure=bool(d.get("notify_on_failure", True)),
+            notify_on_success=bool(d.get("notify_on_success", False)),
+        )
+
+
+@dataclass
 class SessionsConfig:
     archive_after_days: int = 30
     max_sessions: int = 500
@@ -921,6 +955,7 @@ class NerveConfig:
     sync: SyncConfig = field(default_factory=SyncConfig)
     memory: MemoryConfig = field(default_factory=MemoryConfig)
     cron: CronConfig = field(default_factory=CronConfig)
+    backup: BackupConfig = field(default_factory=BackupConfig)
     sessions: SessionsConfig = field(default_factory=SessionsConfig)
     auth: AuthConfig = field(default_factory=AuthConfig)
     channels: ChannelsConfig = field(default_factory=ChannelsConfig)
@@ -1036,6 +1071,7 @@ class NerveConfig:
             sync=SyncConfig.from_dict(d.get("sync", {})),
             memory=MemoryConfig.from_dict(d.get("memory", {})),
             cron=CronConfig.from_dict(d.get("cron", {})),
+            backup=BackupConfig.from_dict(d.get("backup", {})),
             sessions=SessionsConfig.from_dict(d.get("sessions", {})),
             auth=AuthConfig.from_dict(d.get("auth", {})),
             channels=ChannelsConfig.from_dict(d.get("channels", {})),

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -262,6 +262,76 @@ async def lifespan(app: FastAPI):
 
     notify_expiry_task = asyncio.create_task(_periodic_notify_expiry())
 
+    # Periodic backup (opt-in). Hourly tick; runs a bundle when the newest
+    # one in the target dir is older than interval_hours (or none exists).
+    # The heavy work (consistent DB snapshots + tar) runs in a thread so it
+    # never blocks the event loop. Failures notify high-priority — a backup
+    # that fails silently is worse than no backup at all.
+    async def _periodic_backup():
+        from nerve import backup as backup_mod
+
+        bcfg = config.backup
+        nerve_dir = Path("~/.nerve").expanduser()
+        interval_s = max(1, bcfg.interval_hours) * 3600
+        target = Path(bcfg.target_dir).expanduser() if bcfg.target_dir else None
+        while True:
+            await asyncio.sleep(3600)  # hourly tick
+            if not bcfg.enabled or target is None:
+                continue
+            try:
+                age = await asyncio.to_thread(
+                    backup_mod.latest_bundle_age_seconds, target,
+                )
+                if age is not None and age < interval_s:
+                    continue  # not due yet
+
+                result = await asyncio.to_thread(
+                    backup_mod.create_backup,
+                    nerve_dir,
+                    config.workspace,
+                    target,
+                    config_dir=config.config_dir,
+                    include_workspace=bcfg.include_workspace,
+                    include_secrets=True,
+                    workspace_excludes=bcfg.workspace_excludes,
+                )
+                deleted = await asyncio.to_thread(
+                    backup_mod.prune, target, bcfg.retention_count,
+                )
+                size_str = (
+                    f"{result.size / (1024 ** 3):.1f} GB"
+                    if result.size >= 1024 ** 3
+                    else f"{result.size / (1024 ** 2):.0f} MB"
+                )
+                logger.info(
+                    "Scheduled backup OK: %s (%s, pruned %d)",
+                    result.path.name, size_str, len(deleted),
+                )
+                if bcfg.notify_on_success:
+                    await notification_service.send_notification(
+                        session_id="system",
+                        title="💾 Backup OK",
+                        body=(
+                            f"{size_str}, {len(backup_mod.list_bundles(target))} "
+                            f"kept ({result.file_count} files)"
+                        ),
+                        priority="low",
+                    )
+            except Exception as e:
+                logger.error("Scheduled backup failed: %s", e, exc_info=True)
+                if bcfg.notify_on_failure:
+                    try:
+                        await notification_service.send_notification(
+                            session_id="system",
+                            title="⚠️ Nerve backup FAILED",
+                            body=f"{e}\n\nTarget: {target}",
+                            priority="high",
+                        )
+                    except Exception as ne:
+                        logger.error("Backup failure notify failed: %s", ne)
+
+    backup_task = asyncio.create_task(_periodic_backup())
+
     # Start the external-agents sync service. It re-renders
     # ~/.codex/AGENTS.md, ~/.claude/CLAUDE.md, etc. from the workspace
     # identity files on a timer (config.external_agents.sync_interval_minutes).
@@ -371,6 +441,7 @@ async def lifespan(app: FastAPI):
         await cron_task.stop()
 
     notify_expiry_task.cancel()
+    backup_task.cancel()
     idle_sweep_task.cancel()
     memorize_task.cancel()
     cleanup_task.cancel()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,443 @@
+"""Tests for nerve.backup — consistent snapshots, bundle round-trip, restore.
+
+The databases run in WAL mode, so the snapshot must stay consistent under a
+concurrent writer; restore must be verified and refuse to clobber a live or
+non-empty target. These tests exercise the whole bundle lifecycle without a
+running server (the CLI and lifespan task are thin wrappers over this module).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from nerve import backup as backup_mod
+from nerve.backup import BackupError
+from nerve.db import SCHEMA_VERSION
+
+
+# --------------------------------------------------------------------------- #
+#  Fixtures / helpers                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def _make_nerve_db(path: Path, *, schema_version: int = SCHEMA_VERSION,
+                   sessions: int = 7, messages: int = 11, tasks: int = 3) -> None:
+    """Create a WAL-mode nerve.db with the tables the parity counts read."""
+    for suffix in ("", "-wal", "-shm"):
+        p = Path(str(path) + suffix)
+        if p.exists():
+            p.unlink()
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE schema_version (version INTEGER)")
+        conn.execute("INSERT INTO schema_version VALUES (?)", (schema_version,))
+        conn.execute("CREATE TABLE sessions (id TEXT)")
+        conn.execute("CREATE TABLE messages (id TEXT)")
+        conn.execute("CREATE TABLE tasks (id TEXT)")
+        conn.executemany("INSERT INTO sessions VALUES (?)",
+                         [(str(i),) for i in range(sessions)])
+        conn.executemany("INSERT INTO messages VALUES (?)",
+                         [(str(i),) for i in range(messages)])
+        conn.executemany("INSERT INTO tasks VALUES (?)",
+                         [(str(i),) for i in range(tasks)])
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_memu_db(path: Path, *, items: int = 5) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE memu_memory_items (id TEXT)")
+        conn.executemany("INSERT INTO memu_memory_items VALUES (?)",
+                         [(str(i),) for i in range(items)])
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def nerve_dir(tmp_path: Path) -> Path:
+    """A populated ~/.nerve replica, with secrets, state, and junk."""
+    nd = tmp_path / "dot_nerve"
+    nd.mkdir()
+    _make_nerve_db(nd / "nerve.db")
+    _make_memu_db(nd / "memu.sqlite")
+
+    # Secrets + state.
+    (nd / "mcp-token").write_text("super-secret-token")
+    os.chmod(nd / "mcp-token", 0o600)
+    (nd / "telegram_sync.session").write_text("tg-session-blob")
+    (nd / "config_dir").write_text(str(tmp_path / "cfg"))
+    (nd / "cron").mkdir()
+    (nd / "cron" / "jobs.yaml").write_text("jobs: []\n")
+    (nd / "certs").mkdir()
+    (nd / "certs" / "key.pem").write_text("PRIVATE-KEY")
+    (nd / "memu-conversations").mkdir()
+    (nd / "memu-conversations" / "c1.json").write_text("[]")
+    (nd / "memu-manual").mkdir()
+    (nd / "memu-resources").mkdir()
+
+    # Junk that must NEVER be backed up.
+    (nd / "nerve.log").write_text("x" * 5000)
+    (nd / "nerve.pid").write_text("424242")
+    (nd / "bin").mkdir()
+    (nd / "bin" / "cli-proxy-api").write_text("BINARY-BLOB")
+    (nd / "memu.backup.sqlite").write_text("STALE-BACKUP")
+    (nd / "nerve.db-wal").write_text("WAL-SIDECAR")
+    return nd
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    (cfg / "config.local.yaml").write_text("anthropic_api_key: sk-secret\n")
+    (cfg / "config.yaml").write_text("workspace: ~/ws\n")
+    return cfg
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """A workspace with BRAIN files and a lot of junk to exclude."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    # BRAIN
+    (ws / "SOUL.md").write_text("soul")
+    (ws / "MEMORY.md").write_text("memory")
+    (ws / "memory").mkdir()
+    (ws / "memory" / "people.md").write_text("people")
+    (ws / "memory" / "tasks").mkdir()
+    (ws / "memory" / "tasks" / "active").mkdir()
+    (ws / "memory" / "tasks" / "active" / "t1.md").write_text("task one")
+    (ws / "skills").mkdir()
+    (ws / "skills" / "s1").mkdir()
+    (ws / "skills" / "s1" / "SKILL.md").write_text("skill body")
+    (ws / "scripts").mkdir()
+    (ws / "scripts" / "helper.py").write_text("print('hi')")
+
+    # Junk inside included dirs (must be pruned).
+    (ws / "memory" / ".git").mkdir()
+    (ws / "memory" / ".git" / "config").write_text("gitjunk")
+    (ws / "skills" / "node_modules").mkdir()
+    (ws / "skills" / "node_modules" / "dep.js").write_text("nodejunk")
+    (ws / "scripts" / "__pycache__").mkdir()
+    (ws / "scripts" / "__pycache__" / "helper.pyc").write_text("pycjunk")
+
+    # Junk outside the include set (whole dirs ignored — not in the allowlist).
+    (ws / "big-repo").mkdir()
+    (ws / "big-repo" / "huge.bin").write_text("X" * 10000)
+    (ws / "another-repo").mkdir()
+    (ws / "another-repo" / "build.bin").write_text("Y" * 10000)
+    return ws
+
+
+def _bundle_members(path: Path) -> list[str]:
+    comp = backup_mod._compression_for(path)
+    with backup_mod._tar_reader(path, comp) as tar:
+        return [m.name for m in tar]
+
+
+# --------------------------------------------------------------------------- #
+#  1. Consistent snapshot under a concurrent writer                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_snapshot_consistent_with_concurrent_writer(tmp_path: Path):
+    src = tmp_path / "nerve.db"
+    _make_nerve_db(src, sessions=0, messages=10, tasks=0)
+
+    stop = threading.Event()
+
+    def writer():
+        w = sqlite3.connect(str(src))
+        i = 1000
+        while not stop.is_set():
+            try:
+                w.execute("INSERT INTO messages VALUES (?)", (str(i),))
+                w.commit()
+                i += 1
+            except sqlite3.OperationalError:
+                pass
+            time.sleep(0.001)
+        w.close()
+
+    t = threading.Thread(target=writer)
+    t.start()
+    try:
+        dst = tmp_path / "snap.db"
+        # Should not raise (integrity_check passes inside _snapshot_db).
+        backup_mod._snapshot_db(src, dst)
+    finally:
+        stop.set()
+        t.join()
+
+    conn = sqlite3.connect(str(dst))
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    finally:
+        conn.close()
+    # The snapshot captured a consistent point in time; at least the initial
+    # rows are present (more if the writer got ahead before the copy).
+    assert count >= 10
+
+
+# --------------------------------------------------------------------------- #
+#  2. Round-trip: backup → verify → restore                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_backup_verify_restore_roundtrip(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(
+        nerve_dir, workspace, out, config_dir=config_dir,
+    )
+    assert result.path.exists()
+    assert backup_mod.BUNDLE_RE.match(result.path.name)
+    assert result.counts == {
+        "sessions": 7, "messages": 11, "tasks": 3, "memu_items": 5,
+    }
+
+    report = backup_mod.verify_bundle(result.path)
+    assert report.ok, report.errors
+    assert report.counts["sessions"] == 7
+
+    # Restore into fresh dirs.
+    nd2 = tmp_path / "restored_nerve"
+    ws2 = tmp_path / "restored_ws"
+    cfg2 = tmp_path / "restored_cfg"
+    rep = backup_mod.restore_bundle(
+        result.path, nd2, ws2, config_dir=cfg2,
+    )
+    assert rep.ok
+
+    # DB row counts survive.
+    conn = sqlite3.connect(str(nd2 / "nerve.db"))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 7
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 11
+    finally:
+        conn.close()
+
+    # Secrets restored with 0600 mode.
+    assert (nd2 / "mcp-token").read_text() == "super-secret-token"
+    assert (os.stat(nd2 / "mcp-token").st_mode & 0o777) == 0o600
+    assert (os.stat(nd2 / "certs" / "key.pem").st_mode & 0o777) == 0o600
+
+    # config.local.yaml restored to the explicit config dir.
+    assert (cfg2 / "config.local.yaml").read_text() == "anthropic_api_key: sk-secret\n"
+
+    # Workspace BRAIN restored.
+    assert (ws2 / "SOUL.md").read_text() == "soul"
+    assert (ws2 / "memory" / "tasks" / "active" / "t1.md").exists()
+    assert (ws2 / "skills" / "s1" / "SKILL.md").exists()
+
+
+def test_backup_excludes_junk(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(nerve_dir, workspace, out, config_dir=config_dir)
+    members = _bundle_members(result.path)
+    joined = "\n".join(members)
+
+    # State junk excluded.
+    assert "nerve.log" not in joined
+    assert "nerve.pid" not in joined
+    assert "/bin/" not in joined and not joined.endswith("/bin")
+    assert "memu.backup" not in joined
+    assert "db-wal" not in joined
+
+    # Workspace junk excluded (dirs outside the BRAIN allowlist).
+    assert "big-repo" not in joined
+    assert "another-repo" not in joined
+    assert "node_modules" not in joined
+    assert "__pycache__" not in joined
+    assert "/.git/" not in joined
+
+    # BRAIN included.
+    assert any(m.endswith("workspace/SOUL.md") for m in members)
+    assert any(m.endswith("workspace/skills/s1/SKILL.md") for m in members)
+    assert any(m.endswith("workspace/scripts/helper.py") for m in members)
+
+
+def test_workspace_extra_excludes(nerve_dir, workspace, config_dir, tmp_path):
+    # Plant a file the user wants excluded via config glob.
+    (workspace / "memory" / "diagram.png").write_text("PNG")
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(
+        nerve_dir, workspace, out, config_dir=config_dir,
+        workspace_excludes=["*.png"],
+    )
+    members = _bundle_members(result.path)
+    assert not any(m.endswith("diagram.png") for m in members)
+    assert any(m.endswith("memory/people.md") for m in members)
+
+
+# --------------------------------------------------------------------------- #
+#  3. --no-secrets / --state-only                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_no_secrets_omits_and_flags(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(
+        nerve_dir, workspace, out, config_dir=config_dir, include_secrets=False,
+    )
+    members = _bundle_members(result.path)
+    joined = "\n".join(members)
+    assert not any(m.endswith("mcp-token") for m in members)
+    assert "telegram_sync.session" not in joined
+    assert "certs" not in joined
+    assert "config.local.yaml" not in joined
+
+    report = backup_mod.verify_bundle(result.path)
+    assert report.manifest["flags"]["include_secrets"] is False
+    # Non-secret state still present.
+    assert any(m.endswith("state/cron/jobs.yaml") for m in members)
+
+
+def test_state_only_skips_workspace(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(
+        nerve_dir, workspace, out, config_dir=config_dir, state_only=True,
+    )
+    members = _bundle_members(result.path)
+    assert not any("workspace/" in m for m in members)
+    assert result.include_workspace is False
+    assert any(m.endswith("state/nerve.db") for m in members)
+
+
+# --------------------------------------------------------------------------- #
+#  4. Retention + restore safety rails                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_prune_only_matching_files(nerve_dir, workspace, tmp_path):
+    out = tmp_path / "out"
+    out.mkdir()
+    # Create several real bundles.
+    for _ in range(5):
+        backup_mod.create_backup(nerve_dir, workspace, out, state_only=True)
+    assert len(backup_mod.list_bundles(out)) == 5
+
+    # Decoys that must survive.
+    (out / "unrelated.txt").write_text("keep me")
+    (out / "nerve-backup-notes.md").write_text("not a bundle")
+    (out / "README").write_text("keep")
+
+    deleted = backup_mod.prune(out, keep_n=2)
+    assert len(deleted) == 3
+    assert len(backup_mod.list_bundles(out)) == 2
+    assert (out / "unrelated.txt").exists()
+    assert (out / "nerve-backup-notes.md").exists()
+    assert (out / "README").exists()
+    # Everything deleted was a real bundle.
+    assert all(backup_mod.BUNDLE_RE.match(p.name) for p in deleted)
+
+
+def test_restore_refuses_on_live_pidfile(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(nerve_dir, workspace, out, config_dir=config_dir)
+
+    target = tmp_path / "live_nerve"
+    target.mkdir()
+    # A pidfile pointing at THIS process (definitely alive).
+    (target / "nerve.pid").write_text(str(os.getpid()))
+
+    with pytest.raises(BackupError, match="running"):
+        backup_mod.restore_bundle(result.path, target, tmp_path / "ws_x")
+
+
+def test_restore_refuses_nonempty_without_force(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(nerve_dir, workspace, out, config_dir=config_dir)
+
+    target = tmp_path / "occupied"
+    target.mkdir()
+    (target / "existing.txt").write_text("data")
+
+    with pytest.raises(BackupError, match="not empty"):
+        backup_mod.restore_bundle(result.path, target, tmp_path / "ws_y")
+
+
+def test_restore_force_relocates_old_dir(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(nerve_dir, workspace, out, config_dir=config_dir)
+
+    target = tmp_path / "occupied"
+    target.mkdir()
+    (target / "old_marker.txt").write_text("previous state")
+
+    backup_mod.restore_bundle(
+        result.path, target, tmp_path / "ws_z", force=True,
+    )
+    # Old dir relocated, not deleted.
+    relocated = list(tmp_path.glob("occupied.pre-restore-*"))
+    assert len(relocated) == 1
+    assert (relocated[0] / "old_marker.txt").read_text() == "previous state"
+    # New state installed.
+    assert (target / "nerve.db").exists()
+    assert "old_marker.txt" not in [p.name for p in target.iterdir()]
+
+
+# --------------------------------------------------------------------------- #
+#  5. Schema-version guard                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_schema_guard_rejects_newer_bundle(nerve_dir, workspace, config_dir, tmp_path):
+    # Bump the snapshot's schema version above the code's migration head.
+    _make_nerve_db(nerve_dir / "nerve.db", schema_version=SCHEMA_VERSION + 100)
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(nerve_dir, workspace, out, config_dir=config_dir)
+
+    report = backup_mod.verify_bundle(result.path)
+    assert not report.ok
+    assert any("newer than this code" in e for e in report.errors)
+
+    # Restore must refuse cleanly.
+    with pytest.raises(BackupError, match="verification"):
+        backup_mod.restore_bundle(result.path, tmp_path / "nd_new", tmp_path / "ws_new")
+
+
+def test_verify_detects_checksum_tamper(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(
+        nerve_dir, workspace, out, config_dir=config_dir, compression="gzip",
+    )
+    # Tamper: rewrite a file inside the gzip tar so a checksum mismatches.
+    import tarfile
+
+    extract = tmp_path / "x"
+    extract.mkdir()
+    with tarfile.open(result.path, "r:gz") as tar:
+        tar.extractall(extract, filter="data")
+    (extract / "workspace" / "SOUL.md").write_text("TAMPERED CONTENT")
+    tampered = tmp_path / "tampered.tar.gz"
+    with tarfile.open(tampered, "w:gz") as tar:
+        tar.add(extract / "manifest.json", arcname="manifest.json")
+        for sub in ("config", "state", "workspace"):
+            if (extract / sub).exists():
+                tar.add(extract / sub, arcname=sub)
+
+    report = backup_mod.verify_bundle(tampered)
+    assert not report.ok
+    assert any("checksum mismatch" in e for e in report.errors)
+
+
+def test_gzip_fallback_roundtrip(nerve_dir, workspace, config_dir, tmp_path):
+    out = tmp_path / "out"
+    result = backup_mod.create_backup(
+        nerve_dir, workspace, out, config_dir=config_dir, compression="gzip",
+    )
+    assert result.path.name.endswith(".tar.gz")
+    assert result.compression == "gzip"
+    report = backup_mod.verify_bundle(result.path)
+    assert report.ok, report.errors


### PR DESCRIPTION
## Summary

Nerve had **no backup story** — sessions, tasks, plans, and the entire memU long-term memory live in two WAL-mode SQLite DBs on a single disk, with no scheduled copy, no off-box copy, and no documented restore path. A naive `cp` of a hot WAL DB can even produce a torn snapshot. This adds a first-class backup/restore feature.

- **`nerve/backup.py`** — produces a single portable bundle `nerve-backup-<host>-<ts>.tar.zst` (gzip fallback when `zstandard` is absent). The SQLite DBs are copied via the **online-backup API** (`Connection.backup`) + `PRAGMA integrity_check`, so a bundle is transactionally consistent **even while Nerve is running**. Strict allowlists keep bundles small: `~/.nerve` essentials only (drops `nerve.log`, `bin/`, `*-wal/-shm`, stale `memu.backup*`), and the workspace BRAIN only (`*.md` + `memory/`/`scripts/`/`skills/`, with junk dirs pruned).
- **`verify_bundle` / `restore_bundle`** — restore is verified (per-file sha256 vs. manifest, `integrity_check` on both DBs, and a schema-version guard so a newer-schema bundle never lands on older code). Restore **refuses to run against a live daemon** (no override — stop it first) and **refuses to overwrite a non-empty `~/.nerve` without `--force`**, which *relocates* the old dir to `~/.nerve.pre-restore-<ts>` rather than deleting it. Secret files are re-`chmod`'d to `0600`.
- **CLI** — `nerve backup [--output DIR] [--state-only] [--no-secrets] [--quiet]` and `nerve restore BUNDLE [--verify-only] [--force]`. Both work without a running server (direct file access), matching `stop`/`doctor`.
- **Scheduled run** — opt-in lifespan task (hourly tick, fires when the newest bundle is older than `interval_hours`); the heavy snapshot/tar runs in a thread. Applies retention and **notifies high-priority on failure** (silent-failure discipline).
- **`nerve doctor`** — warns when the newest bundle is older than `2× interval`; nudges when backups are unconfigured.
- **Config** — opt-in `BackupConfig` (disabled by default), wired into `NerveConfig`, with a documented block in `config.example.yaml`.

Local-dir targets only in v1 (an external mount / synced dir covers off-box). Cloud upload + bundle encryption are follow-ups. No schema changes; no new required dependencies.

## Test plan

- [x] `tests/test_backup.py` (13 tests) — all green
  - [x] WAL-DB snapshot stays consistent **under a concurrent writer thread**
  - [x] full bundle round-trip: backup → verify → restore (DB row counts + secret modes + workspace BRAIN preserved)
  - [x] junk excluded (state + workspace decoys); `--state-only` and `--no-secrets` honored + flagged in the manifest
  - [x] retention prunes **only** files matching the bundle-name pattern (decoys survive)
  - [x] restore refuses on a live pidfile and on a non-empty target; `--force` relocates the old dir
  - [x] schema-version guard rejects a newer-schema bundle; checksum tamper detected; gzip fallback round-trips
- [x] Full suite: `pytest tests/ -q` → **1158 passed**
- [x] End-to-end CLI smoke test (`backup`, `restore --verify-only`, `restore`) via a synthetic state dir
- [ ] Rollout: set `backup.target_dir` + `enabled: true`, run a first manual `nerve backup` + `nerve restore --verify-only`, then delete the stale `memu.backup*.sqlite` copies

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*