### PR TITLE
Add line-wrap toggle to the file diff panel

### DIFF
--- a/web/src/components/Chat/DiffView.tsx
+++ b/web/src/components/Chat/DiffView.tsx
@@ -15,8 +15,8 @@ function Notice({ children }: { children: React.ReactNode }) {
 //  DiffView — backend-computed file diff, rendered from a patch string //
 // ------------------------------------------------------------------ //
 
-export function DiffView({ diff }: { diff: FileDiff }) {
-  const options = useDiffOptions();
+export function DiffView({ diff, wrap }: { diff: FileDiff; wrap?: boolean }) {
+  const options = useDiffOptions({ wrap });
 
   if (diff.binary) {
     return <Notice>Binary file — diff not available</Notice>;

--- a/web/src/components/Chat/FileChangesPanel.tsx
+++ b/web/src/components/Chat/FileChangesPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, lazy, Suspense } from 'react';
-import { ArrowLeft, FilePlus, FileEdit, FileX, Loader2, RefreshCw } from 'lucide-react';
+import { ArrowLeft, FilePlus, FileEdit, FileX, Loader2, RefreshCw, WrapText } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 import { api } from '../../api/client';
 import { SelectionToolbar } from './SelectionToolbar';
@@ -79,12 +79,22 @@ function FileCard({ file, onClick }: { file: ModifiedFileSummary; onClick: () =>
 //  Detail view (loads diff on demand)                                  //
 // ------------------------------------------------------------------ //
 
+// Persisted line-wrap preference for diff inspection (shared across sessions).
+const WRAP_STORAGE_KEY = 'nerve_diff_wrap';
+
 function FileDetailView({ file, onBack }: { file: ModifiedFileSummary; onBack: () => void }) {
   const activeSession = useChatStore(s => s.activeSession);
   const [diff, setDiff] = useState<FileDiff | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [wrap, setWrap] = useState(() => localStorage.getItem(WRAP_STORAGE_KEY) === 'true');
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const toggleWrap = () => {
+    const next = !wrap;
+    setWrap(next);
+    localStorage.setItem(WRAP_STORAGE_KEY, String(next));
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -119,6 +129,16 @@ function FileDetailView({ file, onBack }: { file: ModifiedFileSummary; onBack: (
             <span className="text-diff-del">&minus;{diff.stats.deletions}</span>
           )}
         </div>
+        <button
+          onClick={toggleWrap}
+          aria-pressed={wrap}
+          className={`ml-auto w-5 h-5 flex items-center justify-center cursor-pointer transition-colors ${
+            wrap ? 'text-accent' : 'text-text-faint hover:text-text-muted'
+          }`}
+          title={wrap ? 'Disable line wrapping' : 'Enable line wrapping'}
+        >
+          <WrapText size={13} />
+        </button>
       </div>
       <div className="text-[11px] text-text-faint px-4 py-1 bg-bg-sunken border-b border-surface-raised">
         {file.short_path}
@@ -143,7 +163,7 @@ function FileDetailView({ file, onBack }: { file: ModifiedFileSummary; onBack: (
               </div>
             }
           >
-            <DiffView diff={diff} />
+            <DiffView diff={diff} wrap={wrap} />
           </Suspense>
         )}
       </div>

--- a/web/src/components/Chat/diffTheme.ts
+++ b/web/src/components/Chat/diffTheme.ts
@@ -28,8 +28,10 @@ export const DIFF_THEME_CSS = `:host {
  * Shared @pierre/diffs options for every Nerve diff render — unified layout,
  * Nerve theming, and no library file header (Nerve renders its own chrome).
  * `themeType` follows the app theme store ('system' | 'light' | 'dark').
+ * `wrap` switches long lines from horizontal scrolling (the default) to
+ * soft wrapping.
  */
-export function useDiffOptions() {
+export function useDiffOptions(opts?: { wrap?: boolean }) {
   const themeType = useThemeStore((s) => s.preference);
   return {
     diffStyle: 'unified' as const,
@@ -38,5 +40,6 @@ export function useDiffOptions() {
     disableFileHeader: true,
     diffIndicators: 'classic' as const,
     unsafeCSS: DIFF_THEME_CSS,
+    overflow: opts?.wrap ? ('wrap' as const) : ('scroll' as const),
   };
 }


### PR DESCRIPTION
Adds a line-wrapping toggle to the side panel's file diff inspector.

## What
- New `WrapText` icon button in the diff detail header — toggles long lines between horizontal scrolling (default, unchanged) and soft wrapping.
- Preference persists across sessions via `localStorage` (`nerve_diff_wrap`).
- Plumbing: `useDiffOptions()` accepts an optional `{ wrap }` flag mapped to @pierre/diffs' `overflow: 'wrap' | 'scroll'` option; `DiffView` forwards a `wrap` prop. Other diff renders (e.g. Edit tool blocks) are untouched — the no-arg call keeps the library default (`scroll`).

## Testing
- `npm run build` clean, full pytest suite passes (1349 passed).
- Verified in the browser: `data-overflow` flips `scroll` ↔ `wrap` in the diffs shadow root, long lines visibly wrap, preference survives reopening files, active state styled with `text-accent`.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*