### PR TITLE
Add dynamic-workflow progress UI (Claude Code Workflow tool)

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -315,6 +315,14 @@ class AgentEngine:
         # task_started / task_updated / task_notification system messages:
         # session_id -> task_id -> {task_id, label, tool, status}.
         self._bg_task_registry: dict[str, dict[str, dict[str, Any]]] = {}
+        # Per-session dynamic-workflow registry: session_id -> tool_use_id ->
+        # {name, snapshot}. The tool_use_id is captured when a ``Workflow``
+        # tool call streams; later task_* system messages carrying a
+        # ``workflow_progress`` tree are matched back to it so the UI can
+        # render a live phase/agent panel. The last snapshot is cached so the
+        # terminal task_notification (which omits the tree) can still settle
+        # the panel and persist the final state.
+        self._workflows: dict[str, dict[str, dict[str, Any]]] = {}
         # Per-session active channel — set on run() entry, cleared on exit.
         # Read by session-scoped tools (send_file) to avoid dispatching via
         # stale router context from a prior inbound channel.
@@ -1869,6 +1877,16 @@ class AgentEngine:
                             description=str(tool_input.get("description", "")),
                             model=str(tool_input.get("model", "")) or None,
                         )
+                    # Track dynamic workflows.  A ``Workflow`` tool call spawns
+                    # a background runtime; later task_* system messages carry
+                    # its progress tree keyed by this tool_use_id.  Register it
+                    # now so _handle_system_message can recognize those events
+                    # even before the first ``workflow_progress`` payload.
+                    if tool_name == "Workflow" and tool_use_id:
+                        self._workflows.setdefault(session_id, {})[tool_use_id] = {
+                            "name": self._derive_workflow_name(tool_input),
+                            "snapshot": None,
+                        }
                     st.tool_calls_log.append({
                         "tool": tool_name,
                         "input": tool_input,
@@ -1991,12 +2009,148 @@ class AgentEngine:
             if not entry["label"]:
                 entry["label"] = data.get("summary") or task_id
 
+        # Dynamic-workflow progress. A workflow task is recognized either by
+        # its tool_use_id (captured when the ``Workflow`` tool streamed) or by
+        # the presence of a ``workflow_progress`` tree on the message. We emit
+        # a dedicated event so the UI can render a live phase/agent panel —
+        # independent of the coarse background-task chip above.
+        tool_use_id = data.get("tool_use_id") or getattr(message, "tool_use_id", None)
+        wf_reg = self._workflows.get(session_id) or {}
+        wp = data.get("workflow_progress")
+        is_workflow = bool(tool_use_id) and (
+            tool_use_id in wf_reg or (isinstance(wp, list) and len(wp) > 0)
+        )
+        if is_workflow:
+            entry["tool"] = "Workflow"
+            await self._emit_workflow_progress(
+                session_id, tool_use_id, subtype, data, message, wp,
+            )
+
         if changed:
             await broadcaster.broadcast(session_id, {
                 "type": "background_tasks_update",
                 "session_id": session_id,
                 "tasks": list(registry.values()),
             })
+
+    async def _emit_workflow_progress(
+        self,
+        session_id: str,
+        tool_use_id: str,
+        subtype: str,
+        data: dict,
+        message: Any,
+        wp: Any,
+    ) -> None:
+        """Build, cache, broadcast (and on terminal, persist) a workflow
+        progress snapshot for the ``Workflow`` call ``tool_use_id``."""
+        reg = self._workflows.setdefault(session_id, {})
+        cached = reg.setdefault(tool_use_id, {"name": "Workflow", "snapshot": None})
+
+        # task_progress carries the full tree; task_notification omits it, so
+        # fall back to the last cached snapshot to settle the panel.
+        if isinstance(wp, list) and wp:
+            snapshot = self._build_workflow_snapshot(wp)
+        else:
+            prev = cached.get("snapshot") or {}
+            snapshot = {
+                "phases": prev.get("phases", []),
+                "agents": prev.get("agents", []),
+                "totalTokens": prev.get("totalTokens", 0),
+                "totalToolCalls": prev.get("totalToolCalls", 0),
+                "agentCount": prev.get("agentCount", 0),
+            }
+
+        status = self._workflow_status(subtype, data, message)
+        snapshot["name"] = cached.get("name") or "Workflow"
+        snapshot["status"] = status
+        summary = (
+            data.get("summary")
+            or data.get("description")
+            or getattr(message, "summary", "")
+            or getattr(message, "description", "")
+        )
+        if summary:
+            snapshot["summary"] = str(summary)[:2000]
+
+        cached["snapshot"] = snapshot
+        await broadcaster.broadcast_workflow_progress(session_id, tool_use_id, snapshot)
+
+        if status in ("completed", "failed", "stopped"):
+            try:
+                await self.db.merge_workflow_into_call(session_id, tool_use_id, snapshot)
+            except Exception as e:  # persistence is best-effort
+                logger.debug("merge_workflow_into_call failed for %s: %s", tool_use_id, e)
+
+    @staticmethod
+    def _workflow_status(subtype: str, data: dict, message: Any) -> str:
+        """Map a task_* system message to a workflow status string
+        (running / completed / failed / stopped)."""
+        if subtype in ("task_started", "task_progress"):
+            return "running"
+        if subtype == "task_updated":
+            patch = data.get("patch") or {}
+            s = str(patch.get("status") or "")
+            if s == "killed":
+                return "stopped"
+            return s or "running"
+        if subtype == "task_notification":
+            return str(
+                data.get("status") or getattr(message, "status", "") or "completed"
+            )
+        return "running"
+
+    @staticmethod
+    def _derive_workflow_name(tool_input: Any) -> str:
+        """Best-effort workflow name: the ``name`` arg for a named workflow,
+        else ``meta.name`` parsed from an inline script, else "Workflow"."""
+        if not isinstance(tool_input, dict):
+            return "Workflow"
+        name = tool_input.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        script = tool_input.get("script")
+        if isinstance(script, str):
+            m = re.search(r"name\s*:\s*['\"]([^'\"]+)['\"]", script)
+            if m:
+                return m.group(1)
+        return "Workflow"
+
+    @staticmethod
+    def _build_workflow_snapshot(wp: list) -> dict:
+        """Normalize the CLI's flat ``workflow_progress`` list into a
+        {phases, agents, totals} snapshot for the UI."""
+        phases: list[dict] = []
+        agents: list[dict] = []
+        for e in wp:
+            if not isinstance(e, dict):
+                continue
+            etype = e.get("type")
+            if etype == "workflow_phase":
+                phases.append({"index": e.get("index"), "title": e.get("title")})
+            elif etype == "workflow_agent":
+                summary = e.get("lastToolSummary")
+                agents.append({
+                    "label": e.get("label"),
+                    "phaseIndex": e.get("phaseIndex"),
+                    "phaseTitle": e.get("phaseTitle"),
+                    "state": e.get("state"),
+                    "model": e.get("model"),
+                    "tokens": e.get("tokens"),
+                    "toolCalls": e.get("toolCalls"),
+                    "lastToolName": e.get("lastToolName"),
+                    "lastToolSummary": str(summary)[:200] if summary else None,
+                    "durationMs": e.get("durationMs"),
+                })
+        total_tokens = sum(int(a.get("tokens") or 0) for a in agents)
+        total_tool_calls = sum(int(a.get("toolCalls") or 0) for a in agents)
+        return {
+            "phases": phases,
+            "agents": agents,
+            "totalTokens": total_tokens,
+            "totalToolCalls": total_tool_calls,
+            "agentCount": len(agents),
+        }
 
     def _prune_bg_tasks(self, session_id: str) -> None:
         """Drop settled background tasks from the registry.
@@ -2005,12 +2159,24 @@ class AgentEngine:
         accumulate forever. Running tasks are kept.
         """
         registry = self._bg_task_registry.get(session_id)
-        if not registry:
-            return
-        for tid in [t for t, e in registry.items() if e.get("status") != "running"]:
-            del registry[tid]
-        if not registry:
-            self._bg_task_registry.pop(session_id, None)
+        if registry:
+            for tid in [t for t, e in registry.items() if e.get("status") != "running"]:
+                del registry[tid]
+            if not registry:
+                self._bg_task_registry.pop(session_id, None)
+
+        # Drop settled workflows too (terminal snapshot already broadcast +
+        # persisted); keep running ones so late progress still maps back.
+        wf_reg = self._workflows.get(session_id)
+        if wf_reg:
+            terminal = {"completed", "failed", "stopped"}
+            for tuid in [
+                t for t, e in wf_reg.items()
+                if (e.get("snapshot") or {}).get("status") in terminal
+            ]:
+                del wf_reg[tuid]
+            if not wf_reg:
+                self._workflows.pop(session_id, None)
 
     async def _finalize_turn(
         self, session_id: str, st: _TurnState, channel: str | None,

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -2127,6 +2127,21 @@ class AgentEngine:
         return "Workflow"
 
     @staticmethod
+    def _fold_workflow_snapshots(
+        ordered_blocks: list | None, wf_reg: dict | None,
+    ) -> None:
+        """Attach cached workflow snapshots onto their ``Workflow`` tool_call
+        blocks (in place), so a settled-within-turn workflow persists its tree."""
+        if not wf_reg or not ordered_blocks:
+            return
+        for ob in ordered_blocks:
+            if not isinstance(ob, dict) or ob.get("type") != "tool_call":
+                continue
+            snap = (wf_reg.get(ob.get("tool_use_id")) or {}).get("snapshot")
+            if snap:
+                ob["workflow"] = snap
+
+    @staticmethod
     def _build_workflow_snapshot(wp: list) -> dict:
         """Normalize the CLI's flat ``workflow_progress`` list into a
         {phases, agents, totals} snapshot for the UI."""
@@ -2200,6 +2215,13 @@ class AgentEngine:
         """
         # Merge tool results into tool_calls_log
         self._merge_tool_results(st.tool_calls_log, st.tool_results_map)
+
+        # Fold the latest dynamic-workflow snapshot onto its ``Workflow`` block
+        # so the panel reconstructs after reload. This covers workflows that
+        # settle *within* the launching turn — before the message row exists,
+        # so the out-of-band merge_workflow_into_call has nothing to patch.
+        # Longer workflows that settle after finalize are handled by that merge.
+        self._fold_workflow_snapshots(st.ordered_blocks, self._workflows.get(session_id))
 
         # Store assistant message in DB
         await self.sessions.add_message(

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -2017,11 +2017,21 @@ class AgentEngine:
         tool_use_id = data.get("tool_use_id") or getattr(message, "tool_use_id", None)
         wf_reg = self._workflows.get(session_id) or {}
         wp = data.get("workflow_progress")
+        task_type = str(data.get("task_type") or "")
         is_workflow = bool(tool_use_id) and (
-            tool_use_id in wf_reg or (isinstance(wp, list) and len(wp) > 0)
+            tool_use_id in wf_reg
+            or (isinstance(wp, list) and len(wp) > 0)
+            or "workflow" in task_type
         )
         if is_workflow:
             entry["tool"] = "Workflow"
+            # The CLI reports the workflow name on task_started — authoritative
+            # (and better than the tool-input guess for inline scripts).
+            wf_name = data.get("workflow_name")
+            if wf_name:
+                self._workflows.setdefault(session_id, {}).setdefault(
+                    tool_use_id, {"name": "Workflow", "snapshot": None},
+                )["name"] = str(wf_name)
             await self._emit_workflow_progress(
                 session_id, tool_use_id, subtype, data, message, wp,
             )

--- a/nerve/agent/streaming.py
+++ b/nerve/agent/streaming.py
@@ -246,6 +246,26 @@ class StreamBroadcaster:
             "is_error": is_error,
         })
 
+    async def broadcast_workflow_progress(
+        self,
+        session_id: str,
+        tool_use_id: str,
+        workflow: dict[str, Any],
+    ) -> None:
+        """Broadcast a dynamic-workflow progress snapshot.
+
+        ``workflow`` is the normalized progress tree (phases + agents +
+        totals + status) parsed from the CLI's ``task_progress``
+        ``workflow_progress`` payload. The UI renders it in a dedicated
+        side-panel tab keyed by ``tool_use_id`` (the Workflow tool call).
+        """
+        await self.broadcast(session_id, {
+            "type": "workflow_progress",
+            "session_id": session_id,
+            "tool_use_id": tool_use_id,
+            "workflow": workflow,
+        })
+
     async def broadcast_error(self, session_id: str, error: str) -> None:
         await self.broadcast(session_id, {"type": "error", "session_id": session_id, "error": error})
 

--- a/nerve/db/messages.py
+++ b/nerve/db/messages.py
@@ -167,6 +167,58 @@ class MessageStore:
         await self.db.commit()
         return msg_id
 
+    async def merge_workflow_into_call(
+        self,
+        session_id: str,
+        tool_use_id: str,
+        workflow: dict,
+    ) -> int | None:
+        """Attach a dynamic-workflow progress snapshot to its ``Workflow``
+        ``tool_call`` block so it survives reload.
+
+        A workflow runs in the background and can settle *after* the turn
+        that launched it was already persisted, so the snapshot is folded
+        into the stored block out-of-band (keyed by ``tool_use_id``). Unlike
+        :meth:`merge_tool_result_into_call`, normal Nerve turns store every
+        block inside a single assistant message with no per-block
+        ``external_id`` — so we locate the row by scanning recent messages
+        whose ``blocks`` JSON mentions the id.
+
+        Returns the message ``id`` that was updated, or ``None`` if no
+        matching tool_call block exists.
+        """
+        async with self.db.execute(
+            "SELECT id, blocks FROM messages "
+            "WHERE session_id = ? AND blocks LIKE ? "
+            "ORDER BY id DESC LIMIT 10",
+            (session_id, f"%{tool_use_id}%"),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        for row in rows:
+            blocks_json = row["blocks"]
+            if not blocks_json:
+                continue
+            try:
+                blocks = json.loads(blocks_json)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            updated = False
+            for b in blocks:
+                if not isinstance(b, dict):
+                    continue
+                if b.get("type") == "tool_call" and b.get("tool_use_id") == tool_use_id:
+                    b["workflow"] = workflow
+                    updated = True
+                    break
+            if updated:
+                await self.db.execute(
+                    "UPDATE messages SET blocks = ? WHERE id = ?",
+                    (json.dumps(blocks), row["id"]),
+                )
+                await self.db.commit()
+                return row["id"]
+        return None
+
     async def get_messages(
         self, session_id: str, limit: int = 500, offset: int = 0
     ) -> list[dict]:

--- a/tests/test_autonomous_turns.py
+++ b/tests/test_autonomous_turns.py
@@ -37,6 +37,7 @@ def _make_engine() -> AgentEngine:
         ),
     )
     engine._bg_task_registry = {}
+    engine._workflows = {}
     engine._idle_watchers = {}
     engine._session_locks = {}
     return engine

--- a/tests/test_autonomous_turns.py
+++ b/tests/test_autonomous_turns.py
@@ -202,6 +202,63 @@ async def test_non_task_subtypes_ignored():
     assert "s1" not in engine._bg_task_registry
 
 
+@pytest.mark.asyncio
+async def test_workflow_task_emits_progress_and_persists():
+    """A dynamic-workflow task (task_type=local_workflow, workflow_progress on
+    task_progress, terminal via task_updated) drives workflow_progress events
+    and persists the final snapshot. Shapes mirror a real captured run."""
+    engine = _make_engine()
+    engine.db = SimpleNamespace(merge_workflow_into_call=AsyncMock())
+    # _process_sdk_message would have registered the Workflow tool_use id.
+    engine._workflows["s1"] = {"wf-tool": {"name": "Workflow", "snapshot": None}}
+
+    wf_events = []
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        bc.broadcast_workflow_progress = AsyncMock(
+            side_effect=lambda sid, tid, snap: wf_events.append((tid, snap)),
+        )
+        await engine._handle_system_message("s1", SystemMessage(
+            subtype="task_started",
+            data=_sys_msg(
+                "task_started", task_id="wt", tool_use_id="wf-tool",
+                task_type="local_workflow", workflow_name="verify-ui",
+                description="tiny workflow",
+            ),
+        ))
+        await engine._handle_system_message("s1", SystemMessage(
+            subtype="task_progress",
+            data=_sys_msg(
+                "task_progress", task_id="wt", tool_use_id="wf-tool",
+                description="tiny workflow",
+                workflow_progress=[
+                    {"type": "workflow_agent", "label": "echo", "phaseIndex": 1,
+                     "phaseTitle": "Echo", "state": "running", "model": "opus",
+                     "tokens": 100, "toolCalls": 0},
+                ],
+            ),
+        ))
+        await engine._handle_system_message("s1", SystemMessage(
+            subtype="task_updated",
+            data=_sys_msg(
+                "task_updated", task_id="wt", tool_use_id="wf-tool",
+                patch={"status": "completed", "end_time": 1},
+            ),
+        ))
+
+    # Chip relabeled; workflow name captured from the CLI's workflow_name.
+    assert engine._bg_task_registry["s1"]["wt"]["tool"] == "Workflow"
+    # One progress broadcast per task message.
+    assert len(wf_events) == 3
+    tid, last = wf_events[-1]
+    assert tid == "wf-tool"
+    assert last["name"] == "verify-ui"
+    assert last["status"] == "completed"
+    assert last["agentCount"] == 1  # carried over from the progress snapshot
+    # Terminal snapshot persisted onto the Workflow block.
+    engine.db.merge_workflow_into_call.assert_awaited_once()
+
+
 def test_prune_bg_tasks_drops_settled():
     engine = _make_engine()
     engine._bg_task_registry["s1"] = {

--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -1,0 +1,146 @@
+"""Tests for dynamic-workflow (Claude Code Workflow tool) progress support:
+snapshot parsing, status mapping, name derivation, the broadcast envelope,
+and out-of-band persistence onto the Workflow tool_call block."""
+
+import pytest
+
+from nerve.agent.engine import AgentEngine
+from nerve.agent.streaming import StreamBroadcaster
+from nerve.db import Database
+
+
+# A representative ``workflow_progress`` tree as emitted by the CLI on a
+# task_progress message (flat list of phase + agent entries).
+WP_TREE = [
+    {"type": "workflow_phase", "index": 1, "title": "Scope"},
+    {"type": "workflow_phase", "index": 2, "title": "Search"},
+    {
+        "type": "workflow_agent", "label": "scope", "phaseIndex": 1,
+        "phaseTitle": "Scope", "state": "done", "model": "claude-opus-4-8",
+        "tokens": 27172, "toolCalls": 1, "lastToolName": "StructuredOutput",
+        "lastToolSummary": "x" * 400, "durationMs": 26648,
+    },
+    {
+        "type": "workflow_agent", "label": "search:a", "phaseIndex": 2,
+        "phaseTitle": "Search", "state": "running", "model": "claude-opus-4-8",
+        "tokens": 5000, "toolCalls": 3, "lastToolName": "WebSearch",
+    },
+]
+
+
+class TestBuildSnapshot:
+    def test_parses_phases_agents_and_totals(self):
+        snap = AgentEngine._build_workflow_snapshot(WP_TREE)
+        assert [p["title"] for p in snap["phases"]] == ["Scope", "Search"]
+        assert snap["agentCount"] == 2
+        assert snap["totalTokens"] == 27172 + 5000
+        assert snap["totalToolCalls"] == 1 + 3
+        # Agent fields preserved
+        a0 = snap["agents"][0]
+        assert a0["label"] == "scope"
+        assert a0["state"] == "done"
+        assert a0["phaseIndex"] == 1
+        assert a0["lastToolName"] == "StructuredOutput"
+
+    def test_truncates_long_tool_summary(self):
+        snap = AgentEngine._build_workflow_snapshot(WP_TREE)
+        assert len(snap["agents"][0]["lastToolSummary"]) == 200
+
+    def test_ignores_malformed_entries(self):
+        snap = AgentEngine._build_workflow_snapshot(
+            [None, "bad", {"type": "unknown"}, {"type": "workflow_phase", "index": 1, "title": "P"}]
+        )
+        assert snap["agentCount"] == 0
+        assert len(snap["phases"]) == 1
+
+    def test_handles_missing_token_fields(self):
+        snap = AgentEngine._build_workflow_snapshot(
+            [{"type": "workflow_agent", "label": "x", "state": "queued"}]
+        )
+        assert snap["totalTokens"] == 0
+        assert snap["totalToolCalls"] == 0
+
+
+class TestWorkflowStatus:
+    def test_started_and_progress_are_running(self):
+        assert AgentEngine._workflow_status("task_started", {}, object()) == "running"
+        assert AgentEngine._workflow_status("task_progress", {}, object()) == "running"
+
+    def test_notification_status_passes_through(self):
+        assert AgentEngine._workflow_status(
+            "task_notification", {"status": "completed"}, object()
+        ) == "completed"
+        assert AgentEngine._workflow_status(
+            "task_notification", {"status": "failed"}, object()
+        ) == "failed"
+
+    def test_updated_killed_maps_to_stopped(self):
+        assert AgentEngine._workflow_status(
+            "task_updated", {"patch": {"status": "killed"}}, object()
+        ) == "stopped"
+
+    def test_updated_without_status_stays_running(self):
+        assert AgentEngine._workflow_status(
+            "task_updated", {"patch": {"end_time": 1}}, object()
+        ) == "running"
+
+
+class TestDeriveName:
+    def test_named_workflow(self):
+        assert AgentEngine._derive_workflow_name({"name": "deep-research"}) == "deep-research"
+
+    def test_inline_script_meta_name(self):
+        script = "export const meta = {\n  name: 'find-flaky-tests',\n  description: '...'\n}"
+        assert AgentEngine._derive_workflow_name({"script": script}) == "find-flaky-tests"
+
+    def test_fallback(self):
+        assert AgentEngine._derive_workflow_name({}) == "Workflow"
+        assert AgentEngine._derive_workflow_name(None) == "Workflow"
+
+
+@pytest.mark.asyncio
+class TestBroadcastEnvelope:
+    async def test_workflow_progress_envelope(self):
+        bc = StreamBroadcaster()
+        received = []
+
+        async def handler(sid, msg):
+            received.append(msg)
+
+        await bc.register("s1", "l1", handler)
+        snap = {"name": "wf", "status": "running", "phases": [], "agents": []}
+        await bc.broadcast_workflow_progress("s1", "wf-tool-1", snap)
+
+        assert len(received) == 1
+        msg = received[0]
+        assert msg["type"] == "workflow_progress"
+        assert msg["tool_use_id"] == "wf-tool-1"
+        assert msg["workflow"] is snap
+
+
+@pytest.mark.asyncio
+class TestMergeWorkflowIntoCall:
+    async def test_merges_snapshot_onto_matching_block(self, db: Database):
+        await db.create_session("wf-sess", title="wf", source="web")
+        await db.add_message(
+            "wf-sess", "assistant", "",
+            blocks=[
+                {"type": "text", "content": "running a workflow"},
+                {"type": "tool_call", "tool": "Workflow", "tool_use_id": "wf-1", "input": {}},
+            ],
+        )
+        snap = {"name": "deep-research", "status": "completed", "phases": [], "agents": []}
+        msg_id = await db.merge_workflow_into_call("wf-sess", "wf-1", snap)
+        assert msg_id is not None
+
+        messages = await db.get_messages("wf-sess")
+        tool_block = next(b for b in messages[0]["blocks"] if b["type"] == "tool_call")
+        assert tool_block["workflow"] == snap
+
+    async def test_returns_none_when_no_matching_block(self, db: Database):
+        await db.create_session("wf-sess2", title="wf2", source="web")
+        await db.add_message(
+            "wf-sess2", "assistant", "",
+            blocks=[{"type": "tool_call", "tool": "Bash", "tool_use_id": "other", "input": {}}],
+        )
+        assert await db.merge_workflow_into_call("wf-sess2", "missing-id", {"x": 1}) is None

--- a/tests/test_workflow_progress.py
+++ b/tests/test_workflow_progress.py
@@ -98,6 +98,27 @@ class TestDeriveName:
         assert AgentEngine._derive_workflow_name(None) == "Workflow"
 
 
+class TestFoldSnapshots:
+    def test_folds_cached_snapshot_onto_workflow_block(self):
+        blocks = [
+            {"type": "text", "content": "hi"},
+            {"type": "tool_call", "tool": "Workflow", "tool_use_id": "wf-1", "input": {}},
+            {"type": "tool_call", "tool": "Bash", "tool_use_id": "b-1", "input": {}},
+        ]
+        wf_reg = {"wf-1": {"name": "x", "snapshot": {"status": "completed", "agents": []}}}
+        AgentEngine._fold_workflow_snapshots(blocks, wf_reg)
+        assert blocks[1]["workflow"] == {"status": "completed", "agents": []}
+        assert "workflow" not in blocks[2]  # non-matching block untouched
+
+    def test_noop_without_registry_or_blocks(self):
+        # Should not raise on empty/None inputs.
+        AgentEngine._fold_workflow_snapshots(None, {"wf-1": {"snapshot": {}}})
+        AgentEngine._fold_workflow_snapshots([], None)
+        blocks = [{"type": "tool_call", "tool": "Workflow", "tool_use_id": "wf-1"}]
+        AgentEngine._fold_workflow_snapshots(blocks, {"wf-1": {"snapshot": None}})
+        assert "workflow" not in blocks[0]  # cached snapshot is None → skip
+
+
 @pytest.mark.asyncio
 class TestBroadcastEnvelope:
     async def test_workflow_progress_envelope(self):

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -1,4 +1,5 @@
 import { getToken } from './client';
+import type { WorkflowSnapshot } from '../types/chat';
 
 export type WSMessage =
   | { type: 'token'; session_id: string; content: string; parent_tool_use_id?: string }
@@ -26,6 +27,7 @@ export type WSMessage =
   | { type: 'session_awaiting_input'; session_id: string; awaiting: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'failed' | 'timeout' }[] }
   | { type: 'hoa_progress'; session_id: string; event: Record<string, unknown> }
+  | { type: 'workflow_progress'; session_id: string; tool_use_id: string; workflow: WorkflowSnapshot }
   | { type: 'wakeup'; session_id: string }
   | { type: 'auto_turn'; session_id: string }
   | { type: 'pong' };

--- a/web/src/components/Chat/SidePanel.tsx
+++ b/web/src/components/Chat/SidePanel.tsx
@@ -1,10 +1,11 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
-import { X, Lightbulb, Bot, Search, Wrench, Files, Loader2, Check, Ban } from 'lucide-react';
+import { X, Lightbulb, Bot, Search, Wrench, Files, Loader2, Check, Ban, Workflow as WorkflowIcon } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 import { MarkdownContent } from './MarkdownContent';
 import { SelectionToolbar } from './SelectionToolbar';
 import { BlockRenderer } from './BlockRenderer';
 import { FileChangesPanel } from './FileChangesPanel';
+import { WorkflowPanel } from './WorkflowPanel';
 import type { PanelTab } from '../../types/chat';
 
 const TAB_ICONS: Record<string, typeof Bot> = {
@@ -12,6 +13,7 @@ const TAB_ICONS: Record<string, typeof Bot> = {
   Explore: Search,
   'general-purpose': Wrench,
   files: Files,
+  Workflow: WorkflowIcon,
 };
 
 const TAB_COLORS: Record<string, string> = {
@@ -19,6 +21,7 @@ const TAB_COLORS: Record<string, string> = {
   Explore: 'text-hue-cyan',
   'general-purpose': 'text-link',
   files: 'text-hue-teal',
+  Workflow: 'text-hue-violet',
 };
 
 function formatElapsed(startedAt: number, completedAt?: number): string {
@@ -332,7 +335,9 @@ export function SidePanel() {
       {/* Content area */}
       {activeTab.type === 'files'
         ? <FileChangesPanel />
-        : <TabContent tab={activeTab} containerRef={containerRef} />
+        : activeTab.type === 'workflow'
+          ? <WorkflowPanel tab={activeTab} />
+          : <TabContent tab={activeTab} containerRef={containerRef} />
       }
 
       {/* Footer actions (approve/decline for plans) */}

--- a/web/src/components/Chat/ToolCallBlock.tsx
+++ b/web/src/components/Chat/ToolCallBlock.tsx
@@ -12,6 +12,7 @@ import { CCTaskToolBlock } from './tools/CCTaskToolBlock';
 import { ScheduleWakeupBlock } from './tools/ScheduleWakeupBlock';
 import { SourceToolBlock } from './tools/SourceToolBlock';
 import { SubagentToolBlock } from './tools/SubagentToolBlock';
+import { WorkflowToolBlock } from './tools/WorkflowToolBlock';
 import { HoAToolBlock } from './tools/HoAToolBlock';
 import { QuestionBlock } from './tools/QuestionBlock';
 import { PlanApprovalBlock } from './tools/PlanApprovalBlock';
@@ -45,6 +46,9 @@ export function ToolCallBlock({ block }: { block: ToolCallBlockData }) {
     case 'Agent':
     case 'Task':
       return <SubagentToolBlock block={block} />;
+    // Dynamic workflow: compact card in chat; live phase/agent tree in panel.
+    case 'Workflow':
+      return <WorkflowToolBlock block={block} />;
     // Claude Code 2.1+ task tools (replacement for TodoWrite). Compact card
     // in chat; full list shown by the TaskPanel below the message stream.
     case 'TaskCreate':

--- a/web/src/components/Chat/WorkflowPanel.tsx
+++ b/web/src/components/Chat/WorkflowPanel.tsx
@@ -1,0 +1,134 @@
+import { Loader2, Check, X, Circle } from 'lucide-react';
+import { MarkdownContent } from './MarkdownContent';
+import type { PanelTab, WorkflowAgent, WorkflowSnapshot } from '../../types/chat';
+
+function fmtTokens(n?: number): string {
+  if (!n) return '';
+  return n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : String(n);
+}
+
+function fmtDuration(ms?: number): string {
+  if (!ms) return '';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  return `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+function AgentState({ state }: { state?: string }) {
+  if (state === 'running') return <Loader2 size={12} className="text-hue-amber animate-spin shrink-0" />;
+  if (state === 'done') return <Check size={12} className="text-hue-emerald shrink-0" />;
+  if (state === 'failed') return <X size={12} className="text-hue-red shrink-0" />;
+  // queued / pending / unknown
+  return <Circle size={9} className="text-text-faint shrink-0 mx-[1.5px]" />;
+}
+
+function AgentRow({ agent }: { agent: WorkflowAgent }) {
+  return (
+    <div className="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-hover/50">
+      <AgentState state={agent.state} />
+      <span className="text-[12px] text-text-secondary truncate max-w-[140px]">{agent.label || 'agent'}</span>
+      {agent.lastToolName && (
+        <span className="text-[11px] text-text-faint font-mono shrink-0">{agent.lastToolName}</span>
+      )}
+      {agent.lastToolSummary && (
+        <span className="text-[11px] text-text-dim truncate flex-1">{agent.lastToolSummary}</span>
+      )}
+      <div className="ml-auto shrink-0 flex items-center gap-2 text-[10px] text-text-faint font-mono">
+        {agent.tokens ? <span>{fmtTokens(agent.tokens)}</span> : null}
+        {agent.durationMs ? <span>{fmtDuration(agent.durationMs)}</span> : null}
+      </div>
+    </div>
+  );
+}
+
+interface PhaseGroup {
+  index: number;
+  title: string;
+  agents: WorkflowAgent[];
+}
+
+function groupByPhase(wf: WorkflowSnapshot): PhaseGroup[] {
+  const groups = new Map<number, PhaseGroup>();
+  // Seed declared phases so empty/upcoming phases still render.
+  for (const p of wf.phases) {
+    const idx = p.index ?? 0;
+    groups.set(idx, { index: idx, title: p.title || `Phase ${idx}`, agents: [] });
+  }
+  for (const a of wf.agents) {
+    const idx = a.phaseIndex ?? 0;
+    if (!groups.has(idx)) {
+      groups.set(idx, { index: idx, title: a.phaseTitle || (idx ? `Phase ${idx}` : 'Agents'), agents: [] });
+    }
+    groups.get(idx)!.agents.push(a);
+  }
+  return [...groups.values()].sort((x, y) => x.index - y.index);
+}
+
+export function WorkflowPanel({ tab }: { tab: PanelTab }) {
+  const wf = tab.workflow;
+
+  if (!wf || (wf.phases.length === 0 && wf.agents.length === 0)) {
+    return (
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="flex items-center gap-2 text-[13px] text-text-dim">
+          <Loader2 size={14} className="animate-spin" /> Starting workflow…
+        </div>
+      </div>
+    );
+  }
+
+  const groups = groupByPhase(wf);
+  const total = wf.agentCount ?? wf.agents.length;
+  const done = wf.agents.filter(a => a.state === 'done').length;
+  const running = wf.agents.filter(a => a.state === 'running').length;
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-3">
+      {/* Totals bar */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-faint font-mono mb-3 pb-2 border-b border-border-subtle">
+        <span><span className="text-text-secondary">{done}</span>/{total} agents done</span>
+        {running > 0 && <span><span className="text-hue-amber">{running}</span> running</span>}
+        <span>{wf.phases.length} phases</span>
+        {wf.totalTokens ? <span>{fmtTokens(wf.totalTokens)} tokens</span> : null}
+        {wf.totalToolCalls ? <span>{wf.totalToolCalls} tool calls</span> : null}
+      </div>
+
+      {/* Phase groups */}
+      <div className="space-y-3">
+        {groups.map(group => {
+          const gDone = group.agents.filter(a => a.state === 'done').length;
+          return (
+            <div key={group.index}>
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-[10px] uppercase tracking-wider text-text-faint">
+                  Phase {group.index}
+                </span>
+                <span className="text-[12px] font-medium text-text-secondary">{group.title}</span>
+                {group.agents.length > 0 && (
+                  <span className="text-[10px] text-text-faint font-mono ml-auto">
+                    {gDone}/{group.agents.length}
+                  </span>
+                )}
+              </div>
+              {group.agents.length > 0 ? (
+                <div className="space-y-0.5">
+                  {group.agents.map((a, i) => <AgentRow key={i} agent={a} />)}
+                </div>
+              ) : (
+                <div className="px-2 py-1 text-[11px] text-text-faint italic">pending…</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Final summary / result */}
+      {tab.content && (
+        <div className="mt-4 pt-3 border-t border-border-subtle text-[13px]">
+          <div className="text-[10px] uppercase tracking-wider text-text-faint mb-1">Result</div>
+          <MarkdownContent content={tab.content} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Chat/WorkflowPanel.tsx
+++ b/web/src/components/Chat/WorkflowPanel.tsx
@@ -88,7 +88,7 @@ export function WorkflowPanel({ tab }: { tab: PanelTab }) {
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-faint font-mono mb-3 pb-2 border-b border-border-subtle">
         <span><span className="text-text-secondary">{done}</span>/{total} agents done</span>
         {running > 0 && <span><span className="text-hue-amber">{running}</span> running</span>}
-        <span>{wf.phases.length} phases</span>
+        <span>{groups.length} phases</span>
         {wf.totalTokens ? <span>{fmtTokens(wf.totalTokens)} tokens</span> : null}
         {wf.totalToolCalls ? <span>{wf.totalToolCalls} tool calls</span> : null}
       </div>

--- a/web/src/components/Chat/tools/WorkflowToolBlock.tsx
+++ b/web/src/components/Chat/tools/WorkflowToolBlock.tsx
@@ -1,0 +1,112 @@
+import { Workflow as WorkflowIcon, Loader2, Check, X, Ban, ArrowRight } from 'lucide-react';
+import type { ToolCallBlockData, WorkflowSnapshot } from '../../../types/chat';
+import { useChatStore } from '../../../stores/chatStore';
+
+/** Current phase index (1-based) = the highest phase that has agents, biased
+ *  toward any phase with a running agent. Falls back to phases length. */
+function deriveCurrentPhase(wf: WorkflowSnapshot): number {
+  const running = wf.agents.filter(a => a.state === 'running');
+  const pool = running.length > 0 ? running : wf.agents;
+  let max = 0;
+  for (const a of pool) {
+    if (typeof a.phaseIndex === 'number' && a.phaseIndex > max) max = a.phaseIndex;
+  }
+  return max || (wf.phases.length ? 1 : 0);
+}
+
+export function WorkflowToolBlock({ block }: { block: ToolCallBlockData }) {
+  const panels = useChatStore(s => s.panels);
+  const wf = block.workflow;
+
+  const name = wf?.name || String(block.input?.name || 'Workflow');
+  const status = wf?.status || (block.status === 'running' ? 'running' : 'completed');
+  const isRunning = status === 'running';
+  const isFailed = status === 'failed';
+
+  const agents = wf?.agents || [];
+  const total = wf?.agentCount ?? agents.length;
+  const done = agents.filter(a => a.state === 'done').length;
+  const phaseCount = wf?.phases.length || 0;
+  const curPhase = wf ? deriveCurrentPhase(wf) : 0;
+  const curPhaseTitle = wf?.phases.find(p => p.index === curPhase)?.title;
+  const tokens = wf?.totalTokens || 0;
+
+  const hasTab = panels.some(p => p.id === block.toolUseId);
+
+  const handleViewInPanel = () => {
+    const store = useChatStore.getState();
+    if (hasTab) {
+      store.focusPanelTab(block.toolUseId);
+    } else {
+      store.openPanelTab({
+        id: block.toolUseId,
+        type: 'workflow',
+        label: name,
+        subagentType: 'Workflow',
+        description: '',
+        content: wf?.summary || null,
+        prompt: '',
+        streaming: false,
+        status: isFailed ? 'error' : 'complete',
+        isError: isFailed,
+        startedAt: Date.now(),
+        completedAt: Date.now(),
+        blocks: [],
+        workflow: wf,
+      });
+    }
+  };
+
+  const StatusIcon = isRunning ? (
+    <Loader2 size={14} className="text-hue-violet animate-spin shrink-0" />
+  ) : isFailed ? (
+    <X size={14} className="text-hue-red shrink-0" />
+  ) : status === 'stopped' ? (
+    <Ban size={14} className="text-text-muted shrink-0" />
+  ) : (
+    <Check size={14} className="text-hue-emerald shrink-0" />
+  );
+
+  return (
+    <div className="my-1.5 border border-violet-400/20 rounded-lg bg-surface overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2">
+        {StatusIcon}
+        <WorkflowIcon size={14} className="text-hue-violet shrink-0" />
+        <span className="text-[13px] font-medium text-text-secondary truncate">{name}</span>
+
+        {phaseCount > 0 && (
+          <span className="text-[11px] text-text-faint shrink-0">
+            phase {curPhase}/{phaseCount}{curPhaseTitle ? ` · ${curPhaseTitle}` : ''}
+          </span>
+        )}
+
+        <div className="ml-auto shrink-0 flex items-center gap-2">
+          {total > 0 && (
+            <span className="text-[11px] text-text-faint font-mono" title="agents done / total">
+              {done}/{total} agents
+            </span>
+          )}
+          {tokens > 0 && (
+            <span className="text-[11px] text-text-faint font-mono" title="total tokens">
+              {tokens >= 1000 ? `${Math.round(tokens / 1000)}k` : tokens} tok
+            </span>
+          )}
+          {(isRunning || wf) && (
+            <button
+              onClick={handleViewInPanel}
+              className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-text-dim hover:text-text-secondary cursor-pointer transition-colors rounded hover:bg-surface-raised"
+              title="View workflow in side panel"
+            >
+              View <ArrowRight size={10} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Summary line when settled */}
+      {!isRunning && wf?.summary && (
+        <div className="px-3 pb-2 text-[11px] text-text-faint truncate">{wf.summary}</div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Chat/tools/WorkflowToolBlock.tsx
+++ b/web/src/components/Chat/tools/WorkflowToolBlock.tsx
@@ -26,9 +26,16 @@ export function WorkflowToolBlock({ block }: { block: ToolCallBlockData }) {
   const agents = wf?.agents || [];
   const total = wf?.agentCount ?? agents.length;
   const done = agents.filter(a => a.state === 'done').length;
-  const phaseCount = wf?.phases.length || 0;
+  // Phase rows aren't always emitted (e.g. single-phase runs), but agents
+  // still carry phaseIndex — fall back to the distinct phases they reference.
+  const agentPhases = new Set(
+    agents.map(a => a.phaseIndex).filter((x): x is number => typeof x === 'number'),
+  );
+  const phaseCount = Math.max(wf?.phases.length || 0, agentPhases.size);
   const curPhase = wf ? deriveCurrentPhase(wf) : 0;
-  const curPhaseTitle = wf?.phases.find(p => p.index === curPhase)?.title;
+  const curPhaseTitle =
+    wf?.phases.find(p => p.index === curPhase)?.title
+    || agents.find(a => a.phaseIndex === curPhase)?.phaseTitle;
   const tokens = wf?.totalTokens || 0;
 
   const hasTab = panels.some(p => p.id === block.toolUseId);

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -10,7 +10,7 @@ import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/
 // Handlers
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError, handleWakeup, handleAutoTurn } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected } from './handlers/sessionHandlers';
-import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress } from './handlers/panelHandlers';
+import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress, handleWorkflowProgress } from './handlers/panelHandlers';
 import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
 
 export interface TodoItem {
@@ -531,6 +531,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       case 'subagent_start':     return handleSubagentStart(msg, get, set);
       case 'subagent_complete':  return handleSubagentComplete(msg, get, set);
       case 'hoa_progress':       return handleHoaProgress(msg, get, set);
+      case 'workflow_progress':  return handleWorkflowProgress(msg, get, set);
       // Auxiliary
       case 'interaction':              return handleInteraction(msg, get, set);
       case 'file_changed':             return handleFileChanged(msg, get, set);

--- a/web/src/stores/handlers/panelHandlers.ts
+++ b/web/src/stores/handlers/panelHandlers.ts
@@ -93,6 +93,80 @@ export function handleSubagentComplete(
   get().pruneCompletedTabs();
 }
 
+export function handleWorkflowProgress(
+  msg: Extract<WSMessage, { type: 'workflow_progress' }>,
+  get: Get,
+  set: Set,
+): void {
+  const state = get();
+  const wf = msg.workflow;
+  const terminal = wf.status === 'completed' || wf.status === 'failed' || wf.status === 'stopped';
+
+  // 1) Update (or open) the dedicated workflow panel tab.
+  const tab = state.panels.find(p => p.id === msg.tool_use_id);
+  if (tab) {
+    get().updatePanelTab(msg.tool_use_id, {
+      workflow: wf,
+      label: wf.name || tab.label,
+      content: terminal && wf.summary ? wf.summary : tab.content,
+      streaming: !terminal,
+      status: wf.status === 'failed' ? 'error' : terminal ? 'complete' : 'running',
+      isError: wf.status === 'failed',
+      ...(terminal ? { completedAt: Date.now() } : {}),
+    });
+  } else {
+    // No panel (pruned/closed, or progress arrived first) — recreate it.
+    get().openPanelTab({
+      id: msg.tool_use_id,
+      type: 'workflow',
+      label: wf.name || 'Workflow',
+      subagentType: 'Workflow',
+      description: '',
+      content: terminal && wf.summary ? wf.summary : null,
+      prompt: '',
+      streaming: !terminal,
+      status: wf.status === 'failed' ? 'error' : terminal ? 'complete' : 'running',
+      isError: wf.status === 'failed',
+      startedAt: Date.now(),
+      ...(terminal ? { completedAt: Date.now() } : {}),
+      blocks: [],
+      workflow: wf,
+    });
+  }
+
+  // 2) Fold the snapshot onto the Workflow tool_call block so the inline chat
+  //    card reflects progress. The workflow can settle after the launching
+  //    turn finalized, so check the live stream first, then persisted messages.
+  const inStreaming = state.streamingBlocks.some(
+    b => b.type === 'tool_call' && b.toolUseId === msg.tool_use_id,
+  );
+  if (inStreaming) {
+    set({
+      streamingBlocks: state.streamingBlocks.map(b =>
+        b.type === 'tool_call' && b.toolUseId === msg.tool_use_id
+          ? { ...b, workflow: wf }
+          : b,
+      ),
+    });
+  } else {
+    let touched = false;
+    const messages = state.messages.map(m => {
+      if (m.role !== 'assistant') return m;
+      if (!m.blocks.some(b => b.type === 'tool_call' && b.toolUseId === msg.tool_use_id)) return m;
+      touched = true;
+      return {
+        ...m,
+        blocks: m.blocks.map(b =>
+          b.type === 'tool_call' && b.toolUseId === msg.tool_use_id
+            ? { ...b, workflow: wf }
+            : b,
+        ),
+      };
+    });
+    if (touched) set({ messages });
+  }
+}
+
 export function handleHoaProgress(
   msg: Extract<WSMessage, { type: 'hoa_progress' }>,
   get: Get,

--- a/web/src/stores/handlers/streamingHandlers.ts
+++ b/web/src/stores/handlers/streamingHandlers.ts
@@ -147,6 +147,37 @@ export function handleToolUse(
     return;
   }
 
+  // Is this a dynamic-workflow launch? The Workflow tool spawns a background
+  // runtime; the chat shows a compact card and the live phase/agent tree
+  // lives in a dedicated side-panel tab keyed by this tool_use_id.
+  if (msg.tool === 'Workflow') {
+    const toolUseId = msg.tool_use_id || '';
+    const name = String(msg.input?.name || 'Workflow');
+    const blocks = [...state.streamingBlocks];
+    blocks.push({
+      type: 'tool_call',
+      toolUseId,
+      tool: msg.tool,
+      input: msg.input,
+      status: 'running',
+    });
+    set({ streamingBlocks: blocks, agentStatus: { state: 'tool', toolName: msg.tool } });
+    get().openPanelTab({
+      id: toolUseId,
+      type: 'workflow',
+      label: name,
+      subagentType: 'Workflow',
+      description: '',
+      content: null,
+      prompt: '',
+      streaming: true,
+      status: 'running',
+      startedAt: Date.now(),
+      blocks: [],
+    });
+    return;
+  }
+
   // Is this a child tool call inside a running sub-agent?
   const parentId = msg.parent_tool_use_id;
   if (parentId && state.panels.some(p => p.id === parentId && p.status === 'running')) {
@@ -193,6 +224,20 @@ export function handleToolResult(
   set: Set,
 ): void {
   const state = get();
+
+  // A Workflow tool returns immediately with its run id while the workflow
+  // keeps running in the background. Record the result on the chat card but
+  // DO NOT close the panel — it settles later via a terminal workflow_progress.
+  const workflowTab = state.panels.find(p => p.id === msg.tool_use_id && p.type === 'workflow');
+  if (workflowTab) {
+    const blocks = state.streamingBlocks.map(b =>
+      b.type === 'tool_call' && b.toolUseId === msg.tool_use_id
+        ? { ...b, result: msg.result, isError: msg.is_error, status: 'complete' as const }
+        : b
+    );
+    set({ streamingBlocks: blocks, agentStatus: { state: 'thinking' } });
+    return;
+  }
 
   // Is this a sub-agent (Task) completing?
   // Check if this tool_use_id matches a panel tab (= it's a Task result)
@@ -282,6 +327,9 @@ export function handleToolResult(
 /** Mark any still-running panel tabs as complete & schedule auto-close. */
 function finalizeRunningPanels(get: Get): void {
   for (const panel of get().panels) {
+    // Workflows run in the background past the launching turn — they settle
+    // on their own terminal workflow_progress, not when this turn ends.
+    if (panel.type === 'workflow') continue;
     if (panel.status === 'running') {
       get().updatePanelTab(panel.id, {
         status: 'complete',

--- a/web/src/stores/helpers/bufferReplay.ts
+++ b/web/src/stores/helpers/bufferReplay.ts
@@ -69,6 +69,16 @@ export function applyStreamEvent(blocks: MessageBlock[], event: WSMessage): Mess
       }
       break;
     }
+    case 'workflow_progress': {
+      for (let i = result.length - 1; i >= 0; i--) {
+        const b = result[i];
+        if (b.type === 'tool_call' && b.toolUseId === event.tool_use_id) {
+          result[i] = { ...b, workflow: event.workflow };
+          break;
+        }
+      }
+      break;
+    }
     case 'wakeup': {
       if (!result.some((b) => b.type === 'wakeup')) {
         result.unshift({ type: 'wakeup' });
@@ -97,6 +107,27 @@ export function rebuildPanelTabsFromBuffer(
   // Claude Code 2.1.x renamed the subagent tool from "Task" → "Agent"; we
   // match both so old chat history still rebuilds panels correctly.
   for (const event of events) {
+    // Dynamic-workflow launch — open a workflow tab (settled later by the
+    // workflow_progress pass below).
+    if (event.type === 'tool_use' && event.tool === 'Workflow') {
+      const toolUseId = event.tool_use_id || '';
+      const tab: PanelTab = {
+        id: toolUseId,
+        type: 'workflow',
+        label: String(event.input?.name || 'Workflow'),
+        subagentType: 'Workflow',
+        description: '',
+        content: null,
+        prompt: '',
+        streaming: true,
+        status: 'running',
+        startedAt: Date.now(),
+        blocks: [],
+      };
+      panels.push(tab);
+      panelMap.set(toolUseId, tab);
+      continue;
+    }
     if (event.type === 'tool_use' && (event.tool === 'Agent' || event.tool === 'Task')) {
       const subagentType = String(event.input?.subagent_type || event.input?.model || 'agent');
       const toolUseId = event.tool_use_id || '';
@@ -167,6 +198,22 @@ export function rebuildPanelTabsFromBuffer(
         }
       }
     }
+  }
+
+  // Third pass: settle workflow tabs from their progress snapshots (last wins).
+  for (const event of events) {
+    if (event.type !== 'workflow_progress') continue;
+    const panel = panelMap.get(event.tool_use_id);
+    if (!panel) continue;
+    const wf = event.workflow;
+    const terminal = wf.status === 'completed' || wf.status === 'failed' || wf.status === 'stopped';
+    panel.workflow = wf;
+    panel.label = wf.name || panel.label;
+    panel.status = wf.status === 'failed' ? 'error' : terminal ? 'complete' : 'running';
+    panel.streaming = !terminal;
+    panel.isError = wf.status === 'failed';
+    if (terminal && wf.summary) panel.content = wf.summary;
+    if (terminal) panel.completedAt = Date.now();
   }
 
   // Focus last running tab, or last tab overall

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -18,6 +18,41 @@ export interface ToolCallBlockData {
   status: 'running' | 'complete';
   /** houseofagents NDJSON progress events (populated during hoa_execute runs) */
   hoaEvents?: Record<string, unknown>[];
+  /** Dynamic-workflow progress snapshot (populated during Workflow runs) */
+  workflow?: WorkflowSnapshot;
+}
+
+// --- Dynamic workflow (Claude Code Workflow tool) progress ---
+
+export interface WorkflowPhase {
+  index?: number;
+  title?: string;
+}
+
+export interface WorkflowAgent {
+  label?: string;
+  phaseIndex?: number;
+  phaseTitle?: string;
+  /** queued | running | done | failed (CLI vocabulary) */
+  state?: string;
+  model?: string;
+  tokens?: number;
+  toolCalls?: number;
+  lastToolName?: string;
+  lastToolSummary?: string;
+  durationMs?: number;
+}
+
+export interface WorkflowSnapshot {
+  name: string;
+  /** running | completed | failed | stopped */
+  status: string;
+  summary?: string;
+  phases: WorkflowPhase[];
+  agents: WorkflowAgent[];
+  totalTokens?: number;
+  totalToolCalls?: number;
+  agentCount?: number;
 }
 
 export interface ImageBlockData {
@@ -84,9 +119,9 @@ export type AgentStatus =
 
 export interface PanelTab {
   id: string;              // toolUseId
-  type: 'plan' | 'subagent' | 'files';
-  label: string;           // "Plan", "Explore", "Agent", "Files"
-  subagentType: string;    // "Plan", "Explore", "general-purpose"
+  type: 'plan' | 'subagent' | 'files' | 'workflow';
+  label: string;           // "Plan", "Explore", "Agent", "Files", "Workflow"
+  subagentType: string;    // "Plan", "Explore", "general-purpose", "Workflow"
   description: string;
   model?: string;
   content: string | null;
@@ -97,6 +132,8 @@ export interface PanelTab {
   completedAt?: number;
   isError?: boolean;
   blocks: MessageBlock[];  // live sub-agent activity (same types as main chat)
+  /** For type==='workflow': the live phase/agent progress tree. */
+  workflow?: WorkflowSnapshot;
 }
 
 // --- Session modified files & diff types ---

--- a/web/src/utils/hydrateMessage.ts
+++ b/web/src/utils/hydrateMessage.ts
@@ -39,6 +39,9 @@ export function hydrateMessage(raw: any): ChatMessage {
         result: b.result,
         isError: b.is_error,
         status: 'complete' as const,
+        // Dynamic-workflow snapshot, folded into the block by the backend
+        // (merge_workflow_into_call) so the panel reconstructs after reload.
+        workflow: b.workflow,
       };
     }
     if (b.type === 'image') {


### PR DESCRIPTION
## What

Render Claude Code **dynamic-workflow** runs (the `Workflow` tool) in Nerve's UI: a compact Workflow card in chat that opens a dedicated **side-panel tab** showing the live **phase → agent tree** (per-agent state, model, last tool, tokens, duration) plus totals and the final summary.

Before this, a `Workflow` call rendered as a generic collapsed blob (the whole script as "input") plus a coarse background-task chip — the rich progress was invisible.

## Why this is small

The CLI already streams the full progress tree on `task_progress` system messages (`data["workflow_progress"]`). Nerve's engine consumed those messages for the background-task chip but **discarded the tree**. This mostly surfaces data Nerve already receives — no polling or file-tailing.

## How

**Backend**
- `streaming.broadcast_workflow_progress` — new WS event.
- `engine`: capture the `Workflow` tool_use id; in `_handle_system_message`, normalize `workflow_progress` into a `{phases, agents, totals, status}` snapshot and broadcast it. Workflow tasks are detected by tool_use_id / presence of `workflow_progress` / `task_type=local_workflow`; the name comes from the CLI's `workflow_name`.
- Persistence: `db.merge_workflow_into_call` folds the final snapshot onto the `Workflow` block out-of-band (workflows settle in the background, past the launching turn); `_fold_workflow_snapshots` at finalize covers runs that settle *within* the turn.

**Frontend**
- `WorkflowSnapshot` types; a `workflow` `PanelTab`; `handleWorkflowProgress`; buffer-replay + hydrate passthrough (survives reconnect and reload).
- New `WorkflowPanel` (phase→agent tree) and `WorkflowToolBlock` (chat card); `Workflow` routed in `ToolCallBlock`.

## Testing

- `pytest`: **1232 passed, 2 skipped** — incl. new `tests/test_workflow_progress.py` and a `_handle_system_message` workflow integration test.
- `npm run build`: clean (tsc ✓).
- **Live e2e**: ran a real 2-phase / 4-agent workflow through the running gateway — the engine parsed and broadcast the tree and the panel rendered live. The captured `task_progress` payload shape was validated against the parser (this is also how the `task_type` / `workflow_name` / terminal-via-`task_updated` behaviors were confirmed).

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*
