### PR TITLE
Don't drop pending Telegram updates on restart

### DIFF
--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -332,7 +332,15 @@ class TelegramChannel(BaseChannel):
         await self._app.initialize()
         await self._app.start()
         await self._app.updater.start_polling(
-            drop_pending_updates=True,
+            # Do NOT drop updates that queued while we were offline.
+            # `nerve restart` (and any daemon respawn) goes through this
+            # startup path; with drop_pending_updates=True, every message
+            # the user sent during the restart window was silently discarded
+            # by Telegram and never redelivered — a real "lost message" bug.
+            # Telegram retains updates ~24h and only advances the offset once
+            # we fetch them, so False makes a restart pick up the backlog.
+            # The watchdog _rebuild() path already uses False; keep parity.
+            drop_pending_updates=False,
             # Retry initial connection indefinitely — don't give up on
             # transient network errors during startup
             bootstrap_retries=-1,


### PR DESCRIPTION
## Problem
The Telegram bot's **startup path** — taken by every `nerve restart` and daemon respawn — calls `Updater.start_polling(drop_pending_updates=True)`. That tells Telegram to discard all updates queued while the bot was offline, so **any message a user sends during the restart window is silently dropped and never redelivered**.

The watchdog `_rebuild()` path already uses `drop_pending_updates=False`; only the startup path had `True`.

## How
Set `drop_pending_updates=False` on the startup path. Telegram retains updates (~24h) and only advances the read offset once we fetch them, so a restart now replays the backlog instead of dropping it. Brings the startup path into parity with `_rebuild()`.

## Note
A narrow gap remains: python-telegram-bot holds the fetch offset in memory, so a crash *between* `getUpdates` and handler dispatch could still drop an in-flight update — closing that fully would need a durable inbox. This fixes the common restart-window loss. No Telegram/channel tests exist in the suite; the change is a single kwarg flip.
