### PR TITLE
Broadcast user messages to parallel clients

### DIFF
--- a/nerve/agent/streaming.py
+++ b/nerve/agent/streaming.py
@@ -82,8 +82,13 @@ class StreamBroadcaster:
                 if not self._listeners[session_id]:
                     del self._listeners[session_id]
 
-    async def broadcast(self, session_id: str, message: dict[str, Any]) -> None:
-        """Send a message to all listeners of a session. Also buffers if active."""
+    async def broadcast(self, session_id: str, message: dict[str, Any], exclude: str | None = None) -> None:
+        """Send a message to all listeners of a session. Also buffers if active.
+
+        ``exclude`` skips the listener with that callback id — used to echo an
+        event to every client except the one that originated it (and already
+        rendered it optimistically).
+        """
         # Terminal events close the open-turn flag so the engine's
         # backstop in run() knows no synthetic "done" is needed.
         if message.get("type") in ("done", "stopped", "error"):
@@ -101,6 +106,8 @@ class StreamBroadcaster:
             listeners = list(self._listeners.get(session_id, []))
 
         for callback_id, callback in listeners:
+            if callback_id == exclude:
+                continue
             try:
                 await callback(session_id, message)
             except Exception as e:

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -606,6 +606,17 @@ def create_app() -> FastAPI:
                             _engine.db, file_ids,
                         )
 
+                    # Echo the message to every *other* client of this session so
+                    # parallel tabs render the user bubble live (the sender already
+                    # showed it optimistically). engine.run persists it, so reloads
+                    # get it from history regardless.
+                    await broadcaster.broadcast(session_id, {
+                        "type": "user_message",
+                        "session_id": session_id,
+                        "content": user_text,
+                        "blocks": image_refs or None,
+                    }, exclude=client_id)
+
                     # Run agent in background, store task for stop support
                     task = asyncio.create_task(
                         _engine.run(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -54,6 +54,23 @@ class TestBroadcaster:
         assert len(r1) == 1
         assert len(r2) == 1
 
+    async def test_broadcast_exclude_skips_origin_listener(self):
+        bc = StreamBroadcaster()
+        sender_msgs, other_msgs = [], []
+
+        async def sender(sid, msg):
+            sender_msgs.append(msg)
+
+        async def other(sid, msg):
+            other_msgs.append(msg)
+
+        await bc.register("s1", "sender", sender)
+        await bc.register("s1", "other", other)
+        await bc.broadcast("s1", {"type": "user_message"}, exclude="sender")
+
+        assert sender_msgs == []      # origin listener is skipped
+        assert len(other_msgs) == 1   # every other listener still receives
+
     async def test_failed_listener_doesnt_block(self):
         bc = StreamBroadcaster()
         received = []

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -23,6 +23,7 @@ export type WSMessage =
   | { type: 'notification'; notification_id: string; notification_type: 'notify' | 'question' | 'approval'; session_id: string; title: string; body: string; priority: string; options: string[] | null; option_labels?: Record<string, string>; target_kind?: string; target_id?: string; silenced?: boolean; silence_reason?: string; silence_pattern?: string; silenced_by?: string }
   | { type: 'notification_answered'; notification_id: string; session_id: string; answer: string; answered_by: string; approval_status?: 'answered' | 'snoozed'; dispatch_ok?: boolean }
   | { type: 'answer_injected'; session_id: string; notification_id: string; title: string; answer: string; answered_by: string; content: string }
+  | { type: 'user_message'; session_id: string; content: string; blocks?: { type: string; url?: string; filename?: string; media_type?: string; size?: number }[] | null }
   | { type: 'session_running'; session_id: string; is_running: boolean }
   | { type: 'session_awaiting_input'; session_id: string; awaiting: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'failed' | 'timeout' }[] }

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -10,7 +10,7 @@ import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
 // Handlers
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleDone, handleStopped, handleError, handleWakeup, handleAutoTurn } from './handlers/streamingHandlers';
-import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected } from './handlers/sessionHandlers';
+import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected, handleUserMessage } from './handlers/sessionHandlers';
 import { handlePlanUpdate, handleSubagentStart, handleSubagentComplete, handleHoaProgress, handleWorkflowProgress } from './handlers/panelHandlers';
 import { handleInteraction, handleFileChanged, handleNotification, handleNotificationAnswered, handleBackgroundTasksUpdate } from './handlers/auxiliaryHandlers';
 
@@ -707,6 +707,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       case 'session_running':  return handleSessionRunning(msg, get, set);
       case 'session_awaiting_input': return handleSessionAwaitingInput(msg, get, set);
       case 'answer_injected':  return handleAnswerInjected(msg, get, set);
+      case 'user_message':     return handleUserMessage(msg, get, set);
       // Panels
       case 'plan_update':        return handlePlanUpdate(msg, get, set);
       case 'subagent_start':     return handleSubagentStart(msg, get, set);

--- a/web/src/stores/handlers/sessionHandlers.ts
+++ b/web/src/stores/handlers/sessionHandlers.ts
@@ -1,6 +1,7 @@
 import type { WSMessage } from '../../api/websocket';
 import type { PanelTab } from '../../types/chat';
 import { applyStreamEvent, rebuildPanelTabsFromBuffer, deriveStatus, extractTodosFromBuffer, extractCCTasksFromBuffer } from '../helpers/bufferReplay';
+import { hydrateMessage } from '../../utils/hydrateMessage';
 import type { Get, Set } from './types';
 
 // ------------------------------------------------------------------ //
@@ -261,4 +262,17 @@ export function handleAnswerInjected(
       }],
     }));
   }
+}
+
+export function handleUserMessage(
+  msg: Extract<WSMessage, { type: 'user_message' }>,
+  get: Get,
+  set: Set,
+): void {
+  // A message sent from another client of this session — render the user
+  // bubble live. The sender is excluded server-side, so this never duplicates
+  // its own optimistic message. hydrateMessage rebuilds any image/file blocks.
+  if (msg.session_id !== get().activeSession) return;
+  const hydrated = hydrateMessage({ role: 'user', content: msg.content, blocks: msg.blocks ?? undefined });
+  set(s => ({ messages: [...s.messages, hydrated] }));
 }


### PR DESCRIPTION
## Summary
- A chat message sent from one web client was only rendered optimistically on the sender. Other connected clients — and the same user in a second tab — saw the assistant reply appear with **no preceding user bubble** until they reloaded the session.
- The inbound WS `message` handler now echoes the user's text over the session channel via a new `user_message` event, **excluding the sender** (which already showed it optimistically). Parallel clients append the bubble live; `engine.run` still persists the message, so reloads continue to source it from history.
- Adds an `exclude` argument to `StreamBroadcaster.broadcast` (skip one listener by callback id) and a unit test.

## Why
Streaming events (`token`/`tool_*`/`done`) and `session_running` already reach every client, but the user's own message text was never broadcast — only the sender optimistically rendered it. So a parallel viewer got a reply with no question.

## Dedup / correctness
- The sender is excluded by `client_id`, so it never double-renders its own optimistic bubble.
- The buffered `user_message` is ignored by `applyStreamEvent` on reconnect replay, and persisted history is the source of truth on full reload — no duplicate bubble in either path.
- Image/file messages re-render via `hydrateMessage` from the broadcast `blocks` (the persisted image refs).

## Test plan
- [ ] Open the same session in two tabs → send from tab A → tab B shows the user bubble immediately, followed by the streamed reply
- [ ] Sender tab shows exactly one bubble (no duplicate)
- [ ] Reload either tab → message present once (from history)
- [ ] Image/file message appears with attachments on the parallel client
- [ ] `pytest tests/test_streaming.py` green; `npm run build` clean

## Out of scope (audit — other parallel-client gaps found)
Not addressed here; flagging for triage. These are sidebar/REST-level and warrant their own change (some need new events):
- Manual **title rename** and **star** toggle (`PATCH /api/sessions` → `update_session`) don't broadcast — other clients' sidebars update only on reload.
- **fork** / **resume** reply to the originating client only (`websocket.send_json`), so other clients don't learn of the new/resumed session live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)