### PR TITLE
Persistent cron rotation starts a new chat, preserving the old one

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -84,7 +84,8 @@ prompt definition.
 | `model` | string | no | Override model (default: `agent.cron_model`) |
 | `target` | string | no | Delivery channel (default: `telegram`) |
 | `session_mode` | string | no | `isolated` (new session per run), `persistent` (reuse context), or `main` |
-| `context_rotate_hours` | int | no | Hours before persistent context resets (default: 24, 0 = never) |
+| `context_rotate_hours` | int | no | Hours before a persistent job rotates to a fresh chat (default: 24, 0 = never). The old chat is preserved |
+| `context_rotate_at` | string | no | Time of day to rotate (e.g. `"04:00"`, in the configured timezone). Overrides the hours-based rotation |
 | `reminder_mode` | bool | no | Persistent only: send short reminder instead of full prompt on subsequent runs (default: false) |
 | `catchup` | bool | no | Fire once on startup if the job missed a run while the server was down (default: true) |
 | `enabled` | bool | no | Whether the job is active (default: true) |
@@ -250,11 +251,16 @@ Each run creates a fresh session (`cron:{job_id}:{timestamp}`). The agent has no
 
 ### Persistent
 
-Jobs with `session_mode: persistent` maintain SDK conversation context across runs:
+Jobs with `session_mode: persistent` maintain SDK conversation context across runs. Each job owns a **generation chat** — one session that is reused run after run until rotation:
 
-- **First trigger**: Creates a fresh session (`cron:{job_id}`) and runs the prompt.
-- **Subsequent triggers**: Resumes the same SDK session and sends the prompt as a new message. The agent sees all prior runs in-context.
-- **Context rotation**: Every `context_rotate_hours` (default: 24), the context is reset. Old messages remain in the database and are searchable via memU, but the agent starts with a clean slate.
+- **First trigger**: Creates a fresh generation session (`cron:{job_id}:{timestamp}`) and runs the prompt.
+- **Subsequent triggers**: Resumes the same SDK session and sends the prompt as a new message. The agent sees all prior runs of this generation in-context.
+- **Context rotation**: Every `context_rotate_hours` (default: 24) — or daily at `context_rotate_at` — the current chat is **retired and a brand-new chat is started**. The old chat is preserved exactly as it was: it keeps its full message history, stays browsable (and resumable) in the UI like any other session, and ages out via the normal session archival policy. Retiring also indexes the old context into memU, cancels the old session's pending wakeups (so a retired thread can't resurrect itself alongside the new one), and retitles it with its end date (`Cron: {job_id} (until 2026-07-05)`).
+
+> **Upgrade note.** Installs that predate generation chats used the stable id
+> `cron:{job_id}`. That session is adopted as the current generation on the
+> first run after upgrading — its SDK context carries over seamlessly — and
+> moves to the generation scheme on its next rotation.
 
 This is useful for jobs that benefit from accumulated context:
 - Monitoring jobs that track changes over time
@@ -262,6 +268,10 @@ This is useful for jobs that benefit from accumulated context:
 - Multi-step workflows that build on previous results
 
 Between runs, the SDK client subprocess is freed (no resource leak). On the next trigger, the SDK resumes the session from its stored state.
+
+Rotation can also be forced from the Cron page ("Rotate") or via
+`POST /api/cron/jobs/{job_id}/rotate` — same behavior: the current chat is
+preserved and the next run starts in a fresh one.
 
 #### Reminder Mode
 

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -3484,11 +3484,12 @@ class AgentEngine:
         skips live-background-task sessions for the same reason).
 
         ``keepalive_if_bg`` MUST be False for runs whose ``session_id`` is
-        reused across runs (``run_persistent_cron``'s stable ``cron:{job_id}``):
-        parking such a client would let the NEXT scheduled run reuse the same
-        client/conversation while the prior run's background task is still in
-        flight, interleaving the two. Keep-alive is only safe for the
-        unique-per-run isolated paths (``run_cron`` / ``run_hook``).
+        reused across runs (``run_persistent_cron``'s generation session,
+        reused until context rotation): parking such a client would let the
+        NEXT scheduled run reuse the same client/conversation while the
+        prior run's background task is still in flight, interleaving the
+        two. Keep-alive is only safe for the unique-per-run isolated paths
+        (``run_cron`` / ``run_hook``).
         """
         # Optimistic check: a task that settles between the watcher's last drain
         # and here still reads as live, parking a client whose work is actually
@@ -3540,19 +3541,24 @@ class AgentEngine:
         job_id: str,
         prompt: str,
         model: str | None = None,
+        session_id: str | None = None,
     ) -> str:
         """Run a persistent cron job that maintains context across runs.
 
-        Uses a stable session_id (cron:{job_id}) so the SDK resumes
-        conversation context on subsequent triggers.  The client is discarded
-        after each run to free the subprocess (sdk_session_id is preserved for
-        the next resume). Unlike the isolated one-shot paths it does NOT keep
-        the client alive for a live background task: the stable session is
-        reused by the next run, which would collide with the parked task — so a
-        persistent-cron background task that outlives its run is not resumed
-        (use an isolated cron for long background work).
+        The caller (CronService) resolves which generation chat session the
+        job currently owns and passes it as ``session_id`` — reusing it run
+        after run so the SDK resumes conversation context, and minting a
+        fresh session on context rotation (the old chat is preserved). When
+        no ``session_id`` is given, falls back to the legacy stable id
+        ``cron:{job_id}``. The client is discarded after each run to free
+        the subprocess (sdk_session_id is preserved for the next resume).
+        Unlike the isolated one-shot paths it does NOT keep the client alive
+        for a live background task: the session is reused by the next run,
+        which would collide with the parked task — so a persistent-cron
+        background task that outlives its run is not resumed (use an
+        isolated cron for long background work).
         """
-        session_id = f"cron:{job_id}"
+        session_id = session_id or f"cron:{job_id}"
         await self.sessions.get_or_create(
             session_id, title=f"Cron: {job_id}", source="cron",
         )
@@ -3564,9 +3570,9 @@ class AgentEngine:
                 model=model or self.config.agent.cron_model,
             )
         finally:
-            # Stable session_id is reused by the next run, which would collide
-            # with a parked background task — so persistent crons always discard
-            # (no keep-alive). See _teardown_oneshot_client.
+            # The session is reused by the next run (until rotation), which
+            # would collide with a parked background task — so persistent
+            # crons always discard (no keep-alive). See _teardown_oneshot_client.
             await self._teardown_oneshot_client(session_id, keepalive_if_bg=False)
 
     async def run_hook(

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -6,6 +6,7 @@ Runs cron jobs and source runners on schedule.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from datetime import datetime, timezone, tzinfo
 from typing import TYPE_CHECKING
@@ -333,57 +334,167 @@ class CronService:
 
     # -- End persistent timers ---------------------------------------------
 
-    async def _maybe_rotate_context(
-        self, session_id: str, rotate_hours: int,
-        rotate_at: str = "",
-        *,
-        force: bool = False,
-    ) -> bool:
-        """Check if a persistent cron session's context should be rotated.
+    # -- Persistent session generations --------------------------------------
+    #
+    # A persistent cron runs in a "generation" chat session. Instead of
+    # resetting the SDK context in place (which piles every context epoch
+    # into one endless chat), rotation RETIRES the current chat — keeping it
+    # and its full history as a normal browsable session — and mints a fresh
+    # chat for subsequent runs. The current generation for a job is tracked
+    # in channel_sessions under the key ``cron:{job_id}``.
 
-        Rotation clears the sdk_session_id so the next run starts a fresh
-        SDK client.  Old messages remain in the DB for memU search.
+    def _channel_key(self, job_id: str) -> str:
+        return f"cron:{job_id}"
+
+    async def _current_persistent_session_id(self, job_id: str) -> str | None:
+        """Resolve the current generation session for a persistent job.
+
+        Returns None when there is no usable current session (never ran,
+        chat deleted, or mapped session archived) — the caller mints a new
+        generation. Pre-generation installs used the stable id
+        ``cron:{job_id}`` directly; such a legacy session is adopted as the
+        current generation once, unless it was already rotated out (its
+        metadata carries ``rotated_at``).
+        """
+        key = self._channel_key(job_id)
+        row = await self.db.get_channel_session(key)
+        if row and row.get("session_id"):
+            session = await self.db.get_session(row["session_id"])
+            if session and session.get("status") != "archived":
+                return row["session_id"]
+            # Mapped chat was deleted or archived → start a new generation.
+            return None
+
+        # Legacy fallback: adopt the stable-id session from installs that
+        # predate generation chats, so their SDK context carries over.
+        legacy = await self.db.get_session(key)
+        if legacy and legacy.get("status") != "archived":
+            try:
+                meta = json.loads(legacy.get("metadata") or "{}")
+            except (TypeError, ValueError):
+                meta = {}
+            if not meta.get("rotated_at"):
+                await self.db.set_channel_session(key, key)
+                logger.info(
+                    "Adopted legacy persistent cron session %s as current "
+                    "generation", key,
+                )
+                return key
+        return None
+
+    async def _start_new_generation(self, job_id: str) -> str:
+        """Create a fresh chat session for a persistent job and map it."""
+        ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        session_id = f"cron:{job_id}:{ts}"
+        await self.engine.sessions.get_or_create(
+            session_id, title=f"Cron: {job_id}", source="cron",
+        )
+        await self.db.set_channel_session(self._channel_key(job_id), session_id)
+        logger.info(
+            "Started new chat for persistent cron %s: %s", job_id, session_id,
+        )
+        return session_id
+
+    async def _retire_session(
+        self, job_id: str, session_id: str, reason: str,
+    ) -> None:
+        """Retire a persistent cron generation, preserving its chat history.
+
+        The session row, its messages, usage, and events are left untouched —
+        the chat stays browsable (and even resumable) in the UI and ages out
+        via the normal session-archival cleanup. This only:
+
+        - schedules memU indexing of the retiring context (safety net),
+        - cancels the session's pending wakeups (a retired thread must not
+          resurrect itself alongside the new generation),
+        - stamps ``rotated_at`` in the session metadata (prevents legacy
+          re-adoption) and retitles the chat with its end date.
+        """
+        # Scheduled, not awaited: memorization queues on a global lock and
+        # awaiting it would delay the run start by the whole queue wait.
+        # The lower bound is frozen at scheduling time.
+        try:
+            await self.engine.schedule_memorize(session_id)
+        except Exception as e:
+            logger.warning(
+                "Pre-rotation memorize failed for %s: %s", session_id, e,
+            )
+
+        try:
+            cancelled = await self.db.cancel_wakeups_for_session(session_id)
+            if cancelled:
+                logger.info(
+                    "Cancelled %d pending wakeup(s) for retired cron "
+                    "session %s", cancelled, session_id,
+                )
+        except Exception as e:
+            logger.warning(
+                "Failed to cancel wakeups for %s: %s", session_id, e,
+            )
+
+        try:
+            session = await self.db.get_session(session_id) or {}
+            try:
+                meta = json.loads(session.get("metadata") or "{}")
+            except (TypeError, ValueError):
+                meta = {}
+            meta["rotated_at"] = datetime.now(timezone.utc).isoformat()
+            await self.db.update_session_metadata(session_id, meta)
+
+            date_str = datetime.now(self.timezone).strftime("%Y-%m-%d")
+            title = session.get("title") or f"Cron: {job_id}"
+            await self.db.update_session_title(
+                session_id, f"{title} (until {date_str})",
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to stamp retired session %s: %s", session_id, e,
+            )
+
+        logger.info(
+            "Retired persistent cron session %s (%s) — history preserved",
+            session_id, reason,
+        )
+
+    def _rotation_reason(
+        self, session: dict, rotate_hours: int, rotate_at: str,
+    ) -> str | None:
+        """Decide whether a generation is due for rotation.
+
+        Returns a human-readable reason string, or None when the session
+        should keep running. ``connected_at`` marks the start of the current
+        SDK context (it is preserved across resumes), so it doubles as the
+        generation's epoch.
 
         If rotate_at is set (e.g. "04:00"), rotation happens once per day
         at that local time instead of using the hours-based approach.
-
-        Returns True if rotation was performed.
         """
-        session = await self.db.get_session(session_id)
-        if not session:
-            return False
-
         now = datetime.now(timezone.utc)
-        should_rotate = force
-        reason = "manual" if force else ""
 
-        connected_at = None
         connected_at_str = session.get("connected_at")
-        if connected_at_str:
-            try:
-                ts = connected_at_str
-                if "T" not in ts:
-                    ts = ts.replace(" ", "T")
-                if not ts.endswith(("Z", "+00:00")):
-                    ts += "+00:00"
-                connected_at = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid connected_at for %s: %s", session_id, connected_at_str,
-                )
-                if not force:
-                    return False
-        elif not force:
-            return False
+        if not connected_at_str:
+            return None
+        try:
+            ts = connected_at_str
+            if "T" not in ts:
+                ts = ts.replace(" ", "T")
+            if not ts.endswith(("Z", "+00:00")):
+                ts += "+00:00"
+            connected_at = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Invalid connected_at for cron session: %s", connected_at_str,
+            )
+            return None
 
-        if not should_rotate and rotate_at:
+        if rotate_at:
             # Time-of-day rotation: rotate if session started before today's
             # rotate_at and current time is past it.
             try:
                 hour, minute = (int(x) for x in rotate_at.split(":"))
             except (ValueError, TypeError):
                 logger.warning("Invalid context_rotate_at: %s", rotate_at)
-                return False
+                return None
 
             today_rotate = now.astimezone(self.timezone).replace(
                 hour=hour, minute=minute, second=0, microsecond=0,
@@ -391,34 +502,39 @@ class CronService:
             today_rotate_utc = today_rotate.astimezone(timezone.utc)
 
             if now >= today_rotate_utc and connected_at < today_rotate_utc:
-                should_rotate = True
-                reason = f"rotate_at={rotate_at}"
-        elif not should_rotate and rotate_hours > 0:
+                return f"rotate_at={rotate_at}"
+        elif rotate_hours > 0:
             age_hours = (now - connected_at).total_seconds() / 3600
             if age_hours >= rotate_hours:
-                should_rotate = True
-                reason = f"age {age_hours:.1f}h >= {rotate_hours}h"
+                return f"age {age_hours:.1f}h >= {rotate_hours}h"
+        return None
 
-        if not should_rotate:
-            return False
+    async def _resolve_persistent_session(self, job: CronJob) -> tuple[str, bool]:
+        """Pick the chat session for a persistent run, rotating if due.
 
-        # Schedule memorization of the pre-rotation context (safety net).
-        # Scheduled, not awaited: memorization queues on a global lock and
-        # awaiting it would delay the run start by the whole queue wait.
-        # The lower bound is frozen at scheduling time, so clearing
-        # connected_at below cannot shrink the covered window.
-        try:
-            await self.engine.schedule_memorize(session_id)
-        except Exception as e:
-            logger.warning("Pre-rotation memorize failed for %s: %s", session_id, e)
+        Returns ``(session_id, rotated)``. When rotation is due, the current
+        generation is retired (chat + history preserved as its own session)
+        and a brand-new chat is minted for this and subsequent runs.
+        """
+        current = await self._current_persistent_session_id(job.id)
+        rotated = False
 
-        # Clear sdk_session_id + connected_at → next run starts fresh
-        await self.engine.sessions.mark_idle(session_id, preserve_sdk_id=False)
-        logger.info(
-            "Rotated context for persistent cron %s (%s)",
-            session_id, reason,
-        )
-        return True
+        if current and (job.context_rotate_at or job.context_rotate_hours > 0):
+            session = await self.db.get_session(current)
+            if session:
+                reason = self._rotation_reason(
+                    session, job.context_rotate_hours, job.context_rotate_at,
+                )
+                if reason:
+                    await self._retire_session(job.id, current, reason)
+                    current = None
+                    rotated = True
+
+        if current is None:
+            current = await self._start_new_generation(job.id)
+        return current, rotated
+
+    # -- End persistent session generations ----------------------------------
 
     def _load_merged_jobs(self) -> list[CronJob]:
         """Load and merge jobs from system.yaml and jobs.yaml.
@@ -501,7 +617,9 @@ class CronService:
             # instead of waiting for the run to finish.
             run_id: str | None = None
             if job.session_mode == "persistent":
-                session_id = f"cron:{job.id}"
+                # Resolve the current generation chat, rotating to a fresh
+                # one first when due (the old chat is preserved).
+                session_id, rotated = await self._resolve_persistent_session(job)
             else:
                 # Isolated mode: per-run session. The run_id is generated
                 # here (the engine would otherwise generate an identical
@@ -518,13 +636,6 @@ class CronService:
                 )
 
             if job.session_mode == "persistent":
-                # Persistent mode: reuse SDK context across runs
-                if job.context_rotate_at or job.context_rotate_hours > 0:
-                    rotated = await self._maybe_rotate_context(
-                        session_id, job.context_rotate_hours,
-                        rotate_at=job.context_rotate_at,
-                    )
-
                 # Determine prompt: full on first run, short reminder on subsequent
                 prompt = base_prompt
                 if job.reminder_mode:
@@ -552,6 +663,7 @@ class CronService:
                     job_id=job.id,
                     prompt=prompt,
                     model=model,
+                    session_id=session_id,
                 )
             else:
                 response = await self.engine.run_cron(
@@ -694,10 +806,11 @@ class CronService:
         await self._run_job_wrapper(job)
 
     async def rotate_session(self, job_id: str) -> dict:
-        """Force-rotate a persistent cron session's context.
+        """Force-rotate a persistent cron to a fresh chat session.
 
-        Runs pre-rotation memorization, then clears the sdk_session_id
-        so the next run starts a fresh SDK client.
+        Retires the current generation chat (its history is preserved as a
+        normal session) and starts a new empty chat that the next run — and
+        the CronPage chat link — picks up immediately.
 
         Returns a dict with rotation details.
         Raises ValueError if job not found or not persistent.
@@ -714,8 +827,8 @@ class CronService:
                 f"Job {job_id!r} is not persistent (mode={job.session_mode!r})"
             )
 
-        session_id = f"cron:{job_id}"
-        session = await self.db.get_session(session_id)
+        session_id = await self._current_persistent_session_id(job_id)
+        session = await self.db.get_session(session_id) if session_id else None
 
         # Calculate current age for the response
         session_age_hours: float | None = None
@@ -733,19 +846,25 @@ class CronService:
             except (ValueError, TypeError):
                 pass
 
-        rotated = await self._maybe_rotate_context(
-            session_id, rotate_hours=0, force=True,
-        )
+        rotated = False
+        new_session_id: str | None = None
+        if session_id and session:
+            await self._retire_session(job_id, session_id, "manual")
+            new_session_id = await self._start_new_generation(job_id)
+            rotated = True
 
         logger.info(
-            "Manual rotation for %s: rotated=%s age=%.1fh",
+            "Manual rotation for %s: rotated=%s age=%.1fh new=%s",
             job_id, rotated,
             session_age_hours if session_age_hours is not None else -1,
+            new_session_id,
         )
         return {
             "job_id": job_id,
             "rotated": rotated,
             "session_age_hours": session_age_hours,
+            "old_session_id": session_id if rotated else None,
+            "new_session_id": new_session_id,
         }
 
     async def list_jobs(self) -> list[dict]:

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -70,6 +70,15 @@ def _make_cron_service(timezone_name: str = "UTC") -> CronService:
     db.log_cron_start = AsyncMock(return_value=1)
     db.log_cron_finish = AsyncMock()
     db.get_last_successful_cron_run = AsyncMock(return_value=None)
+    # Persistent-session generation lookups: default to "no current session"
+    # (AsyncMock's auto-returns are truthy MagicMocks, which would otherwise
+    # read as a live mapping/session).
+    db.get_channel_session = AsyncMock(return_value=None)
+    db.get_session = AsyncMock(return_value=None)
+    db.set_channel_session = AsyncMock()
+    db.cancel_wakeups_for_session = AsyncMock(return_value=0)
+    db.update_session_metadata = AsyncMock()
+    db.update_session_title = AsyncMock()
 
     return CronService(config, engine, db)
 
@@ -590,20 +599,63 @@ class TestJobLock:
 
 
 # ---------------------------------------------------------------------------
-# Context rotation — memorization must not block the run lifecycle
+# Context rotation — retiring the current chat and starting a fresh one
 # ---------------------------------------------------------------------------
 
-class TestRotationMemorize:
+def _pers_job(**kwargs) -> CronJob:
+    kwargs.setdefault("id", "pers")
+    kwargs.setdefault("session_mode", "persistent")
+    return _make_job(**kwargs)
+
+
+def _map_current(svc: CronService, session_id: str, session: dict) -> None:
+    """Point the job's channel mapping at *session_id* with *session* data."""
+    svc.db.get_channel_session = AsyncMock(
+        return_value={"session_id": session_id},
+    )
+    svc.db.get_session = AsyncMock(return_value=session)
+
+
+class TestRotation:
+    @pytest.mark.asyncio
+    async def test_rotation_starts_new_chat_and_preserves_old(self, cron_service):
+        """Rotation retires the old chat untouched and mints a new session."""
+        _map_current(cron_service, "cron:pers", {
+            "connected_at": _hours_ago(30),
+            "status": "idle",
+            "title": "Cron: pers",
+            "metadata": "{}",
+        })
+        job = _pers_job(context_rotate_hours=24)
+
+        session_id, rotated = await cron_service._resolve_persistent_session(job)
+
+        assert rotated is True
+        assert session_id != "cron:pers"
+        assert session_id.startswith("cron:pers:")
+        # Old chat is preserved: its SDK context is never cleared and the
+        # session row is not deleted/archived by rotation.
+        cron_service.engine.sessions.mark_idle.assert_not_called()
+        # New chat is created and becomes the job's current session.
+        cron_service.engine.sessions.get_or_create.assert_awaited_once_with(
+            session_id, title="Cron: pers", source="cron",
+        )
+        cron_service.db.set_channel_session.assert_awaited_once_with(
+            "cron:pers", session_id,
+        )
+
     @pytest.mark.asyncio
     async def test_rotation_schedules_background_memorize(self, cron_service):
         """Rotation schedules memorization instead of awaiting it inline."""
-        cron_service.db.get_session = AsyncMock(return_value={
+        _map_current(cron_service, "cron:pers", {
             "connected_at": _hours_ago(30),
+            "status": "idle",
+            "title": "Cron: pers",
+            "metadata": "{}",
         })
+        job = _pers_job(context_rotate_hours=24)
 
-        rotated = await cron_service._maybe_rotate_context(
-            "cron:pers", rotate_hours=24,
-        )
+        _, rotated = await cron_service._resolve_persistent_session(job)
 
         assert rotated is True
         cron_service.engine.schedule_memorize.assert_awaited_once_with(
@@ -612,26 +664,55 @@ class TestRotationMemorize:
         cron_service.engine._memorize_session.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_no_rotation_no_memorize(self, cron_service):
-        """A session younger than the rotation window is left alone."""
-        cron_service.db.get_session = AsyncMock(return_value={
-            "connected_at": _hours_ago(1),
+    async def test_rotation_stamps_and_cancels_wakeups(self, cron_service):
+        """The retired chat is stamped rotated_at, retitled, wakeups cancelled."""
+        _map_current(cron_service, "cron:pers", {
+            "connected_at": _hours_ago(30),
+            "status": "idle",
+            "title": "Cron: pers",
+            "metadata": "{}",
         })
+        job = _pers_job(context_rotate_hours=24)
 
-        rotated = await cron_service._maybe_rotate_context(
-            "cron:pers", rotate_hours=24,
+        await cron_service._resolve_persistent_session(job)
+
+        cron_service.db.cancel_wakeups_for_session.assert_awaited_once_with(
+            "cron:pers",
         )
+        meta_args = cron_service.db.update_session_metadata.call_args.args
+        assert meta_args[0] == "cron:pers"
+        assert "rotated_at" in meta_args[1]
+        title_args = cron_service.db.update_session_title.call_args.args
+        assert title_args[0] == "cron:pers"
+        assert title_args[1].startswith("Cron: pers (until ")
+
+    @pytest.mark.asyncio
+    async def test_no_rotation_keeps_current_chat(self, cron_service):
+        """A session younger than the rotation window is left alone."""
+        _map_current(cron_service, "cron:pers", {
+            "connected_at": _hours_ago(1),
+            "status": "idle",
+        })
+        job = _pers_job(context_rotate_hours=24)
+
+        session_id, rotated = await cron_service._resolve_persistent_session(job)
 
         assert rotated is False
+        assert session_id == "cron:pers"
         cron_service.engine.schedule_memorize.assert_not_awaited()
+        cron_service.db.set_channel_session.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_rotate_at_uses_configured_timezone(self):
         """Daily rotate_at uses config timezone, not the server timezone."""
         svc = _make_cron_service("America/New_York")
-        svc.db.get_session = AsyncMock(return_value={
+        _map_current(svc, "cron:pers", {
             "connected_at": "2026-01-01T13:59:00+00:00",
+            "status": "idle",
+            "title": "Cron: pers",
+            "metadata": "{}",
         })
+        job = _pers_job(context_rotate_hours=0, context_rotate_at="09:00")
 
         class FixedDateTime(datetime):
             @classmethod
@@ -642,39 +723,153 @@ class TestRotationMemorize:
                 return fixed.astimezone(tz)
 
         with patch("nerve.cron.service.datetime", FixedDateTime):
-            rotated = await svc._maybe_rotate_context(
-                "cron:pers", rotate_hours=0, rotate_at="09:00",
-            )
+            session_id, rotated = await svc._resolve_persistent_session(job)
 
         assert rotated is True
+        assert session_id == "cron:pers:20260101-150000"
         svc.engine.schedule_memorize.assert_awaited_once_with("cron:pers")
-        svc.engine.sessions.mark_idle.assert_awaited_once_with(
-            "cron:pers", preserve_sdk_id=False,
+        svc.engine.sessions.mark_idle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_run_mints_generation_session(self, cron_service):
+        """With no mapping and no legacy session, a fresh chat is minted."""
+        job = _pers_job(context_rotate_hours=24)
+
+        session_id, rotated = await cron_service._resolve_persistent_session(job)
+
+        assert rotated is False
+        assert session_id.startswith("cron:pers:")
+        cron_service.db.set_channel_session.assert_awaited_once_with(
+            "cron:pers", session_id,
         )
 
     @pytest.mark.asyncio
-    async def test_manual_rotation_forces_disabled_rotation_window(self, cron_service):
-        """Manual rotation clears context even when scheduled rotation is disabled."""
-        cron_service._jobs = [
-            _make_job(
-                id="pers", session_mode="persistent", context_rotate_hours=0,
-            ),
-        ]
+    async def test_legacy_stable_session_adopted(self, cron_service):
+        """Pre-generation installs keep their cron:{job_id} session context."""
         cron_service.db.get_session = AsyncMock(return_value={
             "connected_at": _hours_ago(1),
+            "status": "idle",
+            "metadata": "{}",
+        })
+        job = _pers_job(context_rotate_hours=24)
+
+        session_id, rotated = await cron_service._resolve_persistent_session(job)
+
+        assert rotated is False
+        assert session_id == "cron:pers"
+        cron_service.db.set_channel_session.assert_awaited_once_with(
+            "cron:pers", "cron:pers",
+        )
+
+    @pytest.mark.asyncio
+    async def test_rotated_legacy_session_not_readopted(self, cron_service):
+        """A legacy session already rotated out must not be resurrected."""
+        cron_service.db.get_session = AsyncMock(return_value={
+            "connected_at": _hours_ago(1),
+            "status": "idle",
+            "metadata": '{"rotated_at": "2026-01-01T00:00:00+00:00"}',
+        })
+        job = _pers_job(context_rotate_hours=24)
+
+        session_id, rotated = await cron_service._resolve_persistent_session(job)
+
+        assert rotated is False
+        assert session_id.startswith("cron:pers:")
+
+    @pytest.mark.asyncio
+    async def test_archived_mapped_session_starts_new_chat(self, cron_service):
+        """An archived current chat is never resumed — a new one is minted."""
+        _map_current(cron_service, "cron:pers:20250101-000000", {
+            "connected_at": _hours_ago(1),
+            "status": "archived",
+            "metadata": "{}",
+        })
+        job = _pers_job(context_rotate_hours=24)
+
+        session_id, rotated = await cron_service._resolve_persistent_session(job)
+
+        assert rotated is False
+        assert session_id.startswith("cron:pers:")
+        assert session_id != "cron:pers:20250101-000000"
+
+    @pytest.mark.asyncio
+    async def test_manual_rotation_forces_disabled_rotation_window(self, cron_service):
+        """Manual rotation starts a new chat even when auto-rotation is off."""
+        cron_service._jobs = [_pers_job(context_rotate_hours=0)]
+        _map_current(cron_service, "cron:pers", {
+            "connected_at": _hours_ago(1),
             "sdk_session_id": "sdk-123",
+            "status": "idle",
+            "title": "Cron: pers",
+            "metadata": "{}",
         })
 
         result = await cron_service.rotate_session("pers")
 
         assert result["rotated"] is True
         assert result["session_age_hours"] is not None
+        assert result["old_session_id"] == "cron:pers"
+        assert result["new_session_id"].startswith("cron:pers:")
         cron_service.engine.schedule_memorize.assert_awaited_once_with(
             "cron:pers",
         )
-        cron_service.engine.sessions.mark_idle.assert_awaited_once_with(
-            "cron:pers", preserve_sdk_id=False,
+        # Old chat preserved — rotation never wipes its SDK context.
+        cron_service.engine.sessions.mark_idle.assert_not_called()
+        cron_service.db.set_channel_session.assert_awaited_once_with(
+            "cron:pers", result["new_session_id"],
         )
+
+    @pytest.mark.asyncio
+    async def test_manual_rotation_without_session_is_noop(self, cron_service):
+        """Rotating a job that never ran reports rotated=False."""
+        cron_service._jobs = [_pers_job(context_rotate_hours=0)]
+
+        result = await cron_service.rotate_session("pers")
+
+        assert result["rotated"] is False
+        assert result["new_session_id"] is None
+        cron_service.engine.schedule_memorize.assert_not_awaited()
+
+
+class TestReminderModeAcrossRotation:
+    @pytest.mark.asyncio
+    async def test_short_reminder_when_resuming(self, cron_service):
+        """An established chat gets the short reminder, not the full prompt."""
+        _map_current(cron_service, "cron:pers", {
+            "connected_at": _hours_ago(1),
+            "sdk_session_id": "sdk-123",
+            "status": "idle",
+        })
+        job = _pers_job(context_rotate_hours=24, reminder_mode=True)
+
+        await cron_service._run_job_inner(job)
+
+        kwargs = cron_service.engine.run_persistent_cron.call_args.kwargs
+        assert kwargs["prompt"].startswith("Scheduled run — continue")
+        assert kwargs["session_id"] == "cron:pers"
+
+    @pytest.mark.asyncio
+    async def test_full_prompt_after_rotation(self, cron_service):
+        """The first run in a freshly-rotated chat resends the full prompt."""
+        _map_current(cron_service, "cron:pers", {
+            "connected_at": _hours_ago(30),
+            "sdk_session_id": "sdk-123",
+            "status": "idle",
+            "title": "Cron: pers",
+            "metadata": "{}",
+        })
+        job = _pers_job(context_rotate_hours=24, reminder_mode=True)
+
+        await cron_service._run_job_inner(job)
+
+        kwargs = cron_service.engine.run_persistent_cron.call_args.kwargs
+        assert kwargs["prompt"].startswith("do stuff")
+        assert "persistent cron with reminder" in kwargs["prompt"]
+        assert kwargs["session_id"].startswith("cron:pers:")
+        # The run log links the NEW chat, and the output is flagged rotated.
+        log_kwargs = cron_service.db.log_cron_finish.call_args.kwargs
+        assert log_kwargs["session_id"] == kwargs["session_id"]
+        assert log_kwargs["output"].startswith("[context rotated] ")
 
 
 # ---------------------------------------------------------------------------
@@ -918,13 +1113,16 @@ class TestRunLogOutput:
 
     @pytest.mark.asyncio
     async def test_persistent_run_links_session_id(self, cron_service):
-        cron_service.db.get_session = AsyncMock(return_value=None)
         job = _make_job(id="pers-job", session_mode="persistent", context_rotate_hours=0)
 
         await cron_service._run_job_inner(job)
 
         kwargs = cron_service.db.log_cron_finish.call_args.kwargs
-        assert kwargs["session_id"] == "cron:pers-job"
+        # First run mints a generation chat: cron:{job_id}:{timestamp}
+        assert kwargs["session_id"].startswith("cron:pers-job:")
+        # The same session is handed to the engine run.
+        run_kwargs = cron_service.engine.run_persistent_cron.call_args.kwargs
+        assert run_kwargs["session_id"] == kwargs["session_id"]
 
     @pytest.mark.asyncio
     async def test_error_run_still_links_session_id(self, cron_service):
@@ -971,16 +1169,16 @@ class TestLiveSessionLink:
 
     @pytest.mark.asyncio
     async def test_persistent_links_session_before_run(self, cron_service):
-        cron_service.db.get_session = AsyncMock(return_value=None)
         job = _make_job(
             id="pers-live", session_mode="persistent", context_rotate_hours=0,
         )
 
         await cron_service._run_job_inner(job)
 
-        cron_service.db.set_cron_log_session.assert_awaited_once_with(
-            1, "cron:pers-live",
-        )
+        cron_service.db.set_cron_log_session.assert_awaited_once()
+        log_id, session_id = cron_service.db.set_cron_log_session.call_args.args
+        assert log_id == 1
+        assert session_id.startswith("cron:pers-live:")
 
     @pytest.mark.asyncio
     async def test_no_link_when_prompt_unresolvable(self, cron_service, tmp_path):

--- a/web/src/components/Cron/controls.tsx
+++ b/web/src/components/Cron/controls.tsx
@@ -97,7 +97,7 @@ export function RotateButton({ jobId }: { jobId: string }) {
     <button onClick={handleClick} disabled={isRotating}
       className={`flex items-center gap-1 rounded transition-colors cursor-pointer px-2 py-1.5 text-[12px]
         ${isRotating ? 'text-text-faint cursor-not-allowed' : 'text-text-muted hover:text-text-secondary hover:bg-surface-raised'}`}
-      title="Rotate session context">
+      title="Start a fresh chat (current chat is kept)">
       {isRotating ? <Loader2 size={14} className="animate-spin" /> : <RotateCw size={14} />}
       {!isRotating && <span>Rotate</span>}
     </button>


### PR DESCRIPTION
## Investigation

The suspicion was that persistent-cron auto-rotation loses the previous chat history. Findings:

- **No data was ever deleted.** Rotation only cleared `sdk_session_id`/`connected_at` on the stable `cron:{job_id}` session and scheduled memU indexing. E.g. a long-lived `inbox-processor` session holds ~10.7K messages spanning 4 months of daily rotations — all still in the DB.
- **But the history was effectively invisible.** Every context epoch piled into one endless chat, rotation boundaries were invisible, and the chat view only loads the most recent messages (default fetch limit, no pagination) — so after a rotation the old history *appeared* lost.

## Change

Persistent jobs now run in **generation chats**:

- Each generation is its own session (`cron:{job_id}:{timestamp}`); the job's current generation is tracked in `channel_sessions` under the key `cron:{job_id}`.
- **Rotation retires the current chat and mints a fresh one** instead of resetting context in place. The retired chat keeps its full history, messages, per-turn usage, and run-log links; it stays browsable (and resumable) in the UI and ages out via the normal session-archival policy.
- Retiring also: schedules memU indexing (as before), **cancels the session's pending wakeups** (a retired thread must not resurrect itself alongside the new generation), stamps `rotated_at` in metadata, and retitles the chat with its end date (`Cron: {job_id} (until 2026-07-05)`).
- Rotation triggers are unchanged (`context_rotate_hours`, `context_rotate_at`, manual rotate). `connected_at` still marks the SDK context epoch.
- **Manual rotate** (`POST /api/cron/jobs/{id}/rotate`) now retires + mints eagerly, and returns `old_session_id`/`new_session_id`.
- **Upgrade path:** legacy stable-id sessions (`cron:{job_id}`) are adopted as the current generation on the first run after upgrade — SDK context carries over seamlessly — and move to the generation scheme at their next rotation. A rotated-out legacy session is never re-adopted.
- `run_persistent_cron` accepts the resolved `session_id` from the cron service (falls back to the legacy id when omitted).

Reminder mode, run-log session linking, notification session-label suppression (prefix-matched), and the CronPage chat link (`get_latest_cron_session_id`) all work unchanged with generation ids.

## Tests

- Reworked rotation tests + new coverage: new-chat minting, old-chat preservation, wakeup cancellation + retitle/stamp, legacy adoption (and non-re-adoption), archived-mapping recovery, manual rotate (incl. no-session noop), reminder-mode across rotation.
- Full suite: 1379 passed, 2 skipped. Frontend builds clean.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*