### PR TITLE
Discover the account's Anthropic models to give vhoice in composer model picker

### DIFF
--- a/nerve/anthropic.py
+++ b/nerve/anthropic.py
@@ -1,0 +1,88 @@
+"""Anthropic API integration helpers.
+
+This module only handles model *discovery* — querying which chat models
+the configured Anthropic API key can use (``GET /v1/models``) so the web
+composer's model picker can offer them without a hand-maintained list.
+
+Discovery is best-effort and never raises: without an API key (OAuth or
+Bedrock setups) or with the API unreachable, callers get an empty list
+and the picker falls back to the configured models.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+_MODELS_URL = "https://api.anthropic.com/v1/models?limit=100"
+_API_VERSION = "2023-06-01"
+
+# Short, bounded timeout — discovery runs on the request path (model
+# picker); a slow or unreachable API must never hang the UI.
+_DISCOVERY_TIMEOUT = 3.0
+
+
+def discover_models(api_key: str, timeout: float = _DISCOVERY_TIMEOUT) -> list[str]:
+    """Return chat model ids available to an Anthropic API key.
+
+    Queries ``GET /v1/models`` and preserves the API's newest-first order.
+    Returns an empty list (never raises) when the key is missing, the API
+    is unreachable, or the response is malformed.
+
+    Uses the stdlib ``urllib`` so it is safe to call synchronously from a
+    worker thread without pulling in an async HTTP client.
+    """
+    if not api_key:
+        return []
+    try:
+        req = urllib.request.Request(_MODELS_URL, headers={
+            "x-api-key": api_key,
+            "anthropic-version": _API_VERSION,
+            "Accept": "application/json",
+        })
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError) as e:
+        logger.warning("Anthropic model discovery failed: %s", e)
+        return []
+
+    if not isinstance(payload, dict):
+        return []
+
+    ids: list[str] = []
+    for entry in payload.get("data") or []:
+        if isinstance(entry, dict):
+            model_id = entry.get("id")
+            if model_id and str(model_id) not in ids:
+                ids.append(str(model_id))
+    return ids
+
+
+def latest_per_family(model_ids: list[str]) -> list[str]:
+    """Keep the first (newest, in API order) model of each family.
+
+    The family is the first alphabetic token after the ``claude-`` prefix
+    (``opus``, ``sonnet``, ``haiku``, ``fable``, ...), which also covers
+    legacy ``claude-3-5-sonnet-...`` ids where the version precedes it.
+    Ids with no recognizable family are kept as their own family.
+    """
+    seen: set[str] = set()
+    kept: list[str] = []
+    for model_id in model_ids:
+        family = _family(model_id)
+        if family in seen:
+            continue
+        seen.add(family)
+        kept.append(model_id)
+    return kept
+
+
+def _family(model_id: str) -> str:
+    for token in model_id.removeprefix("claude-").split("-"):
+        if token.isalpha():
+            return token
+    return model_id

--- a/nerve/gateway/routes/models.py
+++ b/nerve/gateway/routes/models.py
@@ -13,9 +13,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 
 from fastapi import APIRouter, Depends
 
+from nerve.anthropic import discover_models as discover_anthropic_models
+from nerve.anthropic import latest_per_family
 from nerve.config import get_config
 from nerve.gateway.auth import require_auth
 from nerve.gateway.routes._deps import get_deps
@@ -24,6 +27,28 @@ from nerve.ollama import discover_models
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Anthropic discovery cache — unlike the local Ollama/Codex probes this call
+# leaves the box, and /api/models fires on every composer mount. Successful
+# lists are reused for 15 minutes; failures retry after 60 seconds so a
+# keyless or offline box doesn't pay the discovery timeout on every mount.
+_ANTHROPIC_TTL_OK = 15 * 60.0
+_ANTHROPIC_TTL_EMPTY = 60.0
+_anthropic_cache: tuple[float, list[str]] = (0.0, [])
+
+
+async def _discovered_anthropic_ids(api_key: str) -> list[str]:
+    global _anthropic_cache
+    cached_at, ids = _anthropic_cache
+    ttl = _ANTHROPIC_TTL_OK if ids else _ANTHROPIC_TTL_EMPTY
+    if cached_at and time.monotonic() - cached_at < ttl:
+        return ids
+    # Discovery does blocking I/O (stdlib urllib) — keep the event loop free.
+    found = latest_per_family(
+        await asyncio.to_thread(discover_anthropic_models, api_key),
+    )
+    _anthropic_cache = (time.monotonic(), found)
+    return found
 
 
 @router.get("/api/models")
@@ -45,6 +70,16 @@ async def list_models(user: dict = Depends(require_auth)):
     deps = get_deps()
     default_model = config.agent.model
 
+    # Default model first, then the newest live-discovered model of each
+    # Anthropic family (opus/sonnet/haiku/...), de-duplicated. Discovery is
+    # best-effort — a keyless (OAuth/Bedrock) or offline box simply offers
+    # only the default model.
+    discovered = await _discovered_anthropic_ids(config.anthropic_api_key)
+    anthropic_ids: list[str] = [default_model]
+    for m in discovered:
+        if m and m not in anthropic_ids:
+            anthropic_ids.append(m)
+
     codex_backend = deps.engine._backends.get("codex")
     codex_preflight = (
         await codex_backend.preflight() if codex_backend is not None
@@ -56,7 +91,7 @@ async def list_models(user: dict = Depends(require_auth)):
     options = [
         {
             "id": "claude", "label": "Claude", "model": config.agent.model,
-            "models": [config.agent.model], "available": True,
+            "models": anthropic_ids, "available": True,
         },
     ]
     options.append({
@@ -81,7 +116,7 @@ async def list_models(user: dict = Depends(require_auth)):
     }
 
     models: list[dict[str, str]] = [
-        {"id": default_model, "provider": "anthropic", "backend": "claude"},
+        {"id": m, "provider": "anthropic", "backend": "claude"} for m in anthropic_ids
     ]
     if codex_preflight.get("available"):
         models.extend({

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -1,0 +1,97 @@
+"""Tests for Anthropic model discovery (``nerve/anthropic.py``)."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+from nerve.anthropic import discover_models, latest_per_family
+
+
+class _FakeResponse(io.BytesIO):
+    """Minimal stand-in for the ``urlopen`` context-manager response."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+def _response(payload) -> _FakeResponse:
+    return _FakeResponse(json.dumps(payload).encode("utf-8"))
+
+
+def test_discover_models_requires_api_key():
+    assert discover_models("") == []
+
+
+def test_discover_models_parses_ids_in_api_order():
+    payload = {
+        "data": [
+            {"id": "claude-sonnet-5", "display_name": "Claude Sonnet 5"},
+            {"id": "claude-fable-5", "display_name": "Claude Fable 5"},
+            {"id": "claude-fable-5"},          # duplicate dropped
+            {"display_name": "no id, skipped"},
+        ],
+        "has_more": False,
+    }
+    with patch(
+        "nerve.anthropic.urllib.request.urlopen", return_value=_response(payload),
+    ):
+        assert discover_models("sk-test") == ["claude-sonnet-5", "claude-fable-5"]
+
+
+def test_discover_models_swallows_network_errors():
+    with patch(
+        "nerve.anthropic.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        assert discover_models("sk-test") == []
+
+
+def test_discover_models_tolerates_malformed_payload():
+    with patch(
+        "nerve.anthropic.urllib.request.urlopen", return_value=_response([1, 2]),
+    ):
+        assert discover_models("sk-test") == []
+
+
+def test_latest_per_family_keeps_newest_of_each_family():
+    ids = [
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5-20251001",
+        "claude-opus-4-1-20250805",
+    ]
+    assert latest_per_family(ids) == [
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-opus-4-8",
+        "claude-haiku-4-5-20251001",
+    ]
+
+
+def test_latest_per_family_handles_legacy_version_first_ids():
+    ids = [
+        "claude-3-5-sonnet-20241022",
+        "claude-3-sonnet-20240229",
+        "claude-3-haiku-20240307",
+    ]
+    assert latest_per_family(ids) == [
+        "claude-3-5-sonnet-20241022",
+        "claude-3-haiku-20240307",
+    ]
+
+
+def test_latest_per_family_keeps_unrecognizable_ids():
+    assert latest_per_family(["weird-id-123", "claude-opus-4-8"]) == [
+        "weird-id-123",
+        "claude-opus-4-8",
+    ]


### PR DESCRIPTION
## Summary
The Claude backend offers a single model in the composer's model picker — the configured `agent.model`. This PR discovers the Anthropic chat models available to the account and offers the newest one of each family (opus / sonnet / haiku / …), so switching a turn to a stronger or cheaper model needs no configuration.

- `nerve/anthropic.py` — discovery via `GET /v1/models` with `anthropic_api_key`, mirroring the Ollama discovery module: stdlib `urllib`, bounded timeout, never raises — any failure yields an empty list. `latest_per_family()` keeps the first (newest, in API order) model of each family; the family is the first alphabetic token after the `claude-` prefix, which also covers legacy `claude-3-5-sonnet-…` ids.
- `nerve/gateway/routes/models.py` — the discovered list feeds the existing per-backend `models[]` contract (claude backend option + flat picker list), with the default model always first. Results are cached (15 min on success, 60 s retry on failure) since the call leaves the box and `/api/models` fires on every composer mount; discovery runs via `asyncio.to_thread` to keep the event loop free.
- Keyless (OAuth/Bedrock) or offline setups degrade to offering only the default model.
- No frontend changes — the picker already renders per-backend model lists, exactly as it does for Codex preflight and Ollama discovery.

## Test plan
- [ ] With `anthropic_api_key` set: the Claude-backend picker offers the family-latest models (currently sonnet-5, fable-5, opus-4-8, haiku-4-5)
- [ ] Selecting a discovered model routes the turn to it
- [ ] No API key: only the default model → the picker stays hidden
- [ ] Offline: `/api/models` stays fast after the first miss (60 s retry cache) and degrades to the default model
- [ ] `pytest tests/test_anthropic.py`