### PR TITLE
Make the conversation column and session list drag-resizable

### DIFF
--- a/web/src/components/Chat/AssistantMessage.tsx
+++ b/web/src/components/Chat/AssistantMessage.tsx
@@ -4,7 +4,7 @@ import { BlockRenderer } from './BlockRenderer';
 export function AssistantMessage({ message }: { message: ChatMessage }) {
   return (
     <div className="py-4 px-5 msg-assistant" data-role="assistant">
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-[var(--chat-width)] mx-auto">
         <div className="flex gap-3">
           <div className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium shrink-0 mt-0.5 bg-accent/20 text-accent">
             N

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -379,7 +379,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
       {/* Prompt rewrite preview */}
       {rewrite.status !== 'idle' && (
         <div className="px-4 pt-3 pb-1">
-          <div className="max-w-3xl mx-auto">
+          <div className="max-w-[var(--chat-width)] mx-auto">
             <PromptRewriteCard
               state={
                 rewrite.status === 'loading' ? { status: 'loading' }
@@ -399,7 +399,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
       {/* Quote cards */}
       {quotes.length > 0 && (
         <div className="px-4 pt-3 pb-1">
-          <div className="max-w-3xl mx-auto space-y-2">
+          <div className="max-w-[var(--chat-width)] mx-auto space-y-2">
             {quotes.map((quote, idx) => (
               <QuoteCard
                 key={quote.id}
@@ -417,7 +417,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
       {/* Attachment previews */}
       {attachments.length > 0 && (
         <div className="px-4 pt-3 pb-1">
-          <div className="max-w-3xl mx-auto flex gap-2 flex-wrap">
+          <div className="max-w-[var(--chat-width)] mx-auto flex gap-2 flex-wrap">
             {attachments.map(a => (
               <AttachmentPreview key={a.id} attachment={a} onRemove={() => removeAttachment(a.id)} />
             ))}
@@ -427,7 +427,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
 
       {/* Main input */}
       <div className="px-4 py-3">
-        <div className="max-w-3xl mx-auto flex gap-3 items-end">
+        <div className="max-w-[var(--chat-width)] mx-auto flex gap-3 items-end">
           {/* File attach button */}
           <button
             onClick={() => fileInputRef.current?.click()}

--- a/web/src/components/Chat/ChatWidthHandle.tsx
+++ b/web/src/components/Chat/ChatWidthHandle.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useLayoutEffect, useState } from 'react';
+import { useChatStore } from '../../stores/chatStore';
+
+/**
+ * Drag handle that sets the width of the centered conversation reading column.
+ *
+ * The column is centered, so we grow it symmetrically: moving the handle by
+ * `dx` widens the column by `2 * dx`, which keeps it centered and makes the
+ * dragged edge track the cursor 1:1. The chosen width drives the `--chat-width`
+ * CSS variable (consumed by the message rows, todo panel, and composer via
+ * `max-w-[var(--chat-width)]`) and is persisted in the store (localStorage
+ * `nerve_chat_width`).
+ *
+ * Mirrors the side-panel resize interaction in SidePanel.tsx. Hidden below the
+ * `md` breakpoint, where the column already fills the viewport.
+ */
+export function ChatWidthHandle() {
+  const chatWidth = useChatStore((s) => s.chatWidth);
+  const setChatWidth = useChatStore((s) => s.setChatWidth);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Drive the CSS variable from the stored width. Set on the document root so
+  // it overrides the default declared in index.css (:root { --chat-width }) in
+  // one place; useLayoutEffect applies the persisted width before first paint
+  // to avoid a flash at the default width.
+  useLayoutEffect(() => {
+    document.documentElement.style.setProperty('--chat-width', `${chatWidth}px`);
+  }, [chatWidth]);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    const startX = e.clientX;
+    const startWidth = chatWidth;
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const handleMove = (moveEvent: MouseEvent) => {
+      // Centered column: grow by 2 * dx so the dragged edge tracks the cursor.
+      const dx = moveEvent.clientX - startX;
+      setChatWidth(startWidth + dx * 2);
+    };
+    const handleUp = () => {
+      setIsDragging(false);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+    };
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+  }, [chatWidth, setChatWidth]);
+
+  return (
+    <div
+      onMouseDown={handleResizeStart}
+      className="group absolute top-0 bottom-0 z-20 hidden w-3 -translate-x-1/2 cursor-col-resize md:block"
+      style={{ left: 'min(calc(50% + var(--chat-width) / 2), calc(100% - 8px))' }}
+      title="Drag to resize the conversation width"
+    >
+      <div
+        className={`absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors ${
+          isDragging ? 'bg-accent' : 'bg-transparent group-hover:bg-accent/40'
+        }`}
+      />
+    </div>
+  );
+}

--- a/web/src/components/Chat/ChatWidthHandle.tsx
+++ b/web/src/components/Chat/ChatWidthHandle.tsx
@@ -56,13 +56,21 @@ export function ChatWidthHandle() {
   return (
     <div
       onMouseDown={handleResizeStart}
-      className="group absolute top-0 bottom-0 z-20 hidden w-3 -translate-x-1/2 cursor-col-resize md:block"
+      className="group absolute top-0 bottom-0 z-20 hidden w-4 -translate-x-1/2 cursor-col-resize md:block"
       style={{ left: 'min(calc(50% + var(--chat-width) / 2), calc(100% - 8px))' }}
       title="Drag to resize the conversation width"
     >
+      {/* Full-height guide line: appears on hover/drag to show the resize axis. */}
       <div
         className={`absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors ${
-          isDragging ? 'bg-accent' : 'bg-transparent group-hover:bg-accent/40'
+          isDragging ? 'bg-accent/60' : 'bg-transparent group-hover:bg-accent/30'
+        }`}
+      />
+      {/* Persistent grip so the resize affordance is discoverable at rest;
+          brightens and grows on hover/drag. */}
+      <div
+        className={`absolute left-1/2 top-1/2 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full transition-all duration-150 ${
+          isDragging ? 'h-16 bg-accent' : 'h-10 bg-accent/40 group-hover:h-16 group-hover:bg-accent'
         }`}
       />
     </div>

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -53,8 +53,33 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { searchResults, searchLoading, searchSessions, clearSearch, renameSession, toggleStar, virtualSession, discardVirtualSession } = useChatStore();
+  const { searchResults, searchLoading, searchSessions, clearSearch, renameSession, toggleStar, virtualSession, discardVirtualSession, sidebarWidth, setSidebarWidth } = useChatStore();
   const searchFocusNonce = useChatStore(s => s.searchFocusNonce);
+
+  // Drag-to-resize the session list. It is left-anchored against the nav rail,
+  // so the width tracks the cursor 1:1. The width transition is disabled while
+  // dragging so it stays responsive.
+  const [isDragging, setIsDragging] = useState(false);
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    const startX = e.clientX;
+    const startWidth = sidebarWidth;
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    const handleMove = (ev: MouseEvent) => setSidebarWidth(startWidth + (ev.clientX - startX));
+    const handleUp = () => {
+      setIsDragging(false);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      document.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseup', handleUp);
+    };
+    document.addEventListener('mousemove', handleMove);
+    document.addEventListener('mouseup', handleUp);
+  }, [sidebarWidth, setSidebarWidth]);
 
   const isSearching = localQuery.trim().length > 0;
   const shouldShowSearch = searchHovered || searchFocused || isSearching || searchPinned;
@@ -189,7 +214,21 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
   }, [runningSystemCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div className={`bg-surface border-r border-border-subtle flex flex-col shrink-0 transition-all duration-200 overflow-hidden ${collapsed ? 'w-0 border-r-0' : 'w-60'}`}>
+    <div
+      className={`bg-surface border-r border-border-subtle flex flex-col shrink-0 overflow-hidden relative ${collapsed ? 'border-r-0' : ''} ${isDragging ? '' : 'transition-all duration-200'}`}
+      style={{ width: collapsed ? 0 : sidebarWidth }}
+    >
+      {/* Drag-to-resize handle on the right edge (hidden when collapsed). */}
+      {!collapsed && (
+        <div
+          onMouseDown={handleResizeStart}
+          className="group/resize absolute top-0 right-0 bottom-0 z-20 w-2 cursor-col-resize"
+          title="Drag to resize the session list"
+        >
+          <div className={`absolute inset-y-0 right-0 w-px transition-colors ${isDragging ? 'bg-accent' : 'bg-transparent group-hover/resize:bg-accent/50'}`} />
+        </div>
+      )}
+
       {/* Search + New chat */}
       <div className="px-2 py-1.5 border-b border-border-subtle">
         <div className="relative h-7">

--- a/web/src/components/Chat/StreamingMessage.tsx
+++ b/web/src/components/Chat/StreamingMessage.tsx
@@ -5,7 +5,7 @@ export function StreamingMessage({ blocks }: { blocks: MessageBlock[] }) {
   if (blocks.length === 0) {
     return (
       <div className="py-4 px-5 msg-assistant">
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-[var(--chat-width)] mx-auto">
           <div className="flex gap-3">
             <div className="w-7 h-7 rounded-full bg-accent/20 flex items-center justify-center text-xs font-medium text-accent shrink-0">
               N
@@ -21,7 +21,7 @@ export function StreamingMessage({ blocks }: { blocks: MessageBlock[] }) {
 
   return (
     <div className="py-4 px-5 bg-bg-sunken">
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-[var(--chat-width)] mx-auto">
         <div className="flex gap-3">
           <div className="w-7 h-7 rounded-full bg-accent/20 flex items-center justify-center text-xs font-medium text-accent shrink-0 mt-0.5">
             N

--- a/web/src/components/Chat/TodoPanel.tsx
+++ b/web/src/components/Chat/TodoPanel.tsx
@@ -99,7 +99,7 @@ export function TodoPanel({
 
   return (
     <div className={`border-t border-border-subtle bg-bg-sunken shrink-0 transition-all duration-300 ${allDone ? 'opacity-60' : ''}`}>
-      <div className="max-w-3xl mx-auto px-5 py-2.5">
+      <div className="max-w-[var(--chat-width)] mx-auto px-5 py-2.5">
         <div className="flex items-center gap-2 mb-1.5">
           <span className="text-[11px] font-medium text-text-faint uppercase tracking-wider">Tasks</span>
           <span className="text-[10px] text-text-faint">

--- a/web/src/components/Chat/UserMessage.tsx
+++ b/web/src/components/Chat/UserMessage.tsx
@@ -15,7 +15,7 @@ export function UserMessage({ message }: { message: ChatMessage }) {
 
   return (
     <div className="py-4 px-5">
-      <div className="max-w-3xl mx-auto">
+      <div className="max-w-[var(--chat-width)] mx-auto">
         <div className="flex gap-3">
           <div className="w-7 h-7 rounded-full bg-surface-raised flex items-center justify-center text-xs font-medium text-text-muted shrink-0 mt-0.5">
             U

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -52,6 +52,14 @@
   --color-hue-violet: var(--theme-hue-violet);
 }
 
+/* ── Layout (theme-independent) ── */
+:root {
+  /* Conversation reading-column max width. Defaults to the previous fixed
+     768px cap; ChatWidthHandle overrides this on :root at runtime so the
+     column is drag-resizable (persisted to localStorage 'nerve_chat_width'). */
+  --chat-width: 48rem; /* 768px */
+}
+
 /* ── Dark palette (default) ── */
 :root {
   color-scheme: dark;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -7,6 +7,7 @@ import { ChatInput } from '../components/Chat/ChatInput';
 import { ContextBar } from '../components/Chat/ContextBar';
 import { TodoPanel } from '../components/Chat/TodoPanel';
 import { SidePanel } from '../components/Chat/SidePanel';
+import { ChatWidthHandle } from '../components/Chat/ChatWidthHandle';
 import { BackgroundJobs } from '../components/Chat/BackgroundJobs';
 import { Loader2, PanelLeftOpen, PanelLeftClose, Files, ExternalLink } from 'lucide-react';
 import { api } from '../api/client';
@@ -252,15 +253,21 @@ export function ChatPage() {
             </div>
           </div>
 
-          {loading ? (
-            <div className="flex-1 flex items-center justify-center text-text-faint">Loading...</div>
-          ) : (
-            <MessageList
-              messages={messages}
-              streamingBlocks={streamingBlocks}
-              isStreaming={isStreaming}
-            />
-          )}
+          {/* Messages region: wraps the scrollable list so the width handle
+              anchors to the reading-column edge. The header and composer keep
+              their own full width. */}
+          <div className="relative flex-1 flex flex-col min-h-0">
+            {loading ? (
+              <div className="flex-1 flex items-center justify-center text-text-faint">Loading...</div>
+            ) : (
+              <MessageList
+                messages={messages}
+                streamingBlocks={streamingBlocks}
+                isStreaming={isStreaming}
+              />
+            )}
+            <ChatWidthHandle />
+          </div>
 
           <TodoPanel todos={currentTodos} ccTasks={currentCCTasks} />
 

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -106,6 +106,9 @@ interface ChatState {
   activePanelId: string | null;
   panelVisible: boolean;
   panelWidth: number;
+  // Conversation reading-column width in px (drag-resizable, persisted to
+  // localStorage 'nerve_chat_width'). Default 768 = the previous fixed cap.
+  chatWidth: number;
 
   // Pending interactive tool (AskUserQuestion, ExitPlanMode, etc.)
   pendingInteraction: {
@@ -175,6 +178,7 @@ interface ChatState {
   updatePanelTab: (tabId: string, updates: Partial<PanelTab>) => void;
   togglePanel: () => void;
   setPanelWidth: (width: number) => void;
+  setChatWidth: (width: number) => void;
   pruneCompletedTabs: () => void;
   // Interactions
   answerInteraction: (result: Record<string, string> | null) => void;
@@ -203,6 +207,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   activePanelId: null,
   panelVisible: false,
   panelWidth: parseFloat(localStorage.getItem('nerve_panel_width') || '45'),
+  chatWidth: parseFloat(localStorage.getItem('nerve_chat_width') || '768'),
   pendingInteraction: null,
   sidebarCollapsed: localStorage.getItem('nerve_sidebar_collapsed') === 'true',
   modifiedFiles: [],
@@ -283,6 +288,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const clamped = Math.max(20, Math.min(65, width));
     localStorage.setItem('nerve_panel_width', String(clamped));
     set({ panelWidth: clamped });
+  },
+
+  setChatWidth: (width: number) => {
+    // Clamp to a readable band (~60 chars min, very wide max). Mirrors the
+    // setPanelWidth persistence pattern above.
+    const clamped = Math.max(480, Math.min(2000, width));
+    localStorage.setItem('nerve_chat_width', String(clamped));
+    set({ chatWidth: clamped });
   },
 
   pruneCompletedTabs: () => {

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -109,6 +109,9 @@ interface ChatState {
   // Conversation reading-column width in px (drag-resizable, persisted to
   // localStorage 'nerve_chat_width'). Default 768 = the previous fixed cap.
   chatWidth: number;
+  // Session list (left sidebar) width in px (drag-resizable, persisted to
+  // localStorage 'nerve_sidebar_width'). Default 240 = the previous w-60.
+  sidebarWidth: number;
 
   // Pending interactive tool (AskUserQuestion, ExitPlanMode, etc.)
   pendingInteraction: {
@@ -179,6 +182,7 @@ interface ChatState {
   togglePanel: () => void;
   setPanelWidth: (width: number) => void;
   setChatWidth: (width: number) => void;
+  setSidebarWidth: (width: number) => void;
   pruneCompletedTabs: () => void;
   // Interactions
   answerInteraction: (result: Record<string, string> | null) => void;
@@ -208,6 +212,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   panelVisible: false,
   panelWidth: parseFloat(localStorage.getItem('nerve_panel_width') || '45'),
   chatWidth: parseFloat(localStorage.getItem('nerve_chat_width') || '768'),
+  sidebarWidth: parseFloat(localStorage.getItem('nerve_sidebar_width') || '240'),
   pendingInteraction: null,
   sidebarCollapsed: localStorage.getItem('nerve_sidebar_collapsed') === 'true',
   modifiedFiles: [],
@@ -296,6 +301,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const clamped = Math.max(480, Math.min(2000, width));
     localStorage.setItem('nerve_chat_width', String(clamped));
     set({ chatWidth: clamped });
+  },
+
+  setSidebarWidth: (width: number) => {
+    const clamped = Math.max(180, Math.min(480, width));
+    localStorage.setItem('nerve_sidebar_width', String(clamped));
+    set({ sidebarWidth: clamped });
   },
 
   pruneCompletedTabs: () => {


### PR DESCRIPTION
## Summary

Two parts of the chat layout had fixed widths that did not adapt to wider monitors. This makes both drag-resizable.

**Conversation column.** It was capped at a fixed 768px (`max-w-3xl`) and centered, so on a wide window the text stayed in a narrow band and only the side margins grew. A new `ChatWidthHandle` adds a grip at the column's right edge. The column is centered, so it grows symmetrically (the width changes by `2 * dx`), which keeps it centered and makes the dragged edge track the cursor 1:1. The width drives a `--chat-width` CSS variable that the message rows, todo panel, and composer all read via `max-w-[var(--chat-width)]`, so they stay aligned. Default `48rem` (768px); persisted in `localStorage` (`nerve_chat_width`), clamped 480..2000px. The grip is visible at rest and brightens on hover and drag.

**Session list (left sidebar).** It was a fixed 240px (`w-60`). A drag handle on its right edge widens or narrows the conversation list. It is left-anchored, so the width tracks the cursor 1:1. Persisted in `localStorage` (`nerve_sidebar_width`), clamped 180..480px; the width transition is disabled while dragging.

Both default to the previous fixed sizes, so nothing changes until you drag, and each handle is hidden or inert when its panel is collapsed. The column variable is set on `document.documentElement` from a layout effect rather than an inline style, since React 19's `CSSProperties` no longer accepts custom properties without a cast; the layout effect also applies the saved width before first paint, so there is no flash.

## Screenshots

Conversation column, same draft text: narrow default (768px), then dragged wider in dark and light.

![chat width before narrow dark](https://raw.githubusercontent.com/alex-fedotyev/hdx-pr-assets/main/chat-width-resize-pr-chatwidth-before-narrow-dark.png)

![chat width after wide dark](https://raw.githubusercontent.com/alex-fedotyev/hdx-pr-assets/main/chat-width-resize-pr-chatwidth-after-wide-dark.png)

![chat width after wide light](https://raw.githubusercontent.com/alex-fedotyev/hdx-pr-assets/main/chat-width-resize-pr-chatwidth-after-wide-light.png)

The grip sits at the column's right edge so it is discoverable at rest; it brightens and grows on hover and drag.

![chat width grip at rest](https://raw.githubusercontent.com/alex-fedotyev/hdx-pr-assets/main/chat-width-resize-grip-rest-768-dark.png)

## Test plan

- `npm run build` (tsc + vite) passes; `eslint` is clean on the changed files (the repo has pre-existing lint warnings elsewhere that this PR does not touch).
- Verified in the running app with Playwright (1440 to 1600px):
  - Conversation column: dragging widens and narrows it; the message rows and the composer stay aligned (measured 768 to 1168px for a 200px drag); the edge tracks the cursor 1:1; the width persists across a reload with no flash; the minimum clamps at 480px; hidden below `md`; light and dark both verified.
  - Session list: dragging the right edge widens and narrows it (measured 240 to 360px for a 120px drag, left-anchored 1:1); the width persists; clamps to 180..480px.
  - The side panel resize is untouched (`SidePanel.tsx` is not modified).

[no-story: allow] the web app has no Storybook setup.
[ui-states: allow] these are layout controls and add no new empty, loading, or error states.
