### PR TITLE
Fix session stickiness: advance last_activity_at on turns and explicit switches

### DIFF
--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -172,11 +172,21 @@ class SessionManager:
         sdk_session_id: str | None = None,
         connected_at: str | None = None,
     ) -> None:
-        """Mark session as active with an SDK client."""
-        now = connected_at or datetime.now(timezone.utc).isoformat()
+        """Mark session as active with an SDK client.
+
+        ``connected_at`` is the (stable) time the SDK client connected; callers
+        pass the original value when resuming an existing client so it is
+        preserved across turns. ``last_activity_at`` must instead always advance
+        to the real current time, because it drives channel stickiness
+        (see :meth:`_is_within_sticky_period`). Pinning it to ``connected_at``
+        froze it at session start, so any session older than
+        ``sticky_period_minutes`` was wrongly rotated onto a fresh session on
+        the next inbound message even when a turn had just completed.
+        """
+        now = datetime.now(timezone.utc).isoformat()
         fields: dict[str, Any] = {
             "status": SessionStatus.ACTIVE.value,
-            "connected_at": now,
+            "connected_at": connected_at or now,
             "last_activity_at": now,
         }
         if sdk_session_id is not None:

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -315,6 +315,14 @@ class SessionManager:
         if not session:
             raise ValueError(f"Session not found: {session_id}")
         await self.db.set_channel_session(channel_key, session_id)
+        # An explicit switch is a deliberate choice: the next inbound message must
+        # route to this session regardless of how long it has been idle. Mark it
+        # freshly active (this also bumps updated_at) so get_active_session's
+        # sticky-period check honours the switch instead of minting a new session.
+        await self.db.update_session_fields(
+            session_id,
+            {"last_activity_at": datetime.now(timezone.utc).isoformat()},
+        )
         logger.info("Channel %s -> session %s", channel_key, session_id)
 
     # ------------------------------------------------------------------ #

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -51,6 +51,24 @@ class TestLifecycleTransitions:
         assert session["sdk_session_id"] == "sdk-1"
         assert session["connected_at"] == "2024-01-01T00:00:00"
 
+    async def test_mark_active_advances_last_activity_despite_old_connected_at(
+        self, sm: SessionManager, db: Database,
+    ):
+        """Resuming an SDK client passes the ORIGINAL connected_at; last_activity_at
+        must still advance to now, since it drives channel stickiness. Regression:
+        last_activity_at was pinned to connected_at, freezing it at session start."""
+        from datetime import datetime, timezone
+        await sm.get_or_create("trans-la")
+        old = "2020-01-01T00:00:00+00:00"
+        await sm.mark_active("trans-la", sdk_session_id="sdk-la", connected_at=old)
+        session = await db.get_session("trans-la")
+        # connected_at is preserved (the stable original connect time)...
+        assert session["connected_at"] == old
+        # ...but last_activity_at reflects real current activity, not the old connect.
+        assert session["last_activity_at"] != old
+        last = datetime.fromisoformat(session["last_activity_at"])
+        assert (datetime.now(timezone.utc) - last).total_seconds() < 60
+
     async def test_mark_idle_preserves_sdk_id(self, sm: SessionManager, db: Database):
         await sm.get_or_create("trans-2")
         await sm.mark_active("trans-2", sdk_session_id="sdk-2")
@@ -176,6 +194,26 @@ class TestChannelMapping:
         await db.db.commit()
         sid2 = await sm.get_active_session("telegram:444", source="telegram")
         assert sid1 != sid2
+
+    async def test_resumed_long_lived_session_stays_sticky_after_turn(
+        self, sm: SessionManager, db: Database,
+    ):
+        """Regression: a long-lived session that just had a turn must not be rotated.
+
+        On resume the engine calls mark_active() with the session's ORIGINAL
+        connected_at. That used to pin last_activity_at to session start, so once
+        the session was older than sticky_period_minutes, the next inbound message
+        forked a fresh session even though a turn had just completed. last_activity_at
+        must track the turn, so the same session is reused.
+        """
+        sid1 = await sm.get_active_session("telegram:555", source="telegram")
+        # A turn resumes hours after the session first connected (original
+        # connected_at is far in the past), then the turn finishes and goes idle.
+        old_connect = "2020-01-01T00:00:00+00:00"
+        await sm.mark_active(sid1, sdk_session_id="sdk-r", connected_at=old_connect)
+        await sm.mark_idle(sid1)
+        sid2 = await sm.get_active_session("telegram:555", source="telegram")
+        assert sid1 == sid2
 
     async def test_set_and_get_active_session(self, sm: SessionManager, db: Database):
         await sm.get_or_create("ch-1")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -229,6 +229,31 @@ class TestChannelMapping:
         with pytest.raises(ValueError, match="not found"):
             await sm.set_active_session("telegram:123", "nonexistent")
 
+    async def test_explicit_switch_survives_sticky_period(
+        self, sm: SessionManager, db: Database,
+    ):
+        """An explicit switch routes the next message to the chosen session even
+        when it was idle far beyond the sticky period.
+
+        Channels without a per-message session id (e.g. Telegram) resolve the
+        target via get_active_session, whose sticky-period check would otherwise
+        reject a long-idle session and mint a fresh one — silently discarding the
+        user's switch. set_active_session marks the chosen session freshly active
+        so the choice is honoured.
+        """
+        await sm.get_or_create("old-sess", source="telegram")
+        await db.update_session_fields(
+            "old-sess", {"last_activity_at": "2020-01-01T00:00:00+00:00"},
+        )
+        await db.db.execute(
+            "UPDATE sessions SET updated_at = '2020-01-01T00:00:00' WHERE id = ?",
+            ("old-sess",),
+        )
+        await db.db.commit()
+        await sm.set_active_session("telegram:777", "old-sess")   # explicit switch
+        sid = await sm.get_active_session("telegram:777", source="telegram")
+        assert sid == "old-sess"    # honoured, not rotated to a fresh session
+
 
 @pytest.mark.asyncio
 class TestRunningState:


### PR DESCRIPTION
Two related fixes to session-routing stickiness. `last_activity_at` drives `_is_within_sticky_period`, which decides whether an inbound message resumes the channel's mapped session or mints a fresh one.

## 1. `last_activity_at` frozen at connect time
`mark_active()` set `connected_at` and `last_activity_at` to the same value, and its callers pass the session's **original** `connected_at` when resuming an SDK client — so `last_activity_at` was pinned to session start and never advanced across turns. Any session older than `sessions.sticky_period_minutes` was then wrongly rotated onto a fresh session on the next message (an unexpected context reset on Telegram/web). Fix: `connected_at` keeps the caller value (or now); `last_activity_at` **always** advances to now.

## 2. Explicit switches ignored past the sticky period
`set_active_session()` only rewrote the channel→session mapping. Channels without a per-message session id (Telegram) resolve the target via `get_active_session`, whose sticky-period check rejects a session idle longer than the window and mints a fresh one — so selecting a long-idle session and then sending a message **silently routed into a NEW session** instead of the chosen one. Fix: an explicit switch marks the chosen session freshly active (this also bumps `updated_at`, resetting the idle-archive clock), so the deliberate choice is honoured.

## Tests
Regression tests for both: `mark_active` advances `last_activity_at` despite an old `connected_at`; a resumed long-lived session stays sticky after a turn; and an explicit switch to a long-idle session routes the next message there instead of forking. Both fail on `main`, pass with the fix. Full suite: **1550 passed, 2 skipped**. Backend-only.
