### PR TITLE
Fix navigator.clipboard crash over plain HTTP (non-secure context)

### DIFF
--- a/web/src/components/Chat/CodeBlock.tsx
+++ b/web/src/components/Chat/CodeBlock.tsx
@@ -1,14 +1,16 @@
 import { useState, useRef, type ReactNode } from 'react';
 import { Copy, Check } from 'lucide-react';
+import { copyToClipboard } from '../../utils/clipboard';
 
 export function CodeBlock({ className, children }: { className?: string; children: ReactNode }) {
   const [copied, setCopied] = useState(false);
   const codeRef = useRef<HTMLElement>(null);
   const language = className?.replace(/^.*?language-/, '').replace(/\s.*$/, '') || '';
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     const text = codeRef.current?.textContent || '';
-    navigator.clipboard.writeText(text);
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -12,6 +12,7 @@ import { Loader2, PanelLeftOpen, PanelLeftClose, Files, ExternalLink } from 'luc
 import { api } from '../api/client';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import type { ShortcutDef } from '../utils/keyboard';
+import { copyToClipboard } from '../utils/clipboard';
 import type { ChatMessage, TextBlockData } from '../types/chat';
 
 const STATUS_LABELS: Record<string, string> = {
@@ -78,7 +79,7 @@ export function ChatPage() {
       section: 'chat',
       action: () => {
         const text = getLastAssistantText(useChatStore.getState().messages);
-        if (text) void navigator.clipboard.writeText(text);
+        if (text) void copyToClipboard(text);
       },
     },
     {

--- a/web/src/utils/clipboard.ts
+++ b/web/src/utils/clipboard.ts
@@ -1,0 +1,46 @@
+/**
+ * Copy text to clipboard with a fallback for non-secure contexts.
+ *
+ * `navigator.clipboard` is only exposed in *secure contexts* — HTTPS or
+ * `http://localhost`. When the app is accessed over plain HTTP via a LAN
+ * hostname or IP, or behind a proxy without a trusted cert, the entire
+ * `clipboard` object is `undefined` and any call throws synchronously.
+ *
+ * Falls back to the deprecated `document.execCommand('copy')` via a hidden
+ * off-screen `<textarea>` — still works in every browser we care about.
+ *
+ * Mirrors the same non-secure-context fallback pattern already used in
+ * `utils/uuid.ts` for `crypto.randomUUID`.
+ *
+ * @returns true on success, false on failure.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to legacy path.
+    }
+  }
+
+  if (typeof document === 'undefined') return false;
+
+  // Legacy fallback: off-screen textarea + execCommand('copy').
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '-1000px';
+  ta.style.left = '-1000px';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  try {
+    ta.select();
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(ta);
+  }
+}


### PR DESCRIPTION
## Problem

`navigator.clipboard` is only exposed in *secure contexts* — HTTPS or `http://localhost`. When the UI is accessed over plain HTTP via a LAN hostname/IP (e.g. `http://192.168.x.x:8900`, a `.local` mDNS name, a Tailscale IP with a self-signed cert, or a proxy without a trusted cert), the entire `clipboard` object is `undefined` and any call throws synchronously:

```
TypeError: Cannot read properties of undefined (reading 'writeText')
```

Two affected call sites, both silently failed without any UI feedback:

- `web/src/components/Chat/CodeBlock.tsx` — the per-code-block **Copy** button.
- `web/src/pages/ChatPage.tsx` — the `Cmd+Shift+C` **"copy last response"** keyboard shortcut.

Same root cause as #149 (which fixed `crypto.randomUUID` over plain HTTP). Both APIs gate on secure context.

## Fix

Add a shared `copyToClipboard` helper in `web/src/utils/clipboard.ts` that prefers `navigator.clipboard` when available and falls back to a hidden off-screen `<textarea>` + `document.execCommand('copy')`. `execCommand` is deprecated but still implemented in every browser we care about.

Both call sites switched to the helper. `grep` confirms no other `navigator.clipboard` usages in the frontend.

## Style

Mirrors `utils/uuid.ts` from #149 — same file naming convention, same fallback layering (native → legacy), same "client-side use, no crypto strength needed" reasoning.

## Test plan

- [x] Click code-block **Copy** button under plain HTTP — text lands in clipboard.
- [x] Press `Cmd+Shift+C` under plain HTTP — last assistant text lands in clipboard.
- [x] Under HTTPS the native `navigator.clipboard` path is taken — no behavior change.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)