### PR TITLE
Tune nerve.db connection pragmas for concurrency (busy_timeout + synchronous=NORMAL)

### DIFF
--- a/nerve/backup.py
+++ b/nerve/backup.py
@@ -179,6 +179,19 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+# Busy timeout (seconds) for this module's own sqlite3 connections. The online
+# snapshot reads the *live* nerve.db/memu.sqlite while the gateway is writing,
+# so without a wait it could fail with "database is locked". The stdlib
+# ``timeout=`` arg maps to sqlite3_busy_timeout under the hood; 10s matches the
+# gateway's ``PRAGMA busy_timeout=10000`` (see ``nerve/db/base.py``).
+_SQLITE_TIMEOUT = 10.0
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    """Open a sqlite3 connection with the shared busy timeout applied."""
+    return sqlite3.connect(str(path), timeout=_SQLITE_TIMEOUT)
+
+
 def _nerve_version() -> str:
     try:
         from importlib.metadata import version
@@ -246,9 +259,9 @@ def _snapshot_db(src: Path, dst: Path) -> None:
     if not src.exists():
         raise BackupError(f"database not found: {src}")
 
-    source = sqlite3.connect(str(src))
+    source = _connect(src)
     try:
-        dest = sqlite3.connect(str(dst))
+        dest = _connect(dst)
         try:
             # pages>0 copies incrementally, retrying pages dirtied by a
             # concurrent writer rather than holding a long read lock.
@@ -258,7 +271,7 @@ def _snapshot_db(src: Path, dst: Path) -> None:
     finally:
         source.close()
 
-    check = sqlite3.connect(str(dst))
+    check = _connect(dst)
     try:
         row = check.execute("PRAGMA integrity_check").fetchone()
     finally:
@@ -272,7 +285,7 @@ def _snapshot_db(src: Path, dst: Path) -> None:
 def _db_schema_version(db_path: Path) -> int:
     """Read the persisted schema version from a nerve.db (0 if absent)."""
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = _connect(db_path)
         try:
             row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
             return int(row[0]) if row and row[0] is not None else 0
@@ -285,7 +298,7 @@ def _db_schema_version(db_path: Path) -> int:
 def _count(db_path: Path, table: str) -> int | None:
     """COUNT(*) of a table, or None when the DB/table is unavailable."""
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = _connect(db_path)
         try:
             row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
             return int(row[0]) if row else None
@@ -692,7 +705,7 @@ def verify_bundle(path: Path, extract_to: Path | None = None) -> VerifyReport:
                 )
                 continue
             try:
-                conn = sqlite3.connect(str(fp))
+                conn = _connect(fp)
                 try:
                     row = conn.execute("PRAGMA integrity_check").fetchone()
                 finally:

--- a/nerve/db/base.py
+++ b/nerve/db/base.py
@@ -39,6 +39,41 @@ logger = logging.getLogger(__name__)
 SCHEMA_VERSION = max(v for v, _ in discover_migrations()) if discover_migrations() else 0
 
 
+# Connection pragmas applied on every ``connect()``. These mirror the tuning
+# memU already uses for its own SQLite connections (see
+# ``nerve/memory/memu_bridge.py``) — the primary operational DB is where the
+# heaviest cron/CLI/backup contention happens, yet it was never tuned.
+#
+# Why each one matters:
+#   journal_mode=WAL   — readers don't block the single writer. This setting is
+#                        durable (persists in the DB file), but re-asserting it
+#                        on every open is harmless and keeps intent explicit.
+#   busy_timeout=10000 — milliseconds to wait+retry on a locked DB instead of
+#                        failing instantly with "database is locked". The
+#                        gateway, every CLI command (``nerve sync``/``doctor``/
+#                        ``db prune``), and the scheduled backup are separate
+#                        connections to one file; WAL allows a single writer,
+#                        so the others must briefly queue rather than error.
+#   synchronous=NORMAL — safe under WAL (no corruption risk; only the most
+#                        recent transaction can be lost on an OS/power crash)
+#                        and skips the fsync that FULL forces on *every* commit
+#                        — the per-commit cost behind write-lock "wait hours".
+#   foreign_keys=ON    — enforce FK constraints (per-connection; off by default).
+#   temp_store=MEMORY  — keep temp tables/indices in RAM.
+#   cache_size=-16000  — ~16 MB page cache (negative value = KiB).
+#
+# All but ``journal_mode`` are *per-connection* and must be re-applied on every
+# open — which is exactly why this is centralized rather than set inline.
+_DEFAULT_PRAGMAS: dict[str, object] = {
+    "journal_mode": "WAL",
+    "busy_timeout": 10000,
+    "synchronous": "NORMAL",
+    "foreign_keys": "ON",
+    "temp_store": "MEMORY",
+    "cache_size": -16000,
+}
+
+
 class Database(
     SessionStore,
     MessageStore,
@@ -71,14 +106,27 @@ class Database(
         self.workspace = workspace
         self._db: aiosqlite.Connection | None = None
         self._write_lock = asyncio.Lock()
+        # Per-connection pragmas (see _DEFAULT_PRAGMAS). Copied per instance so
+        # a caller or test can tune them before connect() (e.g. busy_timeout=0).
+        self._pragmas: dict[str, object] = dict(_DEFAULT_PRAGMAS)
+
+    async def _apply_pragmas(self) -> None:
+        """Apply the connection pragmas (see :data:`_DEFAULT_PRAGMAS`).
+
+        Pragma names and values are module-controlled constants, never user
+        input, so interpolating them into the statement is safe.
+        """
+        for name, value in self._pragmas.items():
+            await self.db.execute(f"PRAGMA {name}={value}")
 
     async def connect(self) -> None:
-        """Open the database connection and apply migrations."""
+        """Open the database connection, tune it, and apply migrations."""
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._db = await aiosqlite.connect(str(self.db_path))
         self._db.row_factory = aiosqlite.Row
-        await self._db.execute("PRAGMA journal_mode=WAL")
-        await self._db.execute("PRAGMA foreign_keys=ON")
+        # Apply pragmas BEFORE migrations so the migration writes also run under
+        # the tuned busy_timeout/synchronous settings and contend politely.
+        await self._apply_pragmas()
         await run_migrations(self._db)
         await self._check_fts_integrity()
 

--- a/tests/test_db_pragmas.py
+++ b/tests/test_db_pragmas.py
@@ -1,0 +1,116 @@
+"""Tests for nerve.db connection pragmas (busy_timeout, synchronous, WAL).
+
+These guard the concurrency tuning applied in ``Database.connect()`` — the
+same PRAGMA set memU already uses — so that concurrent crons / CLI commands /
+the scheduled backup queue politely instead of failing instantly with
+"database is locked", and the per-commit fsync cost is dropped under WAL.
+"""
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from nerve.db import Database
+
+
+@pytest.mark.asyncio
+class TestConnectionPragmas:
+    """The tuned pragmas are actually applied on connect()."""
+
+    async def test_pragmas_applied(self, db: Database):
+        async with db.db.execute("PRAGMA busy_timeout") as cur:
+            assert (await cur.fetchone())[0] == 10000
+        # synchronous: NORMAL == 1 (OFF=0, NORMAL=1, FULL=2, EXTRA=3)
+        async with db.db.execute("PRAGMA synchronous") as cur:
+            assert (await cur.fetchone())[0] == 1
+        async with db.db.execute("PRAGMA journal_mode") as cur:
+            assert (await cur.fetchone())[0].lower() == "wal"
+        async with db.db.execute("PRAGMA foreign_keys") as cur:
+            assert (await cur.fetchone())[0] == 1
+        async with db.db.execute("PRAGMA temp_store") as cur:
+            assert (await cur.fetchone())[0] == 2  # MEMORY
+        async with db.db.execute("PRAGMA cache_size") as cur:
+            assert (await cur.fetchone())[0] == -16000
+
+    async def test_pragmas_overridable_before_connect(self, tmp_path):
+        """A caller or test can tune ``_pragmas`` before connect()."""
+        database = Database(tmp_path / "override.db")
+        database._pragmas = {**database._pragmas, "busy_timeout": 0}
+        await database.connect()
+        try:
+            async with database.db.execute("PRAGMA busy_timeout") as cur:
+                assert (await cur.fetchone())[0] == 0
+        finally:
+            await database.close()
+
+
+@pytest.mark.asyncio
+class TestBusyTimeoutBehavior:
+    """busy_timeout makes a second writer wait instead of erroring."""
+
+    @staticmethod
+    async def _hold_write_lock(database: Database) -> None:
+        """Begin a write on ``database`` and leave it uncommitted.
+
+        The first write of a deferred transaction acquires the WAL write lock;
+        not committing keeps it held until the caller commits.
+        """
+        await database.db.execute(
+            "CREATE TABLE IF NOT EXISTS _lock_probe (x INTEGER)"
+        )
+        await database.db.commit()
+        await database.db.execute("INSERT INTO _lock_probe VALUES (1)")
+
+    async def test_second_writer_waits_and_succeeds(self, tmp_path):
+        db_path = tmp_path / "contended.db"
+        writer = Database(db_path)
+        waiter = Database(db_path)
+        await writer.connect()
+        await waiter.connect()
+        try:
+            await self._hold_write_lock(writer)
+
+            async def _waiter_write() -> None:
+                await waiter.db.execute("INSERT INTO _lock_probe VALUES (2)")
+                await waiter.db.commit()
+
+            task = asyncio.create_task(_waiter_write())
+            # Give the waiter time to start blocking inside SQLite's busy
+            # handler. With a non-zero busy_timeout it must still be pending
+            # (waiting on the lock), not failed.
+            await asyncio.sleep(0.3)
+            assert not task.done(), "waiter should be blocked on the lock, not done"
+
+            await writer.db.commit()  # release the write lock
+            await asyncio.wait_for(task, timeout=5)  # waiter now proceeds
+
+            async with waiter.db.execute(
+                "SELECT COUNT(*) FROM _lock_probe"
+            ) as cur:
+                assert (await cur.fetchone())[0] == 2
+        finally:
+            await writer.close()
+            await waiter.close()
+
+    async def test_zero_timeout_raises_database_locked(self, tmp_path):
+        """Control: with busy_timeout=0 the same contention raises immediately.
+
+        Proves the positive test actually exercises the busy-timeout mechanism
+        rather than passing for some unrelated reason.
+        """
+        db_path = tmp_path / "contended_zero.db"
+        writer = Database(db_path)
+        waiter = Database(db_path)
+        waiter._pragmas = {**waiter._pragmas, "busy_timeout": 0}
+        await writer.connect()
+        await waiter.connect()
+        try:
+            await self._hold_write_lock(writer)
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                await waiter.db.execute("INSERT INTO _lock_probe VALUES (2)")
+                await waiter.db.commit()
+            await writer.db.commit()
+        finally:
+            await writer.close()
+            await waiter.close()


### PR DESCRIPTION
## Problem

`Database.connect()` applied only `journal_mode=WAL` and `foreign_keys=ON`. Two pragmas this codebase **already trusts elsewhere** (`nerve/memory/memu_bridge.py` sets them on memU's connections) were missing on the primary `nerve.db` connection — where the heaviest contention happens:

1. **No `busy_timeout` (defaults to 0).** A second connection touching `nerve.db` while a write is in flight gets `SQLITE_BUSY` ("database is locked") **immediately**, no wait/retry. Other connections genuinely exist: every CLI command opens its own `Database().connect()` (`nerve sync`, `doctor`, `db prune`/`vacuum`) against the live gateway, and the backup module opens connections for snapshot + `integrity_check`.
2. **`synchronous` defaults to FULL → an fsync on every commit.** Most writers commit per single statement; under concurrent cron load every commit forces a WAL fsync — the mechanism behind the documented "write-lock contention under 6+ concurrent crons causes users to wait hours" pain.

## Change

Centralize the connection pragmas in one place and apply them on **every** `connect()`, mirroring memU's tuning:

- **`nerve/db/base.py`** — module-level `_DEFAULT_PRAGMAS` (`journal_mode=WAL`, `busy_timeout=10000`, `synchronous=NORMAL`, `foreign_keys=ON`, `temp_store=MEMORY`, `cache_size=-16000`), copied to a per-instance `self._pragmas`, applied via a new `_apply_pragmas()` called **before** `run_migrations` so migration writes also contend politely. The gateway and every CLI command inherit this automatically through the shared `connect()`.
- **`nerve/backup.py`** — added a `_connect()` helper (explicit `timeout=10`, the stdlib equivalent of `busy_timeout`) and routed all six raw `sqlite3.connect` calls through it, so a backup that runs while the gateway is writing waits instead of failing.

### Two distinct failure modes fixed

- **`synchronous=NORMAL`** — the *single-connection throughput* facet: NORMAL fsyncs at checkpoint, not on every commit. Safe under WAL — no corruption risk; worst case only the most recent transaction is lost on an OS/power crash (already the accepted tradeoff for memU, which holds the more precious long-term data).
- **`busy_timeout=10000`** — the *multi-connection* facet: gateway + CLI + scheduled backup are separate connections; WAL permits one writer, so the others must wait. Timeout 0 turns that wait into an instant error; 10s lets them retry transparently.

## Scope

Pure connection-config change — **no schema, no API change**. Independent of and complementary to the shared-connection transaction-isolation / connection-pool redesign tracked separately; this can land on its own.

## Tests

New `tests/test_db_pragmas.py`:
- **pragmas applied** — after `connect()`, `busy_timeout=10000`, `synchronous=1` (NORMAL), `journal_mode=wal`, etc.
- **busy_timeout waits** — two connections to one file; the writer holds an uncommitted write (WAL write lock), a second writer is issued concurrently and **succeeds after the first commits** rather than raising.
- **control** — the same contention with `busy_timeout=0` *does* raise `database is locked`, proving the positive test exercises the mechanism.

## Verification

- New tests pass; full suite **1180 passed / 2 skipped** (skips pre-existing, unrelated).
- Read-only probe of the live ~462 MB `nerve.db` through the changed `_connect` → `busy_timeout=10000`, `quick_check=ok`.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*
