### PR TITLE
Fix crypto.randomUUID crash over plain HTTP (non-secure context)

### DIFF
--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -3,6 +3,7 @@ import { Send, Square, X, Plus, Trash2, Sparkles, HelpCircle, StickyNote, Paperc
 import { useChatStore } from '../../stores/chatStore';
 import type { QuoteAction, QuoteEntry } from '../../stores/chatStore';
 import { api } from '../../api/client';
+import { randomUUID } from '../../utils/uuid';
 import { PromptRewriteCard } from './PromptRewriteCard';
 
 const ACTION_CONFIG: Record<QuoteAction, { icon: typeof Plus; label: string; color: string; placeholder: string }> = {
@@ -158,7 +159,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
 
   const addFiles = useCallback(async (files: File[]) => {
     const newAttachments: AttachmentFile[] = files.map(file => ({
-      id: crypto.randomUUID(),
+      id: randomUUID(),
       file,
       preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined,
       uploading: true,

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -4,6 +4,7 @@ import { ws } from '../api/websocket';
 import type { WSMessage } from '../api/websocket';
 import type { ChatMessage, MessageBlock, Session, AgentStatus, PanelTab, ModifiedFileSummary } from '../types/chat';
 import { hydrateMessage } from '../utils/hydrateMessage';
+import { randomUUID } from '../utils/uuid';
 // Helpers
 import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './helpers/blockHelpers';
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
@@ -447,7 +448,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       if (get().activeSession !== existing.id) await get().switchSession(existing.id);
       return;
     }
-    const id = crypto.randomUUID();
+    const id = randomUUID();
     const now = new Date().toISOString();
     const virtual: Session = {
       id, title: '', source: 'web', status: 'created',

--- a/web/src/utils/uuid.ts
+++ b/web/src/utils/uuid.ts
@@ -1,0 +1,44 @@
+/**
+ * UUID generation that works in non-secure contexts.
+ *
+ * `crypto.randomUUID()` is only exposed in *secure contexts* — HTTPS or
+ * `http://localhost`. When the app is accessed over plain HTTP via a LAN
+ * hostname or IP (e.g. `http://192.168.x.x:8900` or a `.local` mDNS name),
+ * `crypto.randomUUID` is `undefined` and calling it throws
+ * `TypeError: crypto.randomUUID is not a function`.
+ *
+ * `crypto.getRandomValues()`, however, IS available in non-secure contexts,
+ * so we derive an RFC 4122 version-4 UUID from it as a fallback. As a last
+ * resort (no Web Crypto at all) we fall back to `Math.random()` — these ids
+ * are only used as client-side keys, never for anything security-sensitive.
+ */
+export function randomUUID(): string {
+  // Fast path: native, available in secure contexts.
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  // Fallback: build a v4 UUID from crypto.getRandomValues (non-secure-context safe).
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10
+    const hex: string[] = [];
+    for (let i = 0; i < 256; i++) hex.push((i + 0x100).toString(16).slice(1));
+    return (
+      hex[bytes[0]] + hex[bytes[1]] + hex[bytes[2]] + hex[bytes[3]] + '-' +
+      hex[bytes[4]] + hex[bytes[5]] + '-' +
+      hex[bytes[6]] + hex[bytes[7]] + '-' +
+      hex[bytes[8]] + hex[bytes[9]] + '-' +
+      hex[bytes[10]] + hex[bytes[11]] + hex[bytes[12]] + hex[bytes[13]] + hex[bytes[14]] + hex[bytes[15]]
+    );
+  }
+
+  // Last resort: no Web Crypto at all. Not cryptographically strong, but these
+  // ids are only client-side keys, never security-sensitive.
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
Accessing the web UI over plain HTTP via a LAN host (e.g. `http://192.168.x.x:8900` or a `.local` name) crashes with:

```
TypeError: crypto.randomUUID is not a function
```

## Cause
`crypto.randomUUID()` is only exposed in **secure contexts** — HTTPS or `http://localhost`. Over plain HTTP to any other host, `crypto.randomUUID` is `undefined`, so the two call sites that generate client-side ids throw.

## Fix
New `web/src/utils/randomUUID()` helper with graceful degradation:
1. native `crypto.randomUUID()` when available (secure context),
2. else an RFC 4122 v4 UUID built from `crypto.getRandomValues()` — which *is* available in non-secure contexts,
3. else `Math.random()` as a last resort (these ids are only client-side keys, never security-sensitive).

Wired into the two existing usages:
- `stores/chatStore.ts` — virtual session id
- `components/Chat/ChatInput.tsx` — attachment id

These were the only `crypto.randomUUID` uses; no `crypto.subtle` usage exists that would hit the same restriction.

## Testing
- `npm run build` passes (tsc + vite).

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*