### PR TITLE
Stop truncating long Telegram replies in format_response

### DIFF
--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -563,9 +563,13 @@ class TelegramChannel(BaseChannel):
             self._cache_message(sent.message_id, chat_id, chunk)
 
     def format_response(self, text: str) -> str:
-        """Truncate for Telegram if needed."""
-        if len(text) > MAX_MSG_LEN:
-            return text[:MAX_MSG_LEN - 20] + "\n\n... (truncated)"
+        """Return text unchanged.
+
+        Long messages must NOT be truncated here: send() already splits text into
+        MAX_MSG_LEN-sized chunks and delivers them as sequential messages. Truncating
+        first (the old behaviour) defeated that chunking and dropped the tail of long
+        replies with a "... (truncated)" marker.
+        """
         return text
 
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Problem
`format_response()` truncated any reply longer than `MAX_MSG_LEN`, appending a `"... (truncated)"` marker. But `send()` already splits outgoing text into `MAX_MSG_LEN`-sized chunks and delivers them as sequential messages — so the truncation ran *first* and permanently dropped the tail of long replies.

## How
Return the text unchanged from `format_response()` and let `send()` do the chunking, so long replies are delivered in full across multiple messages.

## Notes
Independent of #171 (touches a different region of the same file; no conflict). No Telegram/channel tests in the suite.
