### PR TITLE
Fix manual cron session rotation

### DIFF
--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -240,6 +240,8 @@ class CronService:
     async def _maybe_rotate_context(
         self, session_id: str, rotate_hours: int,
         rotate_at: str = "",
+        *,
+        force: bool = False,
     ) -> bool:
         """Check if a persistent cron session's context should be rotated.
 
@@ -252,28 +254,33 @@ class CronService:
         Returns True if rotation was performed.
         """
         session = await self.db.get_session(session_id)
-        if not session or not session.get("connected_at"):
-            return False
-
-        connected_at_str = session["connected_at"]
-        try:
-            ts = connected_at_str
-            if "T" not in ts:
-                ts = ts.replace(" ", "T")
-            if not ts.endswith(("Z", "+00:00")):
-                ts += "+00:00"
-            connected_at = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-        except (ValueError, TypeError):
-            logger.warning(
-                "Invalid connected_at for %s: %s", session_id, connected_at_str,
-            )
+        if not session:
             return False
 
         now = datetime.now(timezone.utc)
-        should_rotate = False
-        reason = ""
+        should_rotate = force
+        reason = "manual" if force else ""
 
-        if rotate_at:
+        connected_at = None
+        connected_at_str = session.get("connected_at")
+        if connected_at_str:
+            try:
+                ts = connected_at_str
+                if "T" not in ts:
+                    ts = ts.replace(" ", "T")
+                if not ts.endswith(("Z", "+00:00")):
+                    ts += "+00:00"
+                connected_at = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Invalid connected_at for %s: %s", session_id, connected_at_str,
+                )
+                if not force:
+                    return False
+        elif not force:
+            return False
+
+        if not should_rotate and rotate_at:
             # Time-of-day rotation: rotate if session started before today's
             # rotate_at and current time is past it.
             try:
@@ -291,7 +298,7 @@ class CronService:
             if now >= today_rotate_utc and connected_at < today_rotate_utc:
                 should_rotate = True
                 reason = f"rotate_at={rotate_at}"
-        elif rotate_hours > 0:
+        elif not should_rotate and rotate_hours > 0:
             age_hours = (now - connected_at).total_seconds() / 3600
             if age_hours >= rotate_hours:
                 should_rotate = True
@@ -631,8 +638,9 @@ class CronService:
             except (ValueError, TypeError):
                 pass
 
-        # Force rotation (rotate_hours=0 ensures any positive age passes)
-        rotated = await self._maybe_rotate_context(session_id, rotate_hours=0)
+        rotated = await self._maybe_rotate_context(
+            session_id, rotate_hours=0, force=True,
+        )
 
         logger.info(
             "Manual rotation for %s: rotated=%s age=%.1fh",

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -479,6 +479,30 @@ class TestRotationMemorize:
         assert rotated is False
         cron_service.engine.schedule_memorize.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_manual_rotation_forces_disabled_rotation_window(self, cron_service):
+        """Manual rotation clears context even when scheduled rotation is disabled."""
+        cron_service._jobs = [
+            _make_job(
+                id="pers", session_mode="persistent", context_rotate_hours=0,
+            ),
+        ]
+        cron_service.db.get_session = AsyncMock(return_value={
+            "connected_at": _hours_ago(1),
+            "sdk_session_id": "sdk-123",
+        })
+
+        result = await cron_service.rotate_session("pers")
+
+        assert result["rotated"] is True
+        assert result["session_age_hours"] is not None
+        cron_service.engine.schedule_memorize.assert_awaited_once_with(
+            "cron:pers",
+        )
+        cron_service.engine.sessions.mark_idle.assert_awaited_once_with(
+            "cron:pers", preserve_sdk_id=False,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Run gates — service-level skip/run behaviour


### PR DESCRIPTION
## Summary

Fixes the manual cron session rotation endpoint so it actually clears a persistent job's SDK session context.

## Root cause

Manual rotation called `_maybe_rotate_context(..., rotate_hours=0)`. That used to force rotation, but the `context_rotate_at` refactor made `rotate_hours=0` mean "disabled" inside the shared helper, so the manual path returned `rotated: false` without clearing `sdk_session_id`.

## Changes

- Add an explicit `force` flag to the shared rotation helper.
- Use `force=True` from `rotate_session()`.
- Add a regression test covering manual rotation when scheduled rotation is disabled.

## Validation

- `python -m pytest tests/test_cron.py -q`
- `python -m pytest tests/test_cron.py::TestRotationMemorize -q`
