### PR TITLE
Skip context-1m beta header for excluded models

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -973,8 +973,12 @@ class AgentEngine:
             self.config.agent.effort,
             model or self.config.agent.model,
         )
+        # Some subscriptions reject the context-1m beta for specific models
+        # (e.g. claude-sonnet-4-6) — skip the beta header for those.
         betas = (
-            ["context-1m-2025-08-07"] if self.config.agent.context_1m else []
+            ["context-1m-2025-08-07"]
+            if self.config.agent.context_1m_enabled_for(model)
+            else []
         )
 
         # Build PreToolUse (file snapshots, image validation) +
@@ -2042,7 +2046,11 @@ class AgentEngine:
             )
 
         # Persist usage for context bar on session switch
-        max_context = 1_048_576 if self.config.agent.context_1m else 200_000
+        max_context = (
+            1_048_576
+            if self.config.agent.context_1m_enabled_for(st.last_model)
+            else 200_000
+        )
         num_turns = (st.result_meta or {}).get("num_turns") or 1
         if st.last_usage:
             usage_data = {

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -139,6 +139,12 @@ class AgentConfig:
     thinking: str = "max"       # max, high, medium, low, disabled, adaptive, or number (budget_tokens)
     effort: str = "max"         # max, xhigh, high, medium, low
     context_1m: bool = True     # Enable 1M context window beta
+    # Substrings of model names for which the context-1m beta header must NOT
+    # be sent (some subscriptions reject the beta for specific models — e.g.
+    # claude-sonnet-4-6 returns 400 "long context beta not yet available for
+    # this subscription"). Match is case-insensitive substring on the resolved
+    # model name. Empty list = send beta for all models when context_1m=True.
+    context_1m_excluded_models: list[str] = field(default_factory=list)
     # Hung-CLI detection: max idle time between SDK messages on a single
     # turn before the engine treats the subprocess as dead and falls into
     # the existing CLI-crash retry path.  Set to 0 to disable (legacy
@@ -158,8 +164,22 @@ class AgentConfig:
             thinking=str(d.get("thinking", "max")),
             effort=str(d.get("effort", "max")),
             context_1m=d.get("context_1m", True),
+            context_1m_excluded_models=list(
+                d.get("context_1m_excluded_models", []) or []
+            ),
             cli_idle_timeout_seconds=int(d.get("cli_idle_timeout_seconds", 900)),
             prompt_rewrite=PromptRewriteConfig.from_dict(d.get("prompt_rewrite") or {}),
+        )
+
+    def context_1m_enabled_for(self, model: str | None) -> bool:
+        """Whether the context-1m beta applies to *model* (or the default
+        model when None).  False if globally disabled or if the model name
+        matches any entry in ``context_1m_excluded_models``."""
+        if not self.context_1m:
+            return False
+        resolved = (model or self.model).lower()
+        return not any(
+            tok and tok.lower() in resolved for tok in self.context_1m_excluded_models
         )
 
 


### PR DESCRIPTION
## Problem

Some Claude OAuth subscriptions reject the `context-1m-2025-08-07` beta for specific models. Example: a session on `claude-sonnet-4-6` returns

```
400 long context beta not yet available for this subscription
```

while the *same* subscription accepts the beta on `claude-opus-4-8`. The current global `agent.context_1m: bool` is all-or-nothing — turning it off to fix Sonnet kills the 1M context on Opus too. Affected sessions break entirely with `context_1m: true` until manually downgraded.

## Fix

Add `AgentConfig.context_1m_excluded_models: list[str]` — case-insensitive substring match against the resolved model name. When `context_1m=True`, the beta header is sent for every model whose name does **not** match any entry.

```yaml
agent:
  context_1m: true
  context_1m_excluded_models:
    - claude-sonnet-4-6
```

New helper `AgentConfig.context_1m_enabled_for(model: str | None) -> bool` drives both:

1. **Beta header decision** at session start (engine.py: `betas = ["context-1m-2025-08-07"] if context_1m_enabled_for(model) else []`)
2. **`max_context` value** used for context-bar usage metadata (so excluded sessions report the right 200k ceiling, not the 1M one)

Empty list keeps the existing all-or-nothing behaviour — no behaviour change for users who don't set the new field.

## Tests

Existing test suite stays green: `1151 passed, 2 skipped` (excluding pre-existing `tests/test_cron.py::TestMaybeRotateContext` rotate_at failures unrelated to this change — present on `main` too).

The helper is a pure function on `AgentConfig`; substring match + the `context_1m` global guard cover the matrix.

## Files

- `nerve/config.py` — `context_1m_excluded_models` field + `context_1m_enabled_for(model)` helper
- `nerve/agent/engine.py` — use the helper at the beta-header decision and at the `max_context` site

> *Generated with [Claude Code](https://claude.com/claude-code)*