### PR TITLE
Add cron_effort to run cron/hook turns below interactive effort

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1028,9 +1028,16 @@ class AgentEngine:
             None if is_ollama_model
             else self._parse_thinking_config(self.config.agent.thinking, selected_model)
         )
+        # Cron- and hook-sourced turns are sensing / triage work that fires
+        # far more often than interactive sessions; run them at the lower
+        # cron_effort to cut token spend. Interactive sources (web, telegram,
+        # wakeup) keep the full agent.effort.
+        base_effort = self._base_effort_for_source(
+            source, self.config.agent.effort, self.config.agent.cron_effort
+        )
         effort = (
             None if is_ollama_model
-            else self._effective_effort(self.config.agent.effort, selected_model)
+            else self._effective_effort(base_effort, selected_model)
         )
         # Some subscriptions reject the context-1m beta for specific models
         # (e.g. claude-sonnet-4-6) — skip the beta header for those.
@@ -1457,6 +1464,23 @@ class AgentEngine:
         "sonnet-4-6": ("low", "medium", "high"),
     }
     _EFFORT_RANK: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
+
+    # Sources whose turns are sensing / triage work and use ``cron_effort``
+    # instead of the interactive ``effort``. Everything else (web, telegram,
+    # wakeup, ...) is treated as interactive.
+    _CRON_EFFORT_SOURCES: frozenset[str] = frozenset({"cron", "hook"})
+
+    @staticmethod
+    def _base_effort_for_source(source: str, effort: str, cron_effort: str) -> str:
+        """Pick the raw effort string for a turn based on its source.
+
+        Cron and hook turns use ``cron_effort``; interactive sources keep the
+        full ``effort``. The result is still passed through
+        :meth:`_effective_effort` for model-cap clamping.
+        """
+        if source in AgentEngine._CRON_EFFORT_SOURCES:
+            return cron_effort
+        return effort
 
     @staticmethod
     def _effective_effort(value: str, model: str | None = None) -> str | None:

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -138,6 +138,12 @@ class AgentConfig:
     max_concurrent: int = 4
     thinking: str = "max"       # max, high, medium, low, disabled, adaptive, or number (budget_tokens)
     effort: str = "max"         # max, xhigh, high, medium, low
+    # Effort for cron- and hook-sourced turns (sensing / triage work). These
+    # fire far more often than interactive sessions and rarely need Opus-tier
+    # deliberation, so they default lower than `effort` above to cut token
+    # spend. Applied in engine._build_options when source is "cron" or "hook";
+    # interactive sources (web, telegram, wakeup) keep the full `effort`.
+    cron_effort: str = "medium"  # max, xhigh, high, medium, low
     context_1m: bool = True     # Enable 1M context window beta
     # Substrings of model names for which the context-1m beta header must NOT
     # be sent (some subscriptions reject the beta for specific models — e.g.
@@ -174,6 +180,7 @@ class AgentConfig:
             max_concurrent=d.get("max_concurrent", 4),
             thinking=str(d.get("thinking", "max")),
             effort=str(d.get("effort", "max")),
+            cron_effort=str(d.get("cron_effort", "medium")),
             context_1m=d.get("context_1m", True),
             context_1m_excluded_models=list(
                 d.get("context_1m_excluded_models", []) or []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,6 +10,7 @@ import pytest
 from claude_agent_sdk import AssistantMessage
 
 from nerve.agent.engine import AgentEngine, _TurnState, _model_family
+from nerve.config import AgentConfig
 
 
 @pytest.mark.parametrize(
@@ -58,6 +59,47 @@ def test_effective_effort(value, model, expected):
 def test_effective_effort_model_default_none():
     # Signature symmetry with _parse_thinking_config
     assert AgentEngine._effective_effort("max") == "max"
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        # Interactive sources keep the full interactive effort.
+        ("web",      "max"),
+        ("telegram", "max"),
+        ("wakeup",   "max"),
+        ("api",      "max"),
+        # Cron and hook turns drop to cron_effort.
+        ("cron",     "medium"),
+        ("hook",     "medium"),
+    ],
+)
+def test_base_effort_for_source(source, expected):
+    assert AgentEngine._base_effort_for_source(source, "max", "medium") == expected
+
+
+def test_base_effort_for_source_then_capped():
+    # A cron turn at the default cron_effort stays "medium" after the model-cap
+    # pass on Sonnet 4.6 (which tops out at "high", so medium is unaffected).
+    base = AgentEngine._base_effort_for_source("cron", "max", "medium")
+    assert AgentEngine._effective_effort(base, "claude-sonnet-4-6") == "medium"
+    # Sonnet 5 is not in the cap table, so cron_effort passes through unchanged.
+    assert AgentEngine._effective_effort(base, "claude-sonnet-5") == "medium"
+    # An interactive turn keeps "max", which caps to "high" on Sonnet 4.6.
+    base = AgentEngine._base_effort_for_source("web", "max", "medium")
+    assert AgentEngine._effective_effort(base, "claude-sonnet-4-6") == "high"
+    # A cron turn whose cron_effort is left at "max" still caps to the model max.
+    base = AgentEngine._base_effort_for_source("cron", "max", "max")
+    assert AgentEngine._effective_effort(base, "claude-sonnet-4-6") == "high"
+
+
+def test_agent_config_cron_effort_default_and_override():
+    # Default is medium when unset.
+    assert AgentConfig.from_dict({}).cron_effort == "medium"
+    # Explicit value is respected, and interactive effort stays independent.
+    cfg = AgentConfig.from_dict({"cron_effort": "low"})
+    assert cfg.cron_effort == "low"
+    assert cfg.effort == "max"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Cron- and hook-sourced turns are sensing and triage work that fire far more
often than interactive sessions and rarely need the interactive model's full
reasoning depth. Today they inherit the global `agent.effort` (default `max`),
so a high-frequency job like the watcher pays top-tier effort on every quiet
tick, which is the dominant per-turn cost on those jobs.

This adds `agent.cron_effort` (default `medium`) and applies it in
`_build_options`: a turn whose `source` is `cron` or `hook` uses `cron_effort`,
while interactive sources (`web`, `telegram`, `wakeup`) keep `effort`. The
selected value still flows through `_effective_effort`, so it is clamped to the
target model's effort ladder and stays safe on models with a shorter ladder.

The source-to-effort choice is factored into a small
`_base_effort_for_source` staticmethod so the policy is unit-testable in
isolation, mirroring the existing `_effective_effort` helper.

No migration needed: `cron_effort` defaults to `medium`, and a deployment that
wants the previous behavior can set `cron_effort: max`.

## Test plan

- New unit tests in `tests/test_engine.py`:
  - `test_base_effort_for_source`: cron/hook map to `cron_effort`;
    web/telegram/wakeup/api map to `effort`.
  - `test_base_effort_for_source_then_capped`: routing composed with the
    model-cap clamp (Sonnet ladder, and pass-through for an uncapped model).
  - `test_agent_config_cron_effort_default_and_override`: `from_dict` default
    is `medium`, override respected, `effort` stays independent.
- `python3 -m pytest tests/` -> 1355 passed, 2 skipped. The only 2 failures
  are pre-existing and unrelated (docker-mode detection tests that assume the
  host is not a container); they fail identically on `main`.
