### PR TITLE
Cache notification messages for reaction context

### DIFF
--- a/nerve/notifications/service.py
+++ b/nerve/notifications/service.py
@@ -809,10 +809,17 @@ class NotificationService:
         logger.warning("No telegram_chat_id configured for notifications")
         return None
 
-    def _get_telegram_bot(self):
-        """Get the Telegram bot instance, or None if unavailable."""
+    def _get_telegram_channel(self):
+        """Get the TelegramChannel instance, or None if unavailable."""
         channel = self.engine.router.get_channel("telegram")
         if not channel or not hasattr(channel, '_app') or channel._app is None:
+            return None
+        return channel
+
+    def _get_telegram_bot(self):
+        """Get the Telegram bot instance, or None if unavailable."""
+        channel = self._get_telegram_channel()
+        if not channel:
             return None
         return channel._app.bot
 
@@ -862,12 +869,20 @@ class NotificationService:
                 else:
                     rendered = value
                 button_labels.append((rendered, value))
-            return await self._send_telegram_inline(
+            msg_id = await self._send_telegram_inline(
                 chat_id, notification_id, text, button_labels, silent=silent,
             )
         else:
             msg = await self._send_telegram_html(bot, chat_id, text, silent=silent)
-            return str(msg.message_id)
+            msg_id = str(msg.message_id)
+
+        # Cache for reaction context lookups
+        if msg_id:
+            channel = self._get_telegram_channel()
+            if channel:
+                channel._cache_message(int(msg_id), chat_id, text)
+
+        return msg_id
 
     @staticmethod
     async def _send_telegram_html(


### PR DESCRIPTION
## Problem

`NotificationService._deliver_telegram()` sends notifications by calling either `_send_telegram_html()` or `_send_telegram_inline()`, both of which go through `bot.send_message()` directly — bypassing `TelegramChannel.send()` and its `_cache_message()` call.

Consequence: notification messages never land in `_message_cache`. When a user reacts to a notification on Telegram, the reaction handler does `self._message_cache.get(message_id)` (channels/telegram.py:1352), gets `None`, and shows the reaction as:

```
[Reaction: 👎]
```

— no original text, no context for the agent to respond to. For approval prompts and questions this is the difference between "the user said no to *the rollback question*" and "the user said no to *something*."

## Fix

After `_deliver_telegram()` lands a message (via either the inline-buttons path or the plain HTML path), capture `msg_id` and feed it to `channel._cache_message(int(msg_id), chat_id, text)`. Same cache, same eviction policy (`_message_cache_max = 200`) — the entry now flows from the notification path too, so reactions resolve to the actual prompt text.

Both branches converge into a single `msg_id` and the cache call runs once at the end of the function.

Re-application of the previously-closed [#50](https://github.com/ClickHouse/nerve/pull/50) (closed by me in error without comment 2 months ago, never recreated), rebased onto current `main` and merged with the newer `approval`-kind dispatch + emoji button labels added since.

## Tests

Existing `notifications`-keyword tests stay green: `58 passed, 1095 deselected`.

## Files

- `nerve/notifications/service.py` — capture `msg_id` from both inline and HTML paths, then call `channel._cache_message(msg_id, chat_id, text)` (+19 / −4)

> *Generated with [Claude Code](https://claude.com/claude-code)*