### PR TITLE
agent/engine: idle sweep keeps clients with live background tasks

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -3118,11 +3118,29 @@ class AgentEngine:
     #  Idle client sweep                                                   #
     # ------------------------------------------------------------------ #
 
+    def _has_live_background_tasks(self, session_id: str) -> bool:
+        """Whether *session_id* has a background task still running.
+
+        The idle sweep consults this so it never discards a client that is
+        parked on a live Bash/Agent ``run_in_background`` (or Monitor) task:
+        discarding tears down the idle-stream watcher (``_idle_stream_watcher``)
+        that delivers the task's completion turn, so the session would never
+        wake when the task settles.
+        """
+        registry = self._bg_task_registry.get(session_id)
+        return bool(registry) and any(
+            entry.get("status") == "running" for entry in registry.values()
+        )
+
     async def run_idle_client_sweep(self) -> int:
         """Disconnect clients that have been idle beyond the configured timeout.
 
         Idle clients still hold a claude CLI subprocess. Discarding them frees
         resources while preserving sdk_session_id for seamless resume later.
+
+        Sessions parked on a live background task are skipped: discarding their
+        client kills the idle-stream watcher that delivers the task's
+        completion turn, so the session would never wake when the task settles.
 
         Returns count of clients disconnected.
         """
@@ -3131,19 +3149,27 @@ class AgentEngine:
             return 0
 
         idle_ids = self.sessions.get_idle_client_ids(timeout_minutes * 60)
+        discarded = 0
         for sid in idle_ids:
+            if self._has_live_background_tasks(sid):
+                logger.info(
+                    "Idle sweep: keeping session %s — background task in flight",
+                    sid,
+                )
+                continue
             logger.info("Auto-closing idle client for session %s", sid)
             # background_memorize: free the claude subprocess now; indexing
             # follows whenever the memorize queue drains.
             await self._discard_client(sid, background_memorize=True)
+            discarded += 1
 
-        if idle_ids:
+        if discarded:
             logger.info(
                 "Idle client sweep: disconnected %d client(s), %d still active",
-                len(idle_ids),
+                discarded,
                 len(self.sessions._clients),
             )
-        return len(idle_ids)
+        return discarded
 
     # ------------------------------------------------------------------ #
     #  Title generation                                                    #

--- a/tests/test_autonomous_turns.py
+++ b/tests/test_autonomous_turns.py
@@ -487,3 +487,68 @@ async def test_process_sdk_message_returns_true_on_result():
     assert st.sdk_session_id == "sdk-9"
     assert st.last_usage == {"input_tokens": 1}
     assert st.result_meta["total_cost_usd"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# run_idle_client_sweep — never discard a client parked on a live bg task
+# ---------------------------------------------------------------------------
+
+
+def test_has_live_background_tasks():
+    engine = _make_engine()
+    engine._bg_task_registry = {
+        "running": {"t1": {"status": "running"}},
+        "settled": {"t2": {"status": "done"}},
+        "mixed": {"t3": {"status": "done"}, "t4": {"status": "running"}},
+    }
+    assert engine._has_live_background_tasks("running") is True
+    assert engine._has_live_background_tasks("settled") is False
+    assert engine._has_live_background_tasks("mixed") is True
+    assert engine._has_live_background_tasks("unknown") is False
+
+
+@pytest.mark.asyncio
+async def test_idle_sweep_skips_sessions_with_live_background_tasks():
+    """Regression: a session parked on a live background task must survive the
+    idle sweep — discarding its client would tear down the idle-stream watcher
+    that delivers the task's completion turn (the lost-wakeup bug)."""
+    engine = _make_engine()
+    engine.config.sessions = SimpleNamespace(client_idle_timeout_minutes=60)
+    engine.sessions = SimpleNamespace(
+        get_idle_client_ids=lambda _timeout: ["busy", "free"],
+        _clients={"busy": object(), "free": object()},
+    )
+    engine._bg_task_registry = {
+        "busy": {"t1": {"task_id": "t1", "status": "running"}},
+        "free": {"t2": {"task_id": "t2", "status": "done"}},
+    }
+    discarded: list[str] = []
+
+    async def _fake_discard(sid, **_kw):
+        discarded.append(sid)
+
+    engine._discard_client = _fake_discard
+
+    n = await engine.run_idle_client_sweep()
+
+    assert discarded == ["free"]  # only the session with no live bg task
+    assert n == 1
+    assert "busy" in engine._bg_task_registry  # left intact for its watcher
+
+
+@pytest.mark.asyncio
+async def test_idle_sweep_disabled_when_timeout_zero():
+    engine = _make_engine()
+    engine.config.sessions = SimpleNamespace(client_idle_timeout_minutes=0)
+    called = False
+
+    def _should_not_run(_timeout):
+        nonlocal called
+        called = True
+        return []
+
+    engine.sessions = SimpleNamespace(
+        get_idle_client_ids=_should_not_run, _clients={},
+    )
+    assert await engine.run_idle_client_sweep() == 0
+    assert called is False  # short-circuits before touching the session store


### PR DESCRIPTION
## Problem

The periodic idle-client sweep (`run_idle_client_sweep`, fired every 5 min by `_periodic_idle_sweep`) discarded a session's SDK client based on inactivity alone. `get_idle_client_ids` only excludes sessions currently running an agent turn (`_running_sessions`) — it does **not** consider whether the session has a live background task (`Bash`/`Agent` `run_in_background`, or `Monitor`).

A session parked on a long background task has no active turn, so after `client_idle_timeout_minutes` (default 60) the sweep discarded its client. `_discard_client` stops the per-session **idle-stream watcher** (`_idle_stream_watcher`) and disconnects the subprocess — and that watcher is exactly what drains the background task's completion turn (`task_notification`). So when the task finished later, there was no watcher and no client to surface it: **the completion turn was lost and the session never woke.**

The irony: `_idle_stream_watcher` loops indefinitely (no self-expiry) specifically to catch these completions — but the idle sweep killed it because the two subsystems didn't consult each other.

## Fix

`run_idle_client_sweep` now skips any session with a `"running"` entry in `_bg_task_registry` (new helper `_has_live_background_tasks`). The registry is already maintained by `_handle_system_message` from the CLI's `task_started`/`task_updated`/`task_notification` events, so it accurately reflects in-flight background work. Such a session keeps its client (and watcher) until the task settles; a later sweep discards it normally. Also returns the count actually discarded (previously `len(idle_ids)`).

### Trade-off / follow-up
A background task that never settles (runaway/abandoned) will now hold its subprocess open indefinitely — strictly safer than losing wakeups, but a future hardening could add a max-hold cap.

## Tests
`tests/test_autonomous_turns.py`:
- `test_has_live_background_tasks` — helper truth table
- `test_idle_sweep_skips_sessions_with_live_background_tasks` — a session with a running bg task survives; one with only settled tasks is discarded
- `test_idle_sweep_disabled_when_timeout_zero` — `timeout <= 0` short-circuits

Full suite: 1215 passed, 2 skipped.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*
