### PR TITLE
feat(observability): generic OpenTelemetry (OTLP) export + structured logging

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -124,3 +124,20 @@ cron:
 #   host: https://cloud.langfuse.com
 #   # redact_patterns:           # optional — strip these regexes from spans
 #   #   - "sk-ant-[A-Za-z0-9_\\-]{20,}"
+
+# Telemetry (optional) — generic OpenTelemetry (OTLP) export of traces,
+# metrics, and logs to an endpoint YOU run (a collector, or any OTLP backend:
+# Grafana/Tempo, Honeycomb, Datadog, ...). Nerve does not run a collector.
+# Off until `endpoint` is set; coexists with langfuse above. Standard
+# OTEL_EXPORTER_OTLP_* env vars are honored and override these. See
+# docs/observability.md.
+# telemetry:
+#   endpoint: http://localhost:4318   # OTLP endpoint — empty disables export
+#   protocol: http/protobuf           # "http/protobuf" or "grpc"
+#   # headers: {authorization: "Bearer <token>"}   # OTLP auth (set in config.local.yaml)
+#   traces: true
+#   metrics: true
+#   logs: false                       # OTLP log export (off by default)
+#   system_metrics: true              # process/runtime metrics
+#   log_format: console               # "console" (default) or "json" — honored even
+#                                     # without an endpoint (NERVE_LOG_FORMAT overrides)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -133,3 +133,106 @@ key).
   buffers spans and ships them async. If memory is tight you can drop
   the Anthropic instrumentation by editing `init_langfuse`, or deploy
   Langfuse self-hosted on a separate machine.
+
+---
+
+# Observability — OpenTelemetry (OTLP)
+
+A vendor-neutral alternative (or complement) to Langfuse: export **traces,
+metrics, and logs** over OTLP to an endpoint **you** run. Nerve does **not**
+package or run a collector — point it at your own collector or any
+OTLP-speaking backend (Grafana Alloy/Tempo/Mimir/Loki, Honeycomb, Datadog,
+Grafana Cloud, …).
+
+Off by default: with no `telemetry.endpoint`, there is zero overhead and no
+per-request instrumentation. It can run **alongside** Langfuse — Nerve owns
+the global OTel tracer provider and Langfuse attaches to it, so the same spans
+reach both.
+
+## What gets captured
+
+- **Traces:** FastAPI HTTP server requests, outbound `httpx` calls, the Claude
+  Agent SDK agent loop + tool calls, and direct Anthropic (memU) calls — the
+  same spans Langfuse sees, plus HTTP server/client spans.
+- **Metrics:** HTTP server metrics, system/process metrics (CPU, memory, GC),
+  and a few nerve counters: `nerve.memorize.runs` / `.errors`,
+  `nerve.notifications.sent`, `nerve.agent.turns`.
+- **Logs (opt-in):** stdlib logs exported over OTLP with `trace_id`/`span_id`
+  correlation, when `telemetry.logs: true`.
+
+## Setup
+
+1. Run an OTLP endpoint (your collector or backend). For local testing,
+   `otel-tui` or `otelcol-contrib` with the `debug` exporter on `:4318` works.
+2. Configure Nerve (`config.yaml`; put secrets/headers in `config.local.yaml`):
+
+   ```yaml
+   telemetry:
+     endpoint: http://localhost:4318    # empty disables export
+     protocol: http/protobuf            # or "grpc"
+     # headers: {authorization: "Bearer <token>"}
+     traces: true
+     metrics: true
+     logs: false
+     system_metrics: true
+     log_format: console                # or "json"
+   ```
+
+3. Standard `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_HEADERS` /
+   `OTEL_EXPORTER_OTLP_PROTOCOL` / `OTEL_SERVICE_NAME` environment variables
+   are honored by the exporters and **override** the config values.
+
+## Configuration reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `telemetry.endpoint` | `""` | OTLP endpoint. Empty = disabled. |
+| `telemetry.protocol` | `http/protobuf` | `http/protobuf` or `grpc` (grpc needs `opentelemetry-exporter-otlp-proto-grpc`). |
+| `telemetry.headers` | `{}` | OTLP auth headers (set in `config.local.yaml`). |
+| `telemetry.service_name` | `nerve` | `service.name` resource attribute. |
+| `telemetry.traces` | `true` | Export traces. |
+| `telemetry.metrics` | `true` | Export metrics. |
+| `telemetry.logs` | `false` | Export logs over OTLP. |
+| `telemetry.system_metrics` | `true` | Process/runtime metrics sampler. |
+| `telemetry.metric_interval_ms` | `60000` | Metric export interval. |
+| `telemetry.log_format` | `console` | Console log rendering: `console` or `json`. Honored even with no endpoint; `NERVE_LOG_FORMAT` overrides. |
+
+## Logging
+
+Console logs keep the classic `HH:MM:SS [LEVEL] name: message` format and gain
+`trace_id`/`span_id` when a span is active. Set `telemetry.log_format: json`
+(or `NERVE_LOG_FORMAT=json`) to emit JSON for a log shipper — this is
+independent of OTLP export.
+
+## Privacy / PII
+
+Unlike the Langfuse integration, the OTLP path has **no redaction**. Be
+deliberate about what you export and where:
+
+- **Traces** capture request URLs (incl. query strings), outbound URLs, and
+  agent/tool span attributes.
+- **`telemetry.logs: true` exports *all* stdlib log bodies** over OTLP, which
+  in this codebase can include prompt/response content and tokens. It is
+  off by default for that reason — enable it only when exporting to a trusted
+  backend, and prefer keeping logs local (console/file) when pointing at a
+  third-party endpoint.
+- `langfuse.redact_patterns` does **not** apply here. If you need scrubbing on
+  this path, do it at your collector (an attributes/redaction processor)
+  before forwarding to a third-party backend.
+
+## Running alongside Langfuse
+
+Both can be enabled at once. Nerve initializes the OTLP provider first, so
+Langfuse v3 reuses it rather than creating its own; agent spans then export to
+both. Langfuse's cache-aware usage rewriter is unaffected.
+
+## Troubleshooting
+
+- **Nothing arrives.** Check `/api/diagnostics` → `otel.enabled`. If false,
+  `telemetry.endpoint` is unset. Confirm your endpoint includes the scheme
+  (`http://…`) and is reachable.
+- **`protocol: grpc` does nothing.** The grpc exporter is optional; install
+  `opentelemetry-exporter-otlp-proto-grpc` or use `http/protobuf` (default).
+  Nerve logs a warning and falls back to http.
+- **Logs lack trace IDs.** Trace correlation only populates inside an active
+  span; startup logs before a request/turn won't have one.

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -57,6 +57,7 @@ from nerve.agent.tools import (
 from nerve.agent.tools import init_tools
 from nerve.config import NerveConfig, load_mcp_servers
 from nerve.db import Database
+from nerve.observability import otel
 from nerve.observability.langfuse import attributes as lf_attrs
 from nerve.skills.manager import SkillManager
 
@@ -2159,6 +2160,7 @@ class AgentEngine:
                 # mark_running below.
                 self.sessions.pop_stop_request(session_id)
                 self.sessions.mark_running(session_id)
+                otel.agent_turns.add(1)
                 if channel is not None:
                     self._active_channel[session_id] = channel
                 # Mark the turn as in flight so the finally below can

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -43,13 +43,105 @@ PID_FILE = PID_DIR / "nerve.pid"
 LOG_FILE = PID_DIR / "nerve.log"
 
 
-def setup_logging(verbose: bool = False) -> None:
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%H:%M:%S",
+def _add_trace_context(logger, method_name, event_dict):
+    """structlog processor — inject OTel trace_id/span_id when a span is active.
+
+    No-op when no telemetry provider is set (the span context is invalid),
+    so this is safe whether or not OTLP export is enabled.
+    """
+    try:
+        from opentelemetry import trace
+
+        ctx = trace.get_current_span().get_span_context()
+        if ctx and ctx.is_valid:
+            event_dict["trace_id"] = format(ctx.trace_id, "032x")
+            event_dict["span_id"] = format(ctx.span_id, "016x")
+    except Exception:
+        pass
+    return event_dict
+
+
+def _console_renderer(_logger, _name, event_dict: dict) -> str:
+    """Render a log record in Nerve's classic console format.
+
+    Preserves ``HH:MM:SS [LEVEL] name: message``, appending any structured
+    key/values and ``trace_id``/``span_id`` when present.
+    """
+    ts = event_dict.pop("timestamp", "")
+    level = str(event_dict.pop("level", "info")).upper()
+    name = event_dict.pop("logger", "") or event_dict.pop("logger_name", "")
+    event = event_dict.pop("event", "")
+    trace_id = event_dict.pop("trace_id", None)
+    span_id = event_dict.pop("span_id", None)
+    # `format_exc_info` (in the processor chain) renders any exc_info into
+    # this "exception" string; append it on its own lines like stdlib does.
+    exception = event_dict.pop("exception", None)
+    line = f"{ts} [{level}] {name}: {event}"
+    extras = " ".join(
+        f"{k}={v}" for k, v in event_dict.items() if not k.startswith("_")
     )
+    if extras:
+        line += " " + extras
+    if trace_id:
+        line += f" trace_id={trace_id} span_id={span_id}"
+    if exception:
+        line += "\n" + exception
+    return line
+
+
+def setup_logging(verbose: bool = False, log_format: str | None = None) -> None:
+    """Configure structured logging (idempotent).
+
+    All existing ``logging.getLogger(__name__)`` call sites are bridged
+    through structlog's ``ProcessorFormatter`` — no call-site changes. The
+    console renderer preserves the classic ``HH:MM:SS [LEVEL] name: msg``
+    format by default; ``log_format="json"`` (or ``NERVE_LOG_FORMAT=json``)
+    emits JSON. ``trace_id``/``span_id`` are injected whenever an OTel span
+    is active.
+    """
+    import structlog
+
+    level = logging.DEBUG if verbose else logging.INFO
+    fmt = (log_format or os.environ.get("NERVE_LOG_FORMAT", "console")).lower()
+
+    shared_processors = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="%H:%M:%S"),
+        _add_trace_context,
+        # Render any exc_info (from logger.exception / exc_info=True) into an
+        # "exception" string so both the console and JSON renderers include
+        # the traceback instead of dropping or choking on the raw tuple.
+        structlog.processors.format_exc_info,
+    ]
+    renderer = (
+        structlog.processors.JSONRenderer()
+        if fmt == "json"
+        else _console_renderer
+    )
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    # Idempotent: replace any handlers we (or basicConfig) installed before,
+    # but preserve the OTLP log-export handler attached by otel.init_otel —
+    # otherwise a later setup_logging() call would silently kill log export.
+    for h in list(root.handlers):
+        cls = type(h)
+        if cls.__name__ == "LoggingHandler" and cls.__module__.startswith("opentelemetry"):
+            continue
+        root.removeHandler(h)
+    root.addHandler(handler)
+    root.setLevel(level)
+
     # Quiet noisy loggers
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -186,6 +278,11 @@ def main(ctx: click.Context, config_dir: str | None, verbose: bool) -> None:
         resolved_dir = resolved_dir.resolve()
     config = load_config(resolved_dir)
     set_config(config)
+    # Re-apply logging with the configured format now that config is loaded
+    # (the early call above used the console/env default). An explicit
+    # NERVE_LOG_FORMAT env var still wins.
+    if os.environ.get("NERVE_LOG_FORMAT") is None and config.telemetry.log_format != "console":
+        setup_logging(verbose, log_format=config.telemetry.log_format)
     ctx.ensure_object(dict)
     ctx.obj["config"] = config
     ctx.obj["config_dir"] = str(resolved_dir)

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -973,6 +973,64 @@ class LangfuseConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """Generic OpenTelemetry (OTLP) export — optional, vendor-neutral.
+
+    Exports traces, metrics, and logs over OTLP to an endpoint **you**
+    run (a collector, or any OTLP-speaking backend — Grafana/Tempo,
+    Honeycomb, Datadog, etc.). Nerve does not run a collector. Activated
+    by setting ``endpoint``; empty endpoint = no-op, zero overhead. Can
+    run alongside the Langfuse integration (both receive the same spans).
+
+    Standard ``OTEL_EXPORTER_OTLP_*`` environment variables are honored by
+    the exporters directly; the fields here are a convenience that seed
+    those env vars from config (operator-set env always wins).
+
+    ``log_format`` is honored even with no ``endpoint`` configured —
+    structured JSON console logs are useful for any log shipper.
+    """
+
+    endpoint: str = ""                      # e.g. http://localhost:4318 — empty disables
+    protocol: str = "http/protobuf"         # "http/protobuf" | "grpc"
+    headers: dict[str, str] = field(default_factory=dict)  # OTLP auth headers
+    service_name: str = "nerve"
+    traces: bool = True
+    metrics: bool = True
+    logs: bool = False                      # OTLP log export off unless asked
+    system_metrics: bool = True             # process/runtime metrics sampler
+    metric_interval_ms: int = 60000
+    log_format: str = "console"             # "console" (default) or "json"
+
+    @property
+    def enabled(self) -> bool:
+        """True only when an OTLP endpoint is configured."""
+        return bool(self.endpoint.strip())
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TelemetryConfig":
+        log_format = d.get("log_format", "console")
+        if log_format not in ("console", "json"):
+            logger.warning(
+                "telemetry.log_format %r is not one of ('console', 'json') — "
+                "falling back to 'console'", log_format,
+            )
+            log_format = "console"
+        return cls(
+            endpoint=d.get("endpoint", ""),
+            protocol=d.get("protocol", "http/protobuf"),
+            headers=dict(d.get("headers", {}) or {}),
+            service_name=d.get("service_name", "nerve"),
+            traces=bool(d.get("traces", True)),
+            metrics=bool(d.get("metrics", True)),
+            logs=bool(d.get("logs", False)),
+            system_metrics=bool(d.get("system_metrics", True)),
+            # Guard against 0/negative intervals that would break the reader.
+            metric_interval_ms=max(1000, int(d.get("metric_interval_ms", 60000))),
+            log_format=log_format,
+        )
+
+
+@dataclass
 class XmemoryConfig:
     """xmemory.ai structured memory — optional, runs alongside memU.
 
@@ -1031,6 +1089,7 @@ class NerveConfig:
     proxy: ProxyConfig = field(default_factory=ProxyConfig)
     houseofagents: HouseOfAgentsConfig = field(default_factory=HouseOfAgentsConfig)
     langfuse: LangfuseConfig = field(default_factory=LangfuseConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     xmemory: XmemoryConfig = field(default_factory=XmemoryConfig)
     mcp_endpoint: McpEndpointConfig = field(default_factory=McpEndpointConfig)
     mcp_servers: list[McpServerConfig] = field(default_factory=list)
@@ -1148,6 +1207,7 @@ class NerveConfig:
             proxy=ProxyConfig.from_dict(d.get("proxy", {})),
             houseofagents=HouseOfAgentsConfig.from_dict(d.get("houseofagents", {})),
             langfuse=LangfuseConfig.from_dict(d.get("langfuse", {})),
+            telemetry=TelemetryConfig.from_dict(d.get("telemetry", {})),
             xmemory=XmemoryConfig.from_dict(d.get("xmemory", {})),
             mcp_endpoint=McpEndpointConfig.from_dict(d.get("mcp_endpoint", {})),
             mcp_servers=_parse_mcp_servers(d),
@@ -1316,6 +1376,7 @@ _OPAQUE_PREFIXES = {
     "external_agents.targets",
     "docker.extra_mounts",
     "langfuse.redact_patterns",
+    "telemetry.headers",
 }
 
 

--- a/nerve/gateway/routes/diagnostics.py
+++ b/nerve/gateway/routes/diagnostics.py
@@ -14,6 +14,7 @@ from nerve.config import get_config
 from nerve.gateway.auth import require_auth
 from nerve.gateway.routes._deps import get_deps
 from nerve.observability.langfuse import get_status as langfuse_status
+from nerve.observability.otel import get_status as otel_status
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,7 @@ async def diagnostics(user: dict = Depends(require_auth)):
         },
         "usage": usage_data,
         "langfuse": langfuse_status(),
+        "otel": otel_status(),
     }
 
 
@@ -172,7 +174,7 @@ async def observability_status(user: dict = Depends(require_auth)):
     Kept separate from /api/diagnostics so the chat page can poll it
     without paying for the full diagnostics fan-out.
     """
-    return {"langfuse": langfuse_status()}
+    return {"langfuse": langfuse_status(), "otel": otel_status()}
 
 
 @router.post("/api/memorization/sweep")

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -36,6 +36,11 @@ from nerve.observability.langfuse import (
     flush as langfuse_flush,
     init_langfuse,
 )
+from nerve.observability import otel
+from nerve.observability.otel import (
+    init_otel,
+    shutdown as otel_shutdown,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +139,13 @@ async def lifespan(app: FastAPI):
     db = await init_db(db_path, workspace=config.workspace)
     logger.info("Database initialized at %s", db_path)
 
+    # Generic OTLP export — must be set up BEFORE init_langfuse so Nerve
+    # owns the global OTel TracerProvider. Langfuse v3 then reuses our
+    # provider (it only creates its own when the global is still a proxy),
+    # so spans fan out to both the OTLP endpoint and Langfuse. No-op when
+    # telemetry.endpoint is unset. Never raises.
+    init_otel(config)
+
     # Optional Langfuse observability — must be set up BEFORE the engine
     # creates SDK clients so the configure_claude_agent_sdk() patches are
     # in place when the SDK initializes its OTEL tracer provider. Failures
@@ -230,10 +242,12 @@ async def lifespan(app: FastAPI):
                     _memorize_stats["last_run_at"] = datetime.now(timezone.utc).isoformat()
                     _memorize_stats["last_result"] = result
                     _memorize_stats["total_runs"] += 1
+                    otel.memorize_runs.add(1)
             except Exception as e:
                 logger.error("Memorization sweep failed: %s", e)
                 _memorize_stats["total_errors"] += 1
                 _memorize_stats["last_result"] = {"error": str(e)}
+                otel.memorize_errors.add(1)
 
     memorize_task = asyncio.create_task(_periodic_memorize())
 
@@ -481,6 +495,11 @@ async def lifespan(app: FastAPI):
         await asyncio.to_thread(langfuse_flush)
     except Exception as e:
         logger.debug("Langfuse flush during shutdown failed: %s", e)
+    # Flush + shut down OTLP providers (sync, may block on the network).
+    try:
+        await asyncio.to_thread(otel_shutdown)
+    except Exception as e:
+        logger.debug("OTel shutdown failed: %s", e)
     await close_db()
     if proxy_service:
         await proxy_service.stop()
@@ -510,6 +529,15 @@ def create_app() -> FastAPI:
     # of that compresses ~3-4x. minimum_size=1024 skips tiny responses
     # where the framing overhead would dominate.
     app.add_middleware(GZipMiddleware, minimum_size=1024)
+
+    # OpenTelemetry FastAPI instrumentation (HTTP server spans + metrics).
+    # Gated on config so disabled installs pay no per-request overhead. The
+    # OTLP providers are set up later in lifespan (init_otel); the
+    # instrumentor binds to OTel's global proxy tracer/meter, which resolve
+    # to those providers once set.
+    _tel = get_config().telemetry
+    if _tel.enabled and (_tel.traces or _tel.metrics):
+        otel.instrument_app(app)
 
     # REST routes
     app.include_router(register_all_routes())

--- a/nerve/notifications/service.py
+++ b/nerve/notifications/service.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from nerve.notifications import handlers as _handlers
+from nerve.observability import otel
 
 if TYPE_CHECKING:
     from nerve.agent.engine import AgentEngine
@@ -278,6 +279,7 @@ class NotificationService:
             notification_id, session_id, "notify", title, body, priority,
             channels=channels, silent=silent,
         )
+        otel.notifications_sent.add(1)
 
         return notification_id
 

--- a/nerve/observability/__init__.py
+++ b/nerve/observability/__init__.py
@@ -1,5 +1,6 @@
 """Observability integrations.
 
-Currently houses the Langfuse adapter. Other backends (Helicone, Phoenix,
-plain OTEL collectors) can sit alongside in this package if ever needed.
+Houses the Langfuse adapter (``langfuse``) and a vendor-neutral OpenTelemetry
+OTLP exporter (``otel``). Both are optional and config-driven; they can run
+together (Langfuse reuses the OTel-provided global tracer provider).
 """

--- a/nerve/observability/otel.py
+++ b/nerve/observability/otel.py
@@ -1,0 +1,387 @@
+"""Generic OpenTelemetry (OTLP) export.
+
+Vendor-neutral counterpart to :mod:`nerve.observability.langfuse`. When
+``telemetry.endpoint`` is configured, this module sets up global OTel
+Tracer / Meter / Logger providers with OTLP exporters pointed at an
+endpoint the operator runs (a collector, or any OTLP backend). Nerve does
+not run a collector — bring your own.
+
+Activation is config-driven: empty ``endpoint`` → every entry point is a
+no-op and Nerve runs identically (the FastAPI request middleware is only
+attached when enabled, so there is zero per-request overhead).
+
+Coexistence with Langfuse
+-------------------------
+Langfuse v3 *reuses* an existing global ``TracerProvider`` if one is
+already set, only creating its own when the global is still a
+``ProxyTracerProvider``. So :func:`init_otel` MUST run before
+``init_langfuse``: Nerve installs the global provider, then Langfuse
+attaches its span processor onto it, and every span fans out to both the
+OTLP exporter and Langfuse.
+
+Failure mode
+------------
+Best-effort, like the Langfuse integration. Missing optional packages,
+a bad endpoint, or exporter errors log a warning and leave Nerve running
+with telemetry disabled — they never raise.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module state — set once by ``init_otel``. When ``_enabled`` is False every
+# public entry point short-circuits.
+# ---------------------------------------------------------------------------
+_enabled: bool = False
+_endpoint: str = ""
+_traces: bool = False
+_metrics: bool = False
+_logs: bool = False
+_tracer_provider: Any = None      # opentelemetry.sdk.trace.TracerProvider
+_meter_provider: Any = None       # opentelemetry.sdk.metrics.MeterProvider
+_logger_provider: Any = None      # opentelemetry.sdk._logs.LoggerProvider
+_log_handler: Any = None          # LoggingHandler attached to the root logger
+_last_flush_at: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# No-op instrument — lets call sites do ``otel.memorize_runs.add(1)``
+# unconditionally. Replaced with real counters in ``init_otel`` when metrics
+# are enabled.
+# ---------------------------------------------------------------------------
+class _NoopInstrument:
+    def add(self, *args: Any, **kwargs: Any) -> None:  # counters
+        pass
+
+    def record(self, *args: Any, **kwargs: Any) -> None:  # histograms
+        pass
+
+
+_NOOP = _NoopInstrument()
+
+# nerve-specific instruments (reassigned to real counters in init_otel)
+memorize_runs: Any = _NOOP
+memorize_errors: Any = _NOOP
+notifications_sent: Any = _NOOP
+agent_turns: Any = _NOOP
+
+
+def is_enabled() -> bool:
+    """Return True when OTLP export is active."""
+    return _enabled
+
+
+def get_status() -> dict[str, Any]:
+    """Status block for ``/api/diagnostics`` and the UI."""
+    return {
+        "enabled": _enabled,
+        "endpoint": _endpoint or None,
+        "traces": _traces,
+        "metrics": _metrics,
+        "logs": _logs,
+        "last_flush_at": _last_flush_at,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Exporter / reader factories — overridable so tests can inject in-memory
+# variants. Endpoint/protocol come from the standard OTEL_EXPORTER_OTLP_* env
+# vars (seeded by init_otel from config, operator env winning). ``headers``
+# is passed to the exporter constructor directly rather than via the
+# OTEL_EXPORTER_OTLP_HEADERS env var, whose comma/percent-encoded string
+# format would mangle values containing commas — see init_otel.
+# ---------------------------------------------------------------------------
+def _make_span_exporter(headers: dict | None = None) -> Any:
+    if _proto_is_grpc():
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    else:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    return OTLPSpanExporter(headers=headers) if headers else OTLPSpanExporter()
+
+
+def _make_metric_reader(interval_ms: int, headers: dict | None = None) -> Any:
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+    if _proto_is_grpc():
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+            OTLPMetricExporter,
+        )
+    else:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+            OTLPMetricExporter,
+        )
+    exporter = OTLPMetricExporter(headers=headers) if headers else OTLPMetricExporter()
+    return PeriodicExportingMetricReader(
+        exporter, export_interval_millis=interval_ms,
+    )
+
+
+def _make_log_exporter(headers: dict | None = None) -> Any:
+    if _proto_is_grpc():
+        from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+            OTLPLogExporter,
+        )
+    else:
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+            OTLPLogExporter,
+        )
+    return OTLPLogExporter(headers=headers) if headers else OTLPLogExporter()
+
+
+def _proto_is_grpc() -> bool:
+    """Effective protocol, resolved from the (already-seeded) env var."""
+    proto = os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    return proto == "grpc"
+
+
+def _service_version() -> str:
+    try:
+        from importlib.metadata import version
+        return version("nerve")
+    except Exception:
+        return "0.1.0"
+
+
+def init_otel(config: Any) -> bool:
+    """Set up global Trace/Meter/Logger providers with OTLP exporters.
+
+    Returns True when active, False when disabled (no endpoint) or on a
+    setup failure. Never raises. MUST be called before ``init_langfuse``
+    and before the agent engine / SDK clients are created.
+    """
+    global _enabled, _endpoint, _traces, _metrics, _logs
+    global _tracer_provider, _meter_provider, _logger_provider, _log_handler
+    global memorize_runs, memorize_errors, notifications_sent, agent_turns
+
+    if _enabled:
+        return True  # idempotent — providers are set-once globally
+
+    tel = getattr(config, "telemetry", None)
+    if tel is None or not getattr(tel, "enabled", False):
+        logger.info("OTel: disabled (no telemetry.endpoint configured)")
+        return False
+
+    endpoint = tel.endpoint.strip()
+
+    # Seed standard env vars (operator-set env always wins via setdefault).
+    # Headers are NOT seeded here — they're passed to exporter constructors
+    # below to avoid the OTEL_EXPORTER_OTLP_HEADERS string-encoding pitfalls.
+    os.environ.setdefault("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint)
+    os.environ.setdefault("OTEL_EXPORTER_OTLP_PROTOCOL", tel.protocol)
+    os.environ.setdefault("OTEL_SERVICE_NAME", tel.service_name)
+
+    # Resolve the EFFECTIVE protocol (env wins) and verify the exporter is
+    # available; fall back to http/protobuf so a grpc request without the
+    # grpc package degrades gracefully instead of silently dropping spans.
+    # This MUST read the env var (not tel.protocol) so the factories — which
+    # also read env via _proto_is_grpc() — and this check always agree.
+    if os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] == "grpc":
+        try:
+            import opentelemetry.exporter.otlp.proto.grpc  # noqa: F401
+        except ImportError:
+            logger.warning(
+                "OTel: protocol 'grpc' requested but opentelemetry-exporter-"
+                "otlp-proto-grpc is not installed — falling back to "
+                "'http/protobuf'.",
+            )
+            os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+
+    # Headers go to the exporter constructor directly. If the operator set
+    # OTEL_EXPORTER_OTLP_HEADERS themselves, defer to the SDK's env parsing
+    # (pass None) so we don't double-apply.
+    headers: dict | None = (
+        None
+        if "OTEL_EXPORTER_OTLP_HEADERS" in os.environ
+        else (tel.headers or None)
+    )
+
+    try:
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({
+            "service.name": tel.service_name,
+            "service.version": _service_version(),
+        })
+    except Exception as e:
+        logger.warning("OTel: failed to build resource (%s) — disabled", e)
+        return False
+
+    # --- Traces -----------------------------------------------------------
+    if tel.traces:
+        try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+            tp = TracerProvider(resource=resource)
+            tp.add_span_processor(BatchSpanProcessor(_make_span_exporter(headers)))
+            # First-call-wins globally. We run before init_langfuse, so
+            # Langfuse will reuse this provider rather than replace it.
+            trace.set_tracer_provider(tp)
+            _tracer_provider = tp
+            _traces = True
+        except Exception as e:
+            logger.warning("OTel: trace setup failed (%s)", e)
+
+    # --- Metrics ----------------------------------------------------------
+    if tel.metrics:
+        try:
+            from opentelemetry import metrics
+            from opentelemetry.sdk.metrics import MeterProvider
+
+            reader = _make_metric_reader(tel.metric_interval_ms, headers)
+            mp = MeterProvider(resource=resource, metric_readers=[reader])
+            metrics.set_meter_provider(mp)
+            _meter_provider = mp
+
+            # Bind counters to our provider directly (not the global) so they
+            # are correct even if another provider won the set-once global.
+            meter = mp.get_meter("nerve")
+            memorize_runs = meter.create_counter(
+                "nerve.memorize.runs", description="Memorization sweep runs",
+            )
+            memorize_errors = meter.create_counter(
+                "nerve.memorize.errors", description="Memorization sweep errors",
+            )
+            notifications_sent = meter.create_counter(
+                "nerve.notifications.sent", description="Notifications dispatched",
+            )
+            agent_turns = meter.create_counter(
+                "nerve.agent.turns", description="Agent run turns started",
+            )
+            # Only mark metrics live once all counters are bound, so a failure
+            # mid-setup doesn't leave a mix of real + no-op instruments.
+            _metrics = True
+
+            if tel.system_metrics:
+                try:
+                    from opentelemetry.instrumentation.system_metrics import (
+                        SystemMetricsInstrumentor,
+                    )
+                    SystemMetricsInstrumentor().instrument(meter_provider=mp)
+                except Exception as e:
+                    logger.warning("OTel: system metrics setup failed (%s)", e)
+        except Exception as e:
+            logger.warning("OTel: metric setup failed (%s)", e)
+
+    # --- Logs (opt-in) ----------------------------------------------------
+    if tel.logs:
+        try:
+            from opentelemetry._logs import set_logger_provider
+            from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+            from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+            lp = LoggerProvider(resource=resource)
+            lp.add_log_record_processor(
+                BatchLogRecordProcessor(_make_log_exporter(headers)),
+            )
+            set_logger_provider(lp)
+            _logger_provider = lp
+
+            # Route stdlib logs to OTLP as well. setup_logging() owns console
+            # formatting; this only adds an export sink.
+            handler = LoggingHandler(level=logging.NOTSET, logger_provider=lp)
+            logging.getLogger().addHandler(handler)
+            _log_handler = handler
+            _logs = True
+        except Exception as e:
+            logger.warning("OTel: log export setup failed (%s)", e)
+
+    # --- Outbound HTTP instrumentation ------------------------------------
+    if _traces:
+        try:
+            from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+            HTTPXClientInstrumentor().instrument()
+        except Exception as e:
+            logger.warning("OTel: httpx instrumentation failed (%s)", e)
+
+    if not (_traces or _metrics or _logs):
+        logger.warning("OTel: endpoint set but no signals enabled — disabled")
+        return False
+
+    _enabled = True
+    _endpoint = endpoint
+    logger.info(
+        "OTel: enabled (endpoint=%s, protocol=%s, traces=%s metrics=%s logs=%s)",
+        endpoint, os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL"),
+        _traces, _metrics, _logs,
+    )
+    return True
+
+
+def instrument_app(app: "FastAPI") -> None:
+    """Attach FastAPI server instrumentation (HTTP spans + metrics).
+
+    Called from ``create_app()`` — before the providers exist — so it relies
+    on OTel's proxy tracer/meter resolving to our providers once ``init_otel``
+    sets them in the lifespan. The caller decides whether to call this
+    (gated on ``config.telemetry.enabled``) so disabled installs pay nothing.
+    """
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        FastAPIInstrumentor.instrument_app(app)
+    except Exception as e:
+        logger.warning("OTel: FastAPI instrumentation failed (%s)", e)
+
+
+def flush(timeout_ms: int = 5000) -> None:
+    """Force-flush pending spans/metrics/logs. Safe when disabled."""
+    global _last_flush_at
+    if not _enabled:
+        return
+    ok = False
+    for provider in (_tracer_provider, _meter_provider, _logger_provider):
+        if provider is None:
+            continue
+        try:
+            provider.force_flush(timeout_millis=timeout_ms)
+            ok = True
+        except Exception as e:
+            logger.debug("OTel: force_flush failed (%s)", e)
+    if ok:
+        _last_flush_at = datetime.now(timezone.utc).isoformat()
+
+
+def shutdown(timeout_ms: int = 5000) -> None:
+    """Flush and shut down all providers. Safe when disabled. Idempotent."""
+    global _enabled, _tracer_provider, _meter_provider, _logger_provider
+    global _log_handler, memorize_runs, memorize_errors
+    global notifications_sent, agent_turns
+    if not _enabled:
+        return
+    flush(timeout_ms)
+    if _log_handler is not None:
+        try:
+            logging.getLogger().removeHandler(_log_handler)
+        except Exception:
+            pass
+    for provider in (_tracer_provider, _meter_provider, _logger_provider):
+        if provider is None:
+            continue
+        try:
+            provider.shutdown()
+        except Exception as e:
+            logger.debug("OTel: provider shutdown failed (%s)", e)
+    # Drop references to the now-dead providers and rebind counters to no-ops
+    # so nothing (flush, diagnostics, call sites) touches a shut-down provider.
+    # (Note: OTel's global tracer/meter providers are set-once per process, so
+    # re-initializing in the same process is not supported regardless.)
+    _tracer_provider = _meter_provider = _logger_provider = None
+    _log_handler = None
+    memorize_runs = memorize_errors = notifications_sent = agent_turns = _NOOP
+    # Flip the flag last so a second shutdown() is a no-op.
+    _enabled = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,18 @@ dependencies = [
     "langfuse>=3.0.0",
     "langsmith[claude-agent-sdk]>=0.4.0",
     "opentelemetry-instrumentation-anthropic>=0.40.0",
+    # Generic OTLP export (traces/metrics/logs) — active only when
+    # telemetry.endpoint is configured. opentelemetry-api/sdk + the OTLP
+    # http exporter are already pulled transitively by langfuse/langsmith;
+    # pinned here explicitly to freeze the version matrix (core 1.{N} pairs
+    # with instrumentation 0.{N}b). structlog backs the structured logging.
+    "opentelemetry-api>=1.42,<2",
+    "opentelemetry-sdk>=1.42,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.42,<2",
+    "opentelemetry-instrumentation-fastapi>=0.63b0,<1",
+    "opentelemetry-instrumentation-httpx>=0.63b0,<1",
+    "opentelemetry-instrumentation-system-metrics>=0.63b0,<1",
+    "structlog>=24.1.0",
 ]
 
 [project.scripts]

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,110 @@
+"""Tests for nerve.cli.setup_logging — structured logging via structlog.
+
+Verifies the classic console format is preserved by default and that JSON
+mode emits parseable records. Saves/restores root logger handlers so the
+global logging config isn't left mutated for other tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+import pytest
+
+from nerve import cli
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logging():
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    saved_level = root.level
+    yield
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for h in saved:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+def _format_one(record: logging.LogRecord) -> str:
+    handler = logging.getLogger().handlers[0]
+    return handler.format(record)
+
+
+def _record(level=logging.INFO, name="nerve.agent.engine", msg="session started"):
+    return logging.LogRecord(name, level, "f.py", 1, msg, None, None)
+
+
+def test_console_format_preserved():
+    cli.setup_logging(log_format="console")
+    out = _format_one(_record())
+    # HH:MM:SS [LEVEL] name: message
+    assert re.match(
+        r"^\d\d:\d\d:\d\d \[INFO\] nerve\.agent\.engine: session started",
+        out,
+    ), out
+
+
+def test_json_format():
+    cli.setup_logging(log_format="json")
+    out = _format_one(_record(level=logging.WARNING, msg="heads up"))
+    data = json.loads(out)
+    assert data["event"] == "heads up"
+    assert data["level"] == "warning"
+    assert data["logger"] == "nerve.agent.engine"
+
+
+def test_env_var_selects_json(monkeypatch):
+    monkeypatch.setenv("NERVE_LOG_FORMAT", "json")
+    cli.setup_logging()  # no explicit log_format → reads env
+    out = _format_one(_record(msg="from env"))
+    assert json.loads(out)["event"] == "from env"
+
+
+def test_idempotent_single_handler():
+    cli.setup_logging(log_format="console")
+    cli.setup_logging(log_format="console")
+    # Re-running replaces handlers rather than stacking them.
+    assert len(logging.getLogger().handlers) == 1
+
+
+def test_console_percent_style_args():
+    # The bridge must apply %-style args (record.getMessage()), not print the
+    # raw format string — the dominant logging idiom across the codebase.
+    cli.setup_logging(log_format="console")
+    rec = logging.LogRecord(
+        "nerve.test", logging.INFO, "f.py", 1, "value is %s and %d", ("hi", 7), None,
+    )
+    out = _format_one(rec)
+    assert "value is hi and 7" in out
+
+
+def test_console_includes_exception_traceback():
+    cli.setup_logging(log_format="console")
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+        rec = logging.LogRecord(
+            "nerve.test", logging.ERROR, "f.py", 1, "it failed", None, sys.exc_info(),
+        )
+    out = _format_one(rec)
+    assert "it failed" in out
+    assert "ValueError" in out and "boom" in out
+
+
+def test_json_includes_args_and_exception():
+    cli.setup_logging(log_format="json")
+    try:
+        raise RuntimeError("kaboom")
+    except RuntimeError:
+        import sys
+        rec = logging.LogRecord(
+            "nerve.test", logging.ERROR, "f.py", 1, "n=%d", (3,), sys.exc_info(),
+        )
+    data = json.loads(_format_one(rec))
+    assert data["event"] == "n=3"
+    assert "kaboom" in data["exception"]

--- a/tests/test_observability_otel.py
+++ b/tests/test_observability_otel.py
@@ -1,0 +1,330 @@
+"""Tests for nerve.observability.otel — the generic OTLP export layer.
+
+Hermetic: no network, no real OTLP endpoint. Exporters are swapped for the
+SDK's in-memory variants by monkeypatching the module's exporter factories,
+so spans/metrics/logs are captured in-process. Also covers the no-op path
+(disabled) and the Langfuse-coexistence ordering invariant.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from nerve.config import TelemetryConfig
+from nerve.observability import otel
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel_state(monkeypatch):
+    """Reset module state + clear OTEL_* env between tests."""
+    otel._enabled = False
+    otel._endpoint = ""
+    otel._traces = otel._metrics = otel._logs = False
+    otel._tracer_provider = None
+    otel._meter_provider = None
+    otel._logger_provider = None
+    # Defensively detach any OTLP log handler a prior test attached to root.
+    if otel._log_handler is not None:
+        logging.getLogger().removeHandler(otel._log_handler)
+    otel._log_handler = None
+    otel._last_flush_at = None
+    otel.memorize_runs = otel._NOOP
+    otel.memorize_errors = otel._NOOP
+    otel.notifications_sent = otel._NOOP
+    otel.agent_turns = otel._NOOP
+    for var in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_EXPORTER_OTLP_HEADERS", "OTEL_SERVICE_NAME",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+    otel._enabled = False
+
+
+def _config(**kwargs) -> SimpleNamespace:
+    cfg = SimpleNamespace()
+    cfg.telemetry = TelemetryConfig(**kwargs)
+    return cfg
+
+
+# --------------------------------------------------------------------------- #
+#  Disabled / no-op                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_disabled_when_no_endpoint():
+    assert otel.init_otel(_config()) is False
+    assert otel.is_enabled() is False
+    # No env seeded.
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ
+    # Counters remain no-ops and are safe to call.
+    otel.memorize_runs.add(1)
+    otel.notifications_sent.add(5)
+
+
+def test_get_status_disabled():
+    s = otel.get_status()
+    assert s["enabled"] is False and s["endpoint"] is None
+    assert s["traces"] is False and s["metrics"] is False and s["logs"] is False
+
+
+def test_no_config_attr():
+    assert otel.init_otel(SimpleNamespace()) is False
+
+
+# --------------------------------------------------------------------------- #
+#  Traces                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_traces_exported(monkeypatch):
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    # Use a SimpleSpanProcessor wrapping the in-memory exporter so spans are
+    # captured synchronously (no batch flush needed).
+    monkeypatch.setattr(otel, "_make_span_exporter", lambda headers=None: exporter)
+    monkeypatch.setattr(
+        "opentelemetry.sdk.trace.export.BatchSpanProcessor", SimpleSpanProcessor,
+    )
+
+    assert otel.init_otel(_config(endpoint="http://localhost:4318",
+                                  metrics=False, logs=False)) is True
+    assert otel.is_enabled() and otel._traces
+
+    tracer = otel._tracer_provider.get_tracer("test")
+    with tracer.start_as_current_span("unit-span"):
+        pass
+
+    spans = exporter.get_finished_spans()
+    assert any(s.name == "unit-span" for s in spans)
+
+
+# --------------------------------------------------------------------------- #
+#  Metrics                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_metrics_counter_recorded(monkeypatch):
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    reader = InMemoryMetricReader()
+    monkeypatch.setattr(otel, "_make_metric_reader", lambda interval_ms, headers=None: reader)
+
+    assert otel.init_otel(_config(endpoint="http://localhost:4318",
+                                  traces=False, logs=False,
+                                  system_metrics=False)) is True
+    assert otel._metrics
+
+    otel.memorize_runs.add(3)
+    otel.notifications_sent.add(1)
+
+    data = reader.get_metrics_data()
+    # Flatten metric names that recorded data points.
+    names = {
+        m.name
+        for rm in data.resource_metrics
+        for sm in rm.scope_metrics
+        for m in sm.metrics
+    }
+    assert "nerve.memorize.runs" in names
+    assert "nerve.notifications.sent" in names
+
+
+# --------------------------------------------------------------------------- #
+#  Logs                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_logs_exported_with_trace_context(monkeypatch):
+    from opentelemetry.sdk._logs.export import (
+        InMemoryLogRecordExporter,
+        SimpleLogRecordProcessor,
+    )
+
+    exporter = InMemoryLogRecordExporter()
+    monkeypatch.setattr(otel, "_make_log_exporter", lambda headers=None: exporter)
+    monkeypatch.setattr(
+        "opentelemetry.sdk._logs.export.BatchLogRecordProcessor",
+        SimpleLogRecordProcessor,
+    )
+    # Need a tracer too so a span context exists for correlation.
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+    monkeypatch.setattr(otel, "_make_span_exporter", lambda headers=None: InMemorySpanExporter())
+    monkeypatch.setattr(
+        "opentelemetry.sdk.trace.export.BatchSpanProcessor", SimpleSpanProcessor,
+    )
+
+    assert otel.init_otel(_config(endpoint="http://localhost:4318",
+                                  logs=True, metrics=False,
+                                  system_metrics=False)) is True
+    assert otel._logs
+
+    try:
+        tracer = otel._tracer_provider.get_tracer("test")
+        with tracer.start_as_current_span("log-span"):
+            logging.getLogger("nerve.test").warning("hello otel logs")
+
+        records = exporter.get_finished_logs()
+        assert any("hello otel logs" in str(r.log_record.body) for r in records)
+        # The record emitted inside the span carries a valid trace id.
+        assert any(r.log_record.trace_id for r in records)
+    finally:
+        otel.shutdown()
+
+
+# --------------------------------------------------------------------------- #
+#  Env passthrough + coexistence + status                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_env_setdefault_does_not_override(monkeypatch):
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://preset:9999")
+
+    otel.init_otel(_config(endpoint="http://localhost:4318",
+                           metrics=False, logs=False))
+    # Operator-set env wins; init must not clobber it.
+    assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://preset:9999"
+
+
+def test_coexistence_provider_is_not_proxy(monkeypatch):
+    from opentelemetry import trace
+    from opentelemetry.trace import ProxyTracerProvider
+
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    otel.init_otel(_config(endpoint="http://localhost:4318",
+                           metrics=False, logs=False))
+
+    # After init the global provider is a real SDK provider — so Langfuse v3
+    # would take its "reuse existing provider" branch rather than replace it.
+    assert not isinstance(trace.get_tracer_provider(), ProxyTracerProvider)
+    from opentelemetry.sdk.trace import TracerProvider
+    assert isinstance(otel._tracer_provider, TracerProvider)
+
+
+def test_status_enabled(monkeypatch):
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    otel.init_otel(_config(endpoint="http://localhost:4318",
+                           metrics=False, logs=False))
+    s = otel.get_status()
+    assert s["enabled"] is True
+    assert s["endpoint"] == "http://localhost:4318"
+    assert s["traces"] is True
+
+
+def test_idempotent_reinit(monkeypatch):
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    cfg = _config(endpoint="http://localhost:4318", metrics=False, logs=False)
+    assert otel.init_otel(cfg) is True
+    first_provider = otel._tracer_provider
+    # Second call short-circuits (already enabled) — no new provider.
+    assert otel.init_otel(cfg) is True
+    assert otel._tracer_provider is first_provider
+
+
+# --------------------------------------------------------------------------- #
+#  Protocol + headers (regression: review H1, H2)                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_grpc_fallback_to_http_when_unavailable(monkeypatch):
+    import importlib.util
+
+    if importlib.util.find_spec("opentelemetry.exporter.otlp.proto.grpc"):
+        pytest.skip("grpc exporter installed — fallback path not exercised")
+
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    otel.init_otel(_config(endpoint="http://localhost:4318", protocol="grpc",
+                           metrics=False, logs=False))
+    # Effective protocol must agree with what the factories read from env.
+    assert os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+
+
+def test_env_protocol_grpc_also_triggers_fallback(monkeypatch):
+    import importlib.util
+
+    if importlib.util.find_spec("opentelemetry.exporter.otlp.proto.grpc"):
+        pytest.skip("grpc exporter installed — fallback path not exercised")
+
+    # Operator sets grpc via env while config stays default http — the check
+    # must read the effective env value, not config.protocol.
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    otel.init_otel(_config(endpoint="http://localhost:4318",
+                           metrics=False, logs=False))
+    assert os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+
+
+def test_headers_passed_to_exporter_not_env(monkeypatch):
+    captured: dict = {}
+
+    def fake_span_exporter(headers=None):
+        captured["headers"] = headers
+        return _silent_span_exporter()
+
+    monkeypatch.setattr(otel, "_make_span_exporter", fake_span_exporter)
+    # A value with a comma and '=' padding — exactly what the env-string
+    # encoding would mangle.
+    hdrs = {"authorization": "Bearer a,b=="}
+    otel.init_otel(_config(endpoint="http://localhost:4318", headers=hdrs,
+                           metrics=False, logs=False))
+    assert captured["headers"] == hdrs
+    # Headers are passed via constructor, NOT serialized into the env var.
+    assert "OTEL_EXPORTER_OTLP_HEADERS" not in os.environ
+
+
+def test_headers_defer_to_operator_env(monkeypatch):
+    captured: dict = {}
+
+    def fake_span_exporter(headers=None):
+        captured["headers"] = headers
+        return _silent_span_exporter()
+
+    monkeypatch.setattr(otel, "_make_span_exporter", fake_span_exporter)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "authorization=Bearer%20x")
+    otel.init_otel(_config(endpoint="http://localhost:4318", headers={"x": "y"},
+                           metrics=False, logs=False))
+    # Operator-set env present → defer to SDK env parsing (pass None).
+    assert captured["headers"] is None
+
+
+def test_shutdown_resets_state(monkeypatch):
+    monkeypatch.setattr(otel, "_make_span_exporter",
+                        lambda headers=None: _silent_span_exporter())
+    otel.init_otel(_config(endpoint="http://localhost:4318",
+                           metrics=False, logs=False))
+    assert otel.is_enabled() and otel._tracer_provider is not None
+
+    otel.shutdown()
+    # State fully reset — no dangling references to shut-down providers.
+    assert otel.is_enabled() is False
+    assert otel._tracer_provider is None
+    assert otel._meter_provider is None and otel._logger_provider is None
+    assert otel.memorize_runs is otel._NOOP
+    assert otel.agent_turns is otel._NOOP
+    # A second shutdown is a no-op (doesn't raise).
+    otel.shutdown()
+
+
+def _silent_span_exporter():
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+    return InMemorySpanExporter()


### PR DESCRIPTION
## Summary

Adds a **vendor-neutral OpenTelemetry (OTLP)** exporter for **traces, metrics, and logs** to a user-provided endpoint, alongside the existing optional Langfuse integration. Also moves logging to **structlog** with trace correlation.

- **Off by default** — no overhead until `telemetry.endpoint` is set (mirrors the Langfuse integration's philosophy).
- **No collector packaged** — bring your own (a collector, or any OTLP backend: Grafana/Tempo, Honeycomb, Datadog, …).
- **No Prometheus** — metrics push over OTLP only.
- **Coexists with Langfuse**: `init_otel` runs before `init_langfuse`, so Nerve owns the global `TracerProvider`; Langfuse v3 reuses it and spans fan out to both.

## What's included

- **`nerve/observability/otel.py`** — `init_otel`/`instrument_app`/`flush`/`shutdown`/`get_status`. Global Tracer/Meter/Logger providers with OTLP exporters; FastAPI + httpx + system-metrics instrumentation; no-op-when-disabled `nerve.*` counters (`memorize.runs/.errors`, `notifications.sent`, `agent.turns`). Headers are passed to exporter constructors (avoids the `OTEL_EXPORTER_OTLP_HEADERS` string-encoding pitfall); effective protocol resolved from env with a graceful grpc→http fallback.
- **Structured logging** — `setup_logging` reimplemented on structlog via the stdlib `ProcessorFormatter` bridge (no call-site changes). Classic console format preserved by default; JSON via `telemetry.log_format` / `NERVE_LOG_FORMAT`; `trace_id`/`span_id` injected when a span is active; `exc_info` rendered in both renderers.
- **Config** — `TelemetryConfig` (endpoint/protocol/headers/signal toggles/log_format).
- **Diagnostics** — `otel` status on `/api/diagnostics` and `/api/observability/status`.
- **Deps** — `opentelemetry-sdk` + `-exporter-otlp-proto-http` + FastAPI/httpx/system-metrics instrumentation (pinned to the `1.42`/`0.63b` matrix Langfuse already pulls) + `structlog`.
- **Docs** — `docs/observability.md` OpenTelemetry section incl. a Privacy/PII note (the OTLP path has no redaction); `config.example.yaml` `telemetry:` block.

## Testing

- New `tests/test_observability_otel.py` + `tests/test_logging_setup.py` (22 hermetic tests, in-memory exporters): disabled no-op, traces/metrics/logs export, env passthrough, grpc fallback, header-via-constructor, Langfuse-coexistence invariant, shutdown state reset, console-format preservation, JSON, `%`-args, and `exc_info`.
- Full local run: 85 tests pass across the telemetry, config, langfuse, and notifications suites; all edited modules import cleanly.
- Two independent review passes (findings fixed: 2 High — grpc protocol resolution, header encoding; 1 Medium — shutdown state reset; plus several Low/Nit).

> Note: the repo's `uv sync` has a pre-existing Python-version conflict (`memu-py` needs >=3.13); tests were run in a 3.13 venv.

## Not yet verified
The live acceptance gate (run the server against a real OTLP collector **and** Langfuse simultaneously, confirm spans reach both) couldn't run in CI/sandbox — it's verified structurally (Langfuse's provider-reuse logic + first-init ordering + the non-proxy test). Worth one manual run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)