### PR TITLE
Set setting_sources=[] to stop duplicating the prompt bundle

### DIFF
--- a/nerve/agent/backends/claude.py
+++ b/nerve/agent/backends/claude.py
@@ -476,6 +476,19 @@ class ClaudeBackend:
             disallowed_tools=["CronCreate", "CronList", "CronDelete"],
             env=self._build_env(cache_ttl=spec.cache_ttl),
             cwd=spec.cwd,
+            # Load no filesystem settings/memory: Nerve owns the entire
+            # prompt. It injects the full identity/memory bundle
+            # (SOUL/IDENTITY/USER/AGENTS/TOOLS/MEMORY) via ``system_prompt``
+            # and passes permissions (``can_use_tool``), MCP (``mcp_servers``),
+            # hooks and env explicitly. Left at the default, the CLI would also
+            # auto-load ~/.claude/CLAUDE.md — the same bundle the Claude Code
+            # renderer writes for external claude-code use — duplicating tens
+            # of thousands of tokens every turn. ["project"] is NOT enough: the
+            # workspace lives under $HOME, so project-root detection climbs to
+            # $HOME and loads the user-level CLAUDE.md under both the "user" and
+            # "project" sources. Native skills/plugins are unaffected — they
+            # load via ``plugins`` (--plugin-dir), independent of this setting.
+            setting_sources=[],
             mcp_servers=self._build_mcp_servers(spec.session_id),
             # Claude Code plugins — loaded via --plugin-dir so the CLI
             # handles OAuth, credentials, and plugin lifecycle natively.


### PR DESCRIPTION
## Problem

Nerve builds the **entire** system prompt itself: the identity/memory bundle (`SOUL`/`IDENTITY`/`USER`/`AGENTS`/`TOOLS`/`MEMORY`) is injected via `system_prompt`, and permissions (`can_use_tool`), MCP servers (`mcp_servers`), hooks and env are all passed explicitly to `ClaudeAgentOptions`.

With `setting_sources` left at its default, the Claude Code CLI *additionally* loads filesystem settings/memory — including `~/.claude/CLAUDE.md`, which is the very same bundle the Claude Code renderer writes for external claude-code use. The result is the identity/memory bundle appearing **twice** in context — tens of thousands of duplicated tokens on every turn.

## Fix

Pass `setting_sources=[]` in the Claude backend's `ClaudeAgentOptions`, disabling all filesystem-based settings/memory loading. Nerve owns the whole prompt, so there is nothing legitimate to load from disk.

### Why `[]` and not `["project"]`

An earlier attempt to drop only the user-level `CLAUDE.md` with `["project"]` is **insufficient**: the managed workspace lives under `$HOME`, so the CLI's project-root detection climbs to `$HOME` and loads `~/.claude/CLAUDE.md` under **both** the `"user"` and `"project"` sources. Only the empty list removes it entirely.

Native skills/plugins are unaffected — they load via `plugins` (`--plugin-dir`), independent of `setting_sources`.

## Verification

- Confirmed on the SDK path that `["project"]` and `["user"]` both re-inject the bundle while `[]` does not (the emitted `--setting-sources=` is parsed as "none", not the default `["user","project"]`).
- Full test suite green: `1547 passed, 2 skipped`.
- Verified live in a running session: no `claudeMd` context block, native skills still present.
