### PR TITLE
feat(sidebar): replace search field + header with Search/New chat pills

### DIFF
--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -42,12 +42,50 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
 }) {
   const [systemExpanded, setSystemExpanded] = useState(false);
   const [localQuery, setLocalQuery] = useState('');
+  const [searchHovered, setSearchHovered] = useState(false);
+  const [searchFocused, setSearchFocused] = useState(false);
+  const [searchMounted, setSearchMounted] = useState(false);
+  const [searchVisible, setSearchVisible] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { searchResults, searchLoading, searchSessions, clearSearch, renameSession, toggleStar } = useChatStore();
 
   const isSearching = localQuery.trim().length > 0;
+  const shouldShowSearch = searchHovered || searchFocused || isSearching;
+
+  // Mount/unmount the search input with a fade transition (200ms).
+  useEffect(() => {
+    if (shouldShowSearch) {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+      setSearchMounted(true);
+    } else if (searchMounted) {
+      setSearchVisible(false);
+      closeTimerRef.current = setTimeout(() => {
+        setSearchMounted(false);
+        closeTimerRef.current = null;
+      }, 200);
+    }
+  }, [shouldShowSearch, searchMounted]);
+
+  // After mount, flip to visible on next frame so the CSS transition runs.
+  useEffect(() => {
+    if (searchMounted && !searchVisible) {
+      const id = requestAnimationFrame(() => setSearchVisible(true));
+      return () => cancelAnimationFrame(id);
+    }
+  }, [searchMounted, searchVisible]);
+
+  // Clean up pending close timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
 
   // Debounced search
   const handleSearchChange = useCallback((value: string) => {
@@ -125,37 +163,58 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onSelect,
 
   return (
     <div className={`bg-surface border-r border-border-subtle flex flex-col shrink-0 transition-all duration-200 overflow-hidden ${collapsed ? 'w-0 border-r-0' : 'w-60'}`}>
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2.5 border-b border-border-subtle">
-        <span className="text-[10px] uppercase tracking-wider text-text-faint font-medium">Conversations</span>
-        <button
-          onClick={onCreate}
-          className="w-5 h-5 rounded flex items-center justify-center text-text-faint hover:text-text-muted hover:bg-surface-hover cursor-pointer"
-          title="New session"
-        >
-          <Plus size={12} />
-        </button>
-      </div>
+      {/* Search + New chat */}
+      <div className="px-2 py-1.5 border-b border-border-subtle">
+        <div className="relative h-7">
+          {/* Search pill (always visible, hover-zone trigger) */}
+          <button
+            type="button"
+            onMouseEnter={() => setSearchHovered(true)}
+            onMouseLeave={() => setSearchHovered(false)}
+            className="absolute left-0 top-1/2 -translate-y-1/2 h-6 pl-1.5 pr-2.5 rounded-full border border-border-subtle flex items-center gap-1 text-[11px] text-text-faint hover:text-text-muted hover:bg-surface-hover cursor-pointer z-10"
+          >
+            <Search size={11} className="pointer-events-none" />
+            <span>Search sessions</span>
+          </button>
 
-      {/* Search */}
-      <div className="px-2 py-1.5">
-        <div className="relative">
-          <Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-faint" />
-          <input
-            ref={inputRef}
-            type="text"
-            value={localQuery}
-            onChange={e => handleSearchChange(e.target.value)}
-            placeholder="Search sessions..."
-            className="w-full bg-surface-raised border border-border rounded-md text-[12px] text-text-secondary placeholder-text-faint pl-7 pr-7 py-1.5 outline-none focus:border-text-faint transition-colors"
-          />
-          {isSearching && (
-            <button
-              onClick={() => { setLocalQuery(''); clearSearch(); }}
-              className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 text-text-faint hover:text-text-muted cursor-pointer"
-            >
-              <X size={12} />
-            </button>
+          {/* New chat pill (hidden under input when open) */}
+          <button
+            onClick={onCreate}
+            title="New chat"
+            className="absolute right-0 top-1/2 -translate-y-1/2 h-6 pl-1.5 pr-2.5 rounded-full border border-border-subtle flex items-center gap-1 text-[11px] text-text-faint hover:text-text-muted hover:bg-surface-hover cursor-pointer"
+          >
+            <Plus size={11} />
+            <span>New chat</span>
+          </button>
+
+          {searchMounted && (
+            <>
+              <input
+                id="nerve-sidebar-search"
+                ref={inputRef}
+                type="text"
+                value={localQuery}
+                onChange={e => handleSearchChange(e.target.value)}
+                onFocus={() => setSearchFocused(true)}
+                onBlur={() => setSearchFocused(false)}
+                onMouseEnter={() => setSearchHovered(true)}
+                onMouseLeave={() => setSearchHovered(false)}
+                placeholder="Search sessions..."
+                className={`absolute inset-0 w-full h-full bg-surface-raised border border-border rounded-md text-[12px] text-text-secondary placeholder-text-faint pl-7 pr-7 outline-none focus:border-text-faint transition-all duration-200 ease-out z-20 ${
+                  searchVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                }`}
+              />
+              {isSearching && (
+                <button
+                  onClick={() => { setLocalQuery(''); clearSearch(); }}
+                  className={`absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 text-text-faint hover:text-text-muted cursor-pointer transition-opacity duration-200 z-30 ${
+                    searchVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                  }`}
+                >
+                  <X size={12} />
+                </button>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Replaces the static "Conversations" header + always-visible search input with two rounded pills: **Search sessions** (left) and **New chat** (right). The search input mounts on hover/focus, fades in over 200ms, and unmounts again when nothing is interacting with it. Reclaims sidebar vertical space without losing functionality.

## Behaviour

- **Search pill** is the hover-zone trigger. On hover (or when a query is non-empty), the input mounts and fades in; on leave + empty query, it fades out and unmounts. Never lingers in the DOM when unused.
- **New chat pill** sits on the right. While the search input is open, the input overlays the pill (z-20) so the create button is hidden behind the field — no visual clutter.
- Both controls share `rounded-full` + subtle border styling so they read clearly as buttons.

## Why pills, not a static field

The previous design committed a full row of vertical space to a permanently-visible search field even though searching is intermittent. The pill stays compact when idle and only grows when you actually reach for it. The 200ms fade is short enough not to feel laggy on a deliberate hover; the unmount-on-leave keeps the DOM small.

Subjective UI — happy to drop the redesign or rework if it doesn't fit upstream taste.

## Tests

`npm run build` clean (`✓ built in 8.45s`). Web-only change, no backend touch, no new tests.

Verified by hand: hover → input appears → focus retained while typing → blur + leave → input unmounts.

## Files

- `web/src/components/Chat/SessionSidebar.tsx` — pills + mount/fade state (`searchHovered` / `searchFocused` / `searchMounted` / `searchVisible`) (+90 / -31)

## Note

The original commit (`7fa6505`) was followed by three sequels (`c4617fc`, `e058d11`, `3cd0e1f`) that wired the pill into the global Cmd+K shortcut and added a `requestSearchFocus()` store action. Those are intertwined with the keyboard-shortcuts work and are not part of this PR — they belong in [#133](https://github.com/ClickHouse/nerve/pull/133) (or a follow-up after both this PR and #133 land).

> *Generated with [Claude Code](https://claude.com/claude-code)*