### PR TITLE
Telegram /sessions: inline-keyboard switch + catch-up tail (expandable, timestamped)

### DIFF
--- a/nerve/channels/router.py
+++ b/nerve/channels/router.py
@@ -430,6 +430,20 @@ class ChannelRouter:
         """List sessions, most recently updated first."""
         return await self.engine.sessions.list_sessions(limit=limit)
 
+    async def get_session(self, session_id: str) -> dict[str, Any] | None:
+        """Fetch a session row (title/status/…), or None if it is gone."""
+        return await self.engine.db.get_session(session_id)
+
+    async def get_session_messages(
+        self, session_id: str, limit: int,
+    ) -> list[dict[str, Any]]:
+        """Recent messages for a session, oldest→newest (native chat order)."""
+        return await self.engine.db.get_messages(session_id, limit=limit)
+
+    async def count_session_messages(self, session_id: str) -> int:
+        """Total message count for a session (to know if more history exists)."""
+        return await self.engine.db.count_messages(session_id)
+
     # ------------------------------------------------------------------ #
     #  Outbound: engine → channel (cron delivery, etc.)                    #
     # ------------------------------------------------------------------ #

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -287,7 +287,14 @@ _TAIL_WINDOW = 6        # messages shown right after a switch
 _TAIL_STEP = 6          # extra messages added per "Load more"
 _TAIL_MAX = 18          # hard cap (keeps the card under Telegram's 4096 limit)
 _TAIL_MSG_MAX = 180     # per-message content truncation
-_STATUS_EMOJI = {"running": "🟢", "idle": "✅", "stopped": "⏹", "error": "⚠️"}
+_STATUS_EMOJI = {
+    "active": "🟢",     # a client is connected (live / possibly mid-turn)
+    "running": "🟢",    # defensive alias
+    "idle": "💤",       # no client attached, resumable
+    "stopped": "⏹",
+    "error": "⚠️",
+    "archived": "🗄",
+}
 
 
 def _safe_zone(tzname: str | None):

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -1064,12 +1064,18 @@ class TelegramChannel(BaseChannel):
         """
         current = await self.router.get_last_session(channel_key)
         sessions = await self.router.list_sessions(limit=30)
-        sessions = [s for s in sessions if s.get("source") in ("telegram", "web")]
-        # Drop empty (0-message) sessions — nothing to switch to or catch up on.
-        non_empty = []
+        # Keep the most-recent interactive sessions that have history: empty
+        # (0-message) sessions are useless to switch to, and cron/automation
+        # sessions are never switch targets. Stop once the keyboard is full so
+        # we don't count every session.
+        non_empty: list[dict] = []
         for s in sessions:
+            if s.get("source") not in ("telegram", "web"):
+                continue
             if await self.router.count_session_messages(s["id"]) > 0:
                 non_empty.append(s)
+                if len(non_empty) >= _SESSIONS_BUTTON_LIMIT:
+                    break
         return build_sessions_view(non_empty, current)
 
     async def _handle_sessions(self, update: Update, context: Any) -> None:

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -283,10 +283,17 @@ def build_sessions_view(
 
 
 # Catch-up tail shown after switching to a session -------------------------- #
-_TAIL_WINDOW = 6        # messages shown right after a switch
-_TAIL_STEP = 6          # extra messages added per "Load more"
-_TAIL_MAX = 18          # hard cap (keeps the card under Telegram's 4096 limit)
-_TAIL_MSG_MAX = 180     # per-message content truncation
+_TAIL_WINDOW = 8        # messages fetched for the catch-up view on switch
+_TAIL_STEP = 8          # extra messages fetched per "Load more"
+_TAIL_MAX = 30          # hard cap on how many messages to fetch
+# Rendered-card char budget. The newest message (usually the one you most want
+# to read) gets first claim up to _NEWEST_MAX; older messages get _OLDER_CAP
+# each from what remains. Bodies render as expandable blockquotes, so long
+# messages collapse to a few lines and expand in place — no hard truncation for
+# normal-sized messages, while the whole card stays under Telegram's 4096 limit.
+_TAIL_CARD_MAX = 3800   # max chars of the assembled HTML card (< Telegram's 4096)
+_NEWEST_MAX = 2000      # newest message body clip (raw) — it gets first/largest claim
+_OLDER_CAP = 700        # older message body clip (raw)
 _STATUS_EMOJI = {
     "active": "🟢",     # a client is connected (live / possibly mid-turn)
     "running": "🟢",    # defensive alias
@@ -307,12 +314,12 @@ def _safe_zone(tzname: str | None):
         return None
 
 
-def _one_line(text: str, limit: int) -> str:
-    """Collapse whitespace and truncate to a compact one-line preview."""
-    flat = " ".join((text or "").split())
-    if len(flat) > limit:
-        flat = flat[: limit - 1].rstrip() + "…"
-    return flat or "(no text)"
+def _clip(text: str, cap: int) -> str:
+    """Trim to `cap` visible chars and HTML-escape; '…' appended if truncated."""
+    t = (text or "").strip()
+    if len(t) > cap:
+        t = t[:cap].rstrip() + "…"
+    return _html.escape(t) if t else "(no text)"
 
 
 def _fmt_local(iso: str, tz) -> "tuple[str, str]":
@@ -334,39 +341,73 @@ def build_session_tail_view(
     window: int,
     tzname: str | None,
 ) -> "tuple[str, InlineKeyboardMarkup]":
-    """Render a session's recent history so the user can catch up after switching.
+    """Render a session's recent history (HTML) so the user can catch up.
 
     Native chat order — oldest at the top, most recent at the bottom — with a
     per-message timestamp converted to the user's timezone (``tzname``) so it
-    matches what the Telegram client shows; the timestamp is often as useful as
-    the text. ``messages`` is the last ``window`` messages (oldest→newest, as
-    ``get_messages`` returns them). The "Load more" button widens the window
-    (older history appears above) and is purely informational — it does not
-    change routing. Returns ``(text, keyboard)``.
+    matches the Telegram client (the timestamp is often as useful as the text).
+    Each body is an *expandable blockquote*: long messages collapse to a few
+    lines and expand in place on tap, so there is no hard truncation for normal
+    messages. The char budget is newest-first — the most recent message (usually
+    the important one) gets the largest share — while the whole card stays under
+    Telegram's 4096-char limit. ``messages`` is the last ``window`` messages
+    (oldest→newest). "Load more" fetches more older history; it does not change
+    routing. Returns ``(html_text, keyboard)`` — send/edit with ParseMode.HTML.
     """
     tz = _safe_zone(tzname)
     sid = session.get("id", "?")
     status = session.get("status") or "idle"
-    title = session.get("title") or sid
     emoji = _STATUS_EMOJI.get(status, "•")
-    shown = len(messages)
-    can_load_more = total > window and window < _TAIL_MAX
+    title = _html.escape(str(session.get("title") or sid))
+    header = (
+        f"🗂 <b>{title}</b>\n{emoji} {status} · "
+        f"{total} message" + ("" if total == 1 else "s")
+    )
 
-    lines = [f"🗂 {title}\n{emoji} {status} · {total} message" + ("" if total == 1 else "s")]
     if not messages:
-        lines.append("\n(no messages yet — send one to begin)")
-    else:
-        if total > shown:
-            hint = "tap Load more" if can_load_more else "open the session for the rest"
-            lines.append(f"… {total - shown} earlier — {hint}")
-        last_day = None
-        for m in messages:
-            day, hm = _fmt_local(m.get("created_at", ""), tz)
-            if day and day != last_day:
-                lines.append(f"— {day} —")
-                last_day = day
-            who = "🧑" if m.get("role") == "user" else "🤖"
-            lines.append(f"[{hm}] {who} {_one_line(m.get('content', ''), _TAIL_MSG_MAX)}")
+        rows = [[InlineKeyboardButton("🗂 Sessions", callback_data="sess:list")]]
+        return header + "\n\n<i>(no messages yet — send one to begin)</i>", InlineKeyboardMarkup(rows)
+
+    # Greedy newest-first: the newest message is added first with the largest
+    # clip (so it gets the most budget and is never starved); older messages are
+    # added while the assembled card stays within budget. The budget is measured
+    # on the *rendered, HTML-escaped* block length, so entity expansion (e.g. an
+    # apostrophe → "&#x27;") can never push the card past Telegram's 4096 limit.
+    included: list[tuple[str, str]] = []          # (day_label, block) newest-first
+    used = len(header) + 64                        # header + room for the "earlier" line
+    for idx, m in enumerate(reversed(messages)):   # newest → oldest
+        cap = _NEWEST_MAX if idx == 0 else _OLDER_CAP
+        day, hm = _fmt_local(m.get("created_at", ""), tz)
+        who = "🧑" if m.get("role") == "user" else "🤖"
+        block = (
+            f"[{hm}] {who}\n"
+            f"<blockquote expandable>{_clip(m.get('content', ''), cap)}</blockquote>"
+        )
+        cost = len(block) + len(day) + 6           # + possible day separator
+        if idx > 0 and used + cost > _TAIL_CARD_MAX:
+            break                                  # older message doesn't fit
+        included.append((day, block))
+        used += cost
+    included.reverse()                             # oldest→newest for display
+
+    earlier = total - len(included)
+    # "Load more" fetches more history; it only helps when everything fetched was
+    # shown and more exists (window-bound). If messages were dropped to fit the
+    # card (budget-bound), fetching more won't surface them — point to the session.
+    can_load_more = (
+        len(included) == len(messages) and total > window and window < _TAIL_MAX
+    )
+
+    lines = [header]
+    if earlier > 0:
+        hint = "tap Load more" if can_load_more else "open the session for the rest"
+        lines.append(f"<i>… {earlier} earlier — {hint}</i>")
+    last_day = None
+    for day, block in included:
+        if day and day != last_day:
+            lines.append(f"— {day} —")
+            last_day = day
+        lines.append(block)
     text = "\n".join(lines)
 
     rows: list[list[InlineKeyboardButton]] = []
@@ -1666,10 +1707,14 @@ class TelegramChannel(BaseChannel):
     #  Notification callback handlers                                      #
     # ------------------------------------------------------------------ #
 
-    async def _safe_edit(self, query: Any, text: str, markup: Any) -> None:
+    async def _safe_edit(
+        self, query: Any, text: str, markup: Any, parse_mode: Any = None,
+    ) -> None:
         """edit_message_text, swallowing the benign 'not modified'/transient errors."""
         try:
-            await query.edit_message_text(text=text, reply_markup=markup)
+            await query.edit_message_text(
+                text=text, reply_markup=markup, parse_mode=parse_mode,
+            )
         except Exception:
             pass
 
@@ -1689,7 +1734,7 @@ class TelegramChannel(BaseChannel):
         text, markup = build_session_tail_view(
             session, messages, total, window, self.config.timezone,
         )
-        await self._safe_edit(query, text, markup)
+        await self._safe_edit(query, text, markup, parse_mode=ParseMode.HTML)
 
     async def _handle_session_button(self, query: Any) -> None:
         """Handle /sessions inline-keyboard presses.

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -19,8 +19,10 @@ import subprocess
 import sys
 import time
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ChatAction, ParseMode
@@ -277,6 +279,96 @@ def build_sessions_view(
         text += "\n➕ New session keeps the current one running."
     else:
         text = "No sessions yet — tap ➕ to start one."
+    return text, InlineKeyboardMarkup(rows)
+
+
+# Catch-up tail shown after switching to a session -------------------------- #
+_TAIL_WINDOW = 6        # messages shown right after a switch
+_TAIL_STEP = 6          # extra messages added per "Load more"
+_TAIL_MAX = 18          # hard cap (keeps the card under Telegram's 4096 limit)
+_TAIL_MSG_MAX = 180     # per-message content truncation
+_STATUS_EMOJI = {"running": "🟢", "idle": "✅", "stopped": "⏹", "error": "⚠️"}
+
+
+def _safe_zone(tzname: str | None):
+    """ZoneInfo for the user's configured tz, or None → fall back to system local."""
+    if not tzname:
+        return None
+    try:
+        return ZoneInfo(tzname)
+    except Exception:
+        return None
+
+
+def _one_line(text: str, limit: int) -> str:
+    """Collapse whitespace and truncate to a compact one-line preview."""
+    flat = " ".join((text or "").split())
+    if len(flat) > limit:
+        flat = flat[: limit - 1].rstrip() + "…"
+    return flat or "(no text)"
+
+
+def _fmt_local(iso: str, tz) -> "tuple[str, str]":
+    """Return (day label, HH:MM) for an ISO timestamp in the user's timezone."""
+    try:
+        dt = datetime.fromisoformat(iso)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        local = dt.astimezone(tz) if tz else dt.astimezone()
+        return local.strftime("%a %b %d"), local.strftime("%H:%M")
+    except Exception:
+        return "", "--:--"
+
+
+def build_session_tail_view(
+    session: dict,
+    messages: list[dict],
+    total: int,
+    window: int,
+    tzname: str | None,
+) -> "tuple[str, InlineKeyboardMarkup]":
+    """Render a session's recent history so the user can catch up after switching.
+
+    Native chat order — oldest at the top, most recent at the bottom — with a
+    per-message timestamp converted to the user's timezone (``tzname``) so it
+    matches what the Telegram client shows; the timestamp is often as useful as
+    the text. ``messages`` is the last ``window`` messages (oldest→newest, as
+    ``get_messages`` returns them). The "Load more" button widens the window
+    (older history appears above) and is purely informational — it does not
+    change routing. Returns ``(text, keyboard)``.
+    """
+    tz = _safe_zone(tzname)
+    sid = session.get("id", "?")
+    status = session.get("status") or "idle"
+    title = session.get("title") or sid
+    emoji = _STATUS_EMOJI.get(status, "•")
+    shown = len(messages)
+    can_load_more = total > window and window < _TAIL_MAX
+
+    lines = [f"🗂 {title}\n{emoji} {status} · {total} message" + ("" if total == 1 else "s")]
+    if not messages:
+        lines.append("\n(no messages yet — send one to begin)")
+    else:
+        if total > shown:
+            hint = "tap Load more" if can_load_more else "open the session for the rest"
+            lines.append(f"… {total - shown} earlier — {hint}")
+        last_day = None
+        for m in messages:
+            day, hm = _fmt_local(m.get("created_at", ""), tz)
+            if day and day != last_day:
+                lines.append(f"— {day} —")
+                last_day = day
+            who = "🧑" if m.get("role") == "user" else "🤖"
+            lines.append(f"[{hm}] {who} {_one_line(m.get('content', ''), _TAIL_MSG_MAX)}")
+    text = "\n".join(lines)
+
+    rows: list[list[InlineKeyboardButton]] = []
+    if can_load_more:
+        nxt = min(window + _TAIL_STEP, _TAIL_MAX)
+        rows.append(
+            [InlineKeyboardButton("⬆️ Load more", callback_data=f"sesstail:{sid}:{nxt}")]
+        )
+    rows.append([InlineKeyboardButton("🗂 Sessions", callback_data="sess:list")])
     return text, InlineKeyboardMarkup(rows)
 
 
@@ -1567,21 +1659,76 @@ class TelegramChannel(BaseChannel):
     #  Notification callback handlers                                      #
     # ------------------------------------------------------------------ #
 
-    async def _handle_session_switch(self, query: Any) -> None:
-        """Handle a /sessions button press: switch routing (or start a new one).
+    async def _safe_edit(self, query: Any, text: str, markup: Any) -> None:
+        """edit_message_text, swallowing the benign 'not modified'/transient errors."""
+        try:
+            await query.edit_message_text(text=text, reply_markup=markup)
+        except Exception:
+            pass
 
-        ``callback_data`` is ``sess:<id>`` or ``sess:new``. After acting, the
-        message is re-rendered in place with the new current session marked ✓,
-        mirroring how notification cards update on answer.
+    async def _edit_session_tail(
+        self, query: Any, session_id: str, window: int,
+    ) -> None:
+        """Render a session's recent history (catch-up view) into the card in place."""
+        window = max(1, min(window, _TAIL_MAX))
+        session = await self.router.get_session(session_id)
+        if not session:
+            channel_key = f"telegram:{query.message.chat.id}"
+            text, markup = await self._sessions_view_for(channel_key)
+            await self._safe_edit(query, text, markup)
+            return
+        messages = await self.router.get_session_messages(session_id, limit=window)
+        total = await self.router.count_session_messages(session_id)
+        text, markup = build_session_tail_view(
+            session, messages, total, window, self.config.timezone,
+        )
+        await self._safe_edit(query, text, markup)
+
+    async def _handle_session_button(self, query: Any) -> None:
+        """Handle /sessions inline-keyboard presses.
+
+        callback_data forms:
+          ``sess:list``           — (re)show the session switch list
+          ``sess:new``            — create a fresh session (current keeps running)
+          ``sess:<id>``           — switch routing to <id>, then show its history
+          ``sesstail:<id>:<win>`` — widen the catch-up window (informational only)
+
+        After a switch/create the card is replaced by that session's recent
+        history (native order, oldest→newest) so the user can catch up — which
+        matters most when switching into a background session they weren't
+        following.
         """
         if not query.message:
             await query.answer()
             return
         channel_key = f"telegram:{query.message.chat.id}"
-        target = query.data.split(":", 1)[1]
+        data = query.data
+
+        if data == "sess:list":
+            await query.answer()
+            text, markup = await self._sessions_view_for(channel_key)
+            await self._safe_edit(query, text, markup)
+            return
+
+        if data.startswith("sesstail:"):
+            parts = data.split(":")
+            sid = parts[1] if len(parts) > 1 else ""
+            try:
+                window = int(parts[2])
+            except (IndexError, ValueError):
+                window = _TAIL_WINDOW
+            await query.answer()
+            await self._edit_session_tail(query, sid, window)
+            return
+
+        # sess:new / sess:<id>
+        target = data.split(":", 1)[1]
+        sid = target
         try:
             if target == "new":
-                await self.router.create_session(channel_key, source="telegram")
+                sid = await self.router.create_session(
+                    channel_key, source="telegram",
+                )
                 await query.answer("Started a new session")
             else:
                 await self.router.switch_session(channel_key, target)
@@ -1590,11 +1737,10 @@ class TelegramChannel(BaseChannel):
             await query.answer(
                 "That session is no longer available", show_alert=True,
             )
-        text, markup = await self._sessions_view_for(channel_key)
-        try:
-            await query.edit_message_text(text=text, reply_markup=markup)
-        except Exception:
-            pass
+            text, markup = await self._sessions_view_for(channel_key)
+            await self._safe_edit(query, text, markup)
+            return
+        await self._edit_session_tail(query, sid, _TAIL_WINDOW)
 
     async def _handle_callback_query(self, update: Update, context: Any) -> None:
         """Handle inline keyboard button presses for notification questions."""
@@ -1607,9 +1753,9 @@ class TelegramChannel(BaseChannel):
             await query.answer("Unauthorized", show_alert=True)
             return
 
-        # Session switch/create buttons from /sessions.
-        if query.data.startswith("sess:"):
-            await self._handle_session_switch(query)
+        # /sessions inline keyboard: switch/create/list + history buttons.
+        if query.data.startswith("sess:") or query.data.startswith("sesstail:"):
+            await self._handle_session_button(query)
             return
 
         # Parse callback_data: "notif:{notification_id}:{answer}"

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -258,6 +258,10 @@ def build_sessions_view(
         )
     rows.append([InlineKeyboardButton("➕ New session", callback_data="sess:new")])
 
+    # The New-session button switches routing to a fresh session WITHOUT
+    # stopping the current one (unlike /new). A session switched away from
+    # keeps running any in-flight turn and still delivers its result to the
+    # chat (output is bound per-session, not to the channel's current map).
     if rows[:-1]:
         current_title = next(
             (
@@ -270,8 +274,9 @@ def build_sessions_view(
         text = "🗂 Sessions — tap to switch."
         if current_title:
             text += f"\nCurrent: {current_title}"
+        text += "\n➕ New session keeps the current one running."
     else:
-        text = "No sessions yet — start one:"
+        text = "No sessions yet — tap ➕ to start one."
     return text, InlineKeyboardMarkup(rows)
 
 

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -22,7 +22,7 @@ import zipfile
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
-from telegram import Update
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ChatAction, ParseMode
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, MessageReactionHandler, filters
 
@@ -218,6 +218,61 @@ def _format_reply_context(message: Any) -> str:
             parts.append(f'[Quoted: "{quote_text}"]')
 
     return "\n".join(parts)
+
+
+# Inline-keyboard /sessions rendering ------------------------------------- #
+_SESSIONS_BUTTON_LIMIT = 8      # keep the keyboard thumb-friendly on mobile
+_SESSION_LABEL_MAX = 40         # Telegram wraps long button labels poorly
+
+
+def _session_label(session: dict, current_id: str | None) -> str:
+    """Button label for one session: title (or short id), current marked ✓."""
+    title = (session.get("title") or "").strip() or session.get("id", "?")
+    if len(title) > _SESSION_LABEL_MAX:
+        title = title[: _SESSION_LABEL_MAX - 1] + "…"
+    prefix = "✓ " if session.get("id") == current_id else ""
+    return f"{prefix}{title}"
+
+
+def build_sessions_view(
+    sessions: list[dict], current_id: str | None,
+) -> "tuple[str, InlineKeyboardMarkup]":
+    """Render the /sessions inline keyboard (pure, sync — unit-testable).
+
+    One tap-to-switch button per session (the current one marked ✓), with the
+    session id carried in ``callback_data`` as ``sess:<id>`` — so switching
+    routing takes a single tap and never requires copy-pasting an id on mobile.
+    A trailing ``➕ New session`` button (``sess:new``) starts a fresh one.
+    Returns ``(message_text, keyboard)``.
+    """
+    rows: list[list[InlineKeyboardButton]] = []
+    for s in sessions[:_SESSIONS_BUTTON_LIMIT]:
+        sid = s.get("id")
+        cb = f"sess:{sid}"
+        # callback_data is capped at 64 bytes by Telegram; interactive session
+        # ids are short, but guard defensively so a button always round-trips.
+        if sid is None or len(cb.encode("utf-8")) > 64:
+            continue
+        rows.append(
+            [InlineKeyboardButton(_session_label(s, current_id), callback_data=cb)]
+        )
+    rows.append([InlineKeyboardButton("➕ New session", callback_data="sess:new")])
+
+    if rows[:-1]:
+        current_title = next(
+            (
+                (s.get("title") or s.get("id"))
+                for s in sessions
+                if s.get("id") == current_id
+            ),
+            None,
+        )
+        text = "🗂 Sessions — tap to switch."
+        if current_title:
+            text += f"\nCurrent: {current_title}"
+    else:
+        text = "No sessions yet — start one:"
+    return text, InlineKeyboardMarkup(rows)
 
 
 class TelegramChannel(BaseChannel):
@@ -853,21 +908,32 @@ class TelegramChannel(BaseChannel):
         except ValueError as e:
             await update.message.reply_text(str(e))
 
+    async def _sessions_view_for(
+        self, channel_key: str,
+    ) -> "tuple[str, InlineKeyboardMarkup]":
+        """Build the inline-keyboard sessions view for a channel.
+
+        Shared by /sessions and the button-press handler so both render the
+        same thing. Only interactive (telegram/web) sessions are offered as
+        switch targets — cron/automation sessions are never listed.
+        """
+        current = await self.router.get_last_session(channel_key)
+        sessions = await self.router.list_sessions(limit=30)
+        sessions = [s for s in sessions if s.get("source") in ("telegram", "web")]
+        return build_sessions_view(sessions, current)
+
     async def _handle_sessions(self, update: Update, context: Any) -> None:
-        """Handle /sessions — list sessions."""
+        """Handle /sessions — native inline keyboard to switch session routing.
+
+        Each recent session is a tap-to-switch button (current marked ✓); the
+        id rides in the button's callback_data, so no id copy-paste is needed.
+        """
         self._touch()
         if not self._is_authorized(update.effective_user.id):
             return
-
-        sessions = await self.router.list_sessions(limit=20)
-        if not sessions:
-            await update.message.reply_text("No sessions.")
-            return
-
-        lines = []
-        for s in sessions:
-            lines.append(f"• `{s['id']}` — {s.get('title', 'untitled')}")
-        await update.message.reply_text("\n".join(lines), parse_mode=ParseMode.MARKDOWN)
+        channel_key = f"telegram:{update.effective_chat.id}"
+        text, markup = await self._sessions_view_for(channel_key)
+        await update.message.reply_text(text, reply_markup=markup)
 
     async def _handle_new_session(self, update: Update, context: Any) -> None:
         """Handle /new [title] — stop current session, create and switch to a new one."""
@@ -1496,6 +1562,35 @@ class TelegramChannel(BaseChannel):
     #  Notification callback handlers                                      #
     # ------------------------------------------------------------------ #
 
+    async def _handle_session_switch(self, query: Any) -> None:
+        """Handle a /sessions button press: switch routing (or start a new one).
+
+        ``callback_data`` is ``sess:<id>`` or ``sess:new``. After acting, the
+        message is re-rendered in place with the new current session marked ✓,
+        mirroring how notification cards update on answer.
+        """
+        if not query.message:
+            await query.answer()
+            return
+        channel_key = f"telegram:{query.message.chat.id}"
+        target = query.data.split(":", 1)[1]
+        try:
+            if target == "new":
+                await self.router.create_session(channel_key, source="telegram")
+                await query.answer("Started a new session")
+            else:
+                await self.router.switch_session(channel_key, target)
+                await query.answer("Switched")
+        except ValueError:
+            await query.answer(
+                "That session is no longer available", show_alert=True,
+            )
+        text, markup = await self._sessions_view_for(channel_key)
+        try:
+            await query.edit_message_text(text=text, reply_markup=markup)
+        except Exception:
+            pass
+
     async def _handle_callback_query(self, update: Update, context: Any) -> None:
         """Handle inline keyboard button presses for notification questions."""
         self._touch()
@@ -1505,6 +1600,11 @@ class TelegramChannel(BaseChannel):
 
         if not self._is_authorized(query.from_user.id):
             await query.answer("Unauthorized", show_alert=True)
+            return
+
+        # Session switch/create buttons from /sessions.
+        if query.data.startswith("sess:"):
+            await self._handle_session_switch(query)
             return
 
         # Parse callback_data: "notif:{notification_id}:{answer}"

--- a/nerve/channels/telegram.py
+++ b/nerve/channels/telegram.py
@@ -1065,7 +1065,12 @@ class TelegramChannel(BaseChannel):
         current = await self.router.get_last_session(channel_key)
         sessions = await self.router.list_sessions(limit=30)
         sessions = [s for s in sessions if s.get("source") in ("telegram", "web")]
-        return build_sessions_view(sessions, current)
+        # Drop empty (0-message) sessions — nothing to switch to or catch up on.
+        non_empty = []
+        for s in sessions:
+            if await self.router.count_session_messages(s["id"]) > 0:
+                non_empty.append(s)
+        return build_sessions_view(non_empty, current)
 
     async def _handle_sessions(self, update: Update, context: Any) -> None:
         """Handle /sessions — native inline keyboard to switch session routing.

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -1,5 +1,7 @@
 """Tests for the /sessions inline-keyboard builder (nerve.channels.telegram)."""
 
+import pytest
+
 from nerve.channels.telegram import build_session_tail_view, build_sessions_view
 
 
@@ -164,6 +166,38 @@ def test_tail_stays_within_telegram_message_limit():
     msgs = [_msg("assistant", "y" * 1000, "2026-07-18T09:00:00+00:00") for _ in range(30)]
     text, _m = build_session_tail_view(_SESSION, msgs, total=30, window=30, tzname="UTC")
     assert len(text) <= 4096
+
+
+# --- /sessions list excludes empty sessions -------------------------------- #
+
+class _FakeRouter:
+    def __init__(self, sessions, counts, current):
+        self._s, self._c, self._cur = sessions, counts, current
+
+    async def get_last_session(self, _channel_key):
+        return self._cur
+
+    async def list_sessions(self, limit=20):
+        return self._s
+
+    async def count_session_messages(self, session_id):
+        return self._c.get(session_id, 0)
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_excludes_empty_sessions():
+    from nerve.channels.telegram import TelegramChannel
+    sessions = [
+        {"id": "has111", "title": "Has messages", "source": "telegram"},
+        {"id": "empty2", "title": "empty2", "source": "web"},       # 0 messages
+    ]
+    ch = TelegramChannel.__new__(TelegramChannel)   # bypass __init__; only .router needed
+    ch.router = _FakeRouter(sessions, {"has111": 4, "empty2": 0}, current="has111")
+    _text, markup = await ch._sessions_view_for("telegram:1")
+    cbs = [b.callback_data for row in markup.inline_keyboard for b in row]
+    assert "sess:has111" in cbs        # non-empty shown
+    assert "sess:empty2" not in cbs    # empty hidden
+    assert "sess:new" in cbs           # New button still present
 
 
 def test_tail_empty_session():

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -173,6 +173,7 @@ def test_tail_stays_within_telegram_message_limit():
 class _FakeRouter:
     def __init__(self, sessions, counts, current):
         self._s, self._c, self._cur = sessions, counts, current
+        self.count_calls = 0
 
     async def get_last_session(self, _channel_key):
         return self._cur
@@ -181,6 +182,7 @@ class _FakeRouter:
         return self._s
 
     async def count_session_messages(self, session_id):
+        self.count_calls += 1
         return self._c.get(session_id, 0)
 
 
@@ -198,6 +200,24 @@ async def test_sessions_list_excludes_empty_sessions():
     assert "sess:has111" in cbs        # non-empty shown
     assert "sess:empty2" not in cbs    # empty hidden
     assert "sess:new" in cbs           # New button still present
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_caps_at_button_limit_and_stops_counting():
+    from nerve.channels.telegram import TelegramChannel, _SESSIONS_BUTTON_LIMIT
+    sessions = [
+        {"id": f"s{n:02d}", "title": f"S{n}", "source": "telegram"} for n in range(12)
+    ]
+    counts = {s["id"]: 5 for s in sessions}
+    ch = TelegramChannel.__new__(TelegramChannel)
+    ch.router = _FakeRouter(sessions, counts, current="s00")
+    _text, markup = await ch._sessions_view_for("telegram:1")
+    session_btns = [
+        b for row in markup.inline_keyboard for b in row
+        if b.callback_data.startswith("sess:") and b.callback_data != "sess:new"
+    ]
+    assert len(session_btns) == _SESSIONS_BUTTON_LIMIT       # keyboard capped
+    assert ch.router.count_calls == _SESSIONS_BUTTON_LIMIT   # stopped counting early
 
 
 def test_tail_empty_session():

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -28,6 +28,16 @@ def test_new_session_button_always_present():
     assert "No sessions" in text
 
 
+def test_new_session_note_reassures_current_keeps_running():
+    # The New-session button must not read like /new (which stops the current);
+    # the view states the current session keeps running.
+    text, _markup = build_sessions_view(
+        [{"id": "aaaa1111", "title": "Work", "source": "telegram"}],
+        current_id="aaaa1111",
+    )
+    assert "keeps the current one running" in text
+
+
 def test_long_title_truncated():
     long = "x" * 100
     _text, markup = build_sessions_view(

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -1,0 +1,69 @@
+"""Tests for the /sessions inline-keyboard builder (nerve.channels.telegram)."""
+
+from nerve.channels.telegram import build_sessions_view
+
+
+def _flat(markup):
+    return [btn for row in markup.inline_keyboard for btn in row]
+
+
+def test_current_session_marked_and_ids_ride_in_callback_data():
+    sessions = [
+        {"id": "aaaa1111", "title": "First", "source": "telegram"},
+        {"id": "bbbb2222", "title": "Second", "source": "web"},
+    ]
+    text, markup = build_sessions_view(sessions, current_id="bbbb2222")
+    btns = _flat(markup)
+    by_cb = {b.callback_data: b for b in btns}
+    # Each session is a tap-to-switch button carrying its id (no copy-paste).
+    assert by_cb["sess:aaaa1111"].text == "First"
+    assert by_cb["sess:bbbb2222"].text == "✓ Second"   # current marked
+    assert "Current: Second" in text
+
+
+def test_new_session_button_always_present():
+    text, markup = build_sessions_view([], current_id=None)
+    cbs = [b.callback_data for b in _flat(markup)]
+    assert cbs == ["sess:new"]
+    assert "No sessions" in text
+
+
+def test_long_title_truncated():
+    long = "x" * 100
+    _text, markup = build_sessions_view(
+        [{"id": "cccc3333", "title": long, "source": "telegram"}], current_id=None,
+    )
+    label = _flat(markup)[0].text
+    assert label.endswith("…")
+    assert len(label) <= 40
+
+
+def test_missing_title_falls_back_to_id():
+    _text, markup = build_sessions_view(
+        [{"id": "dddd4444", "source": "telegram"}], current_id="dddd4444",
+    )
+    assert _flat(markup)[0].text == "✓ dddd4444"
+
+
+def test_button_limit_caps_sessions_but_keeps_new():
+    sessions = [
+        {"id": f"id{n:06d}", "title": f"S{n}", "source": "web"} for n in range(20)
+    ]
+    _text, markup = build_sessions_view(sessions, current_id=None)
+    rows = markup.inline_keyboard
+    # 8 session buttons + 1 trailing "New session" row.
+    assert len(rows) == 9
+    assert rows[-1][0].callback_data == "sess:new"
+
+
+def test_oversized_callback_data_is_skipped():
+    huge = "z" * 70  # sess:<70z> > 64 bytes → cannot round-trip, must be dropped
+    sessions = [
+        {"id": huge, "title": "too big", "source": "web"},
+        {"id": "eeee5555", "title": "ok", "source": "web"},
+    ]
+    _text, markup = build_sessions_view(sessions, current_id=None)
+    cbs = [b.callback_data for b in _flat(markup)]
+    assert f"sess:{huge}" not in cbs
+    assert "sess:eeee5555" in cbs
+    assert "sess:new" in cbs

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -142,3 +142,12 @@ def test_tail_empty_session():
     )
     assert "no messages yet" in text
     assert _cbs(markup) == ["sess:list"]
+
+
+def test_tail_active_status_shows_live_emoji():
+    # A live session's status value is "active" (not "running") — it must render
+    # the live marker, not the fallback bullet.
+    text, _m = build_session_tail_view(
+        {"id": "a", "title": "T", "status": "active"}, [], total=0, window=6, tzname="UTC",
+    )
+    assert "🟢" in text and "•" not in text

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -1,10 +1,14 @@
 """Tests for the /sessions inline-keyboard builder (nerve.channels.telegram)."""
 
-from nerve.channels.telegram import build_sessions_view
+from nerve.channels.telegram import build_session_tail_view, build_sessions_view
 
 
 def _flat(markup):
     return [btn for row in markup.inline_keyboard for btn in row]
+
+
+def _cbs(markup):
+    return [b.callback_data for b in _flat(markup)]
 
 
 def test_current_session_marked_and_ids_ride_in_callback_data():
@@ -77,3 +81,64 @@ def test_oversized_callback_data_is_skipped():
     assert f"sess:{huge}" not in cbs
     assert "sess:eeee5555" in cbs
     assert "sess:new" in cbs
+
+
+# --- catch-up tail (build_session_tail_view) ------------------------------- #
+
+_SESSION = {"id": "aaaa1111", "title": "Work", "status": "idle"}
+
+
+def _msg(role, content, iso):
+    return {"role": role, "content": content, "created_at": iso}
+
+
+def test_tail_native_order_oldest_top_recent_bottom():
+    msgs = [
+        _msg("user", "FIRST question", "2026-07-18T09:00:00+00:00"),
+        _msg("assistant", "SECOND answer", "2026-07-18T09:05:00+00:00"),
+        _msg("user", "THIRD followup", "2026-07-18T09:10:00+00:00"),
+    ]
+    text, _markup = build_session_tail_view(_SESSION, msgs, total=3, window=6, tzname="UTC")
+    # Native chat order: earlier messages appear above later ones.
+    assert text.index("FIRST") < text.index("SECOND") < text.index("THIRD")
+    assert "🧑" in text and "🤖" in text
+
+
+def test_tail_timestamps_in_user_timezone():
+    # 09:00 UTC rendered for a UTC+3 zone must read 12:00 (matches the user's client).
+    msgs = [_msg("user", "hi", "2026-07-18T09:00:00+00:00")]
+    text, _m = build_session_tail_view(_SESSION, msgs, total=1, window=6, tzname="Europe/Moscow")
+    assert "[12:00]" in text
+    # And the same instant is 09:00 in UTC.
+    text_utc, _ = build_session_tail_view(_SESSION, msgs, total=1, window=6, tzname="UTC")
+    assert "[09:00]" in text_utc
+
+
+def test_tail_load_more_button_when_more_history():
+    msgs = [_msg("user", f"m{n}", "2026-07-18T09:00:00+00:00") for n in range(6)]
+    text, markup = build_session_tail_view(_SESSION, msgs, total=20, window=6, tzname="UTC")
+    cbs = _cbs(markup)
+    assert "sesstail:aaaa1111:12" in cbs   # next window = 6 + step(6)
+    assert "sess:list" in cbs              # back-to-list always present
+    assert "14 earlier" in text            # 20 - 6 shown
+
+
+def test_tail_no_load_more_when_all_shown():
+    msgs = [_msg("user", "only", "2026-07-18T09:00:00+00:00")]
+    _text, markup = build_session_tail_view(_SESSION, msgs, total=1, window=6, tzname="UTC")
+    assert _cbs(markup) == ["sess:list"]   # no Load more
+
+
+def test_tail_capped_offers_no_more_but_hints_full_history():
+    msgs = [_msg("assistant", f"m{n}", "2026-07-18T09:00:00+00:00") for n in range(18)]
+    text, markup = build_session_tail_view(_SESSION, msgs, total=100, window=18, tzname="UTC")
+    assert not any(c.startswith("sesstail:") for c in _cbs(markup))
+    assert "open the session for the rest" in text
+
+
+def test_tail_empty_session():
+    text, markup = build_session_tail_view(
+        {"id": "x", "status": "running"}, [], total=0, window=6, tzname="UTC",
+    )
+    assert "no messages yet" in text
+    assert _cbs(markup) == ["sess:list"]

--- a/tests/test_telegram_sessions.py
+++ b/tests/test_telegram_sessions.py
@@ -118,9 +118,9 @@ def test_tail_load_more_button_when_more_history():
     msgs = [_msg("user", f"m{n}", "2026-07-18T09:00:00+00:00") for n in range(6)]
     text, markup = build_session_tail_view(_SESSION, msgs, total=20, window=6, tzname="UTC")
     cbs = _cbs(markup)
-    assert "sesstail:aaaa1111:12" in cbs   # next window = 6 + step(6)
+    assert "sesstail:aaaa1111:14" in cbs   # next window = 6 + step(8)
     assert "sess:list" in cbs              # back-to-list always present
-    assert "14 earlier" in text            # 20 - 6 shown
+    assert "14 earlier" in text            # 20 - 6 shown (short msgs, none dropped)
 
 
 def test_tail_no_load_more_when_all_shown():
@@ -129,11 +129,41 @@ def test_tail_no_load_more_when_all_shown():
     assert _cbs(markup) == ["sess:list"]   # no Load more
 
 
-def test_tail_capped_offers_no_more_but_hints_full_history():
-    msgs = [_msg("assistant", f"m{n}", "2026-07-18T09:00:00+00:00") for n in range(18)]
-    text, markup = build_session_tail_view(_SESSION, msgs, total=100, window=18, tzname="UTC")
+def test_tail_budget_bound_offers_no_more_but_hints_full_history():
+    # Long messages exhaust the char budget, so some fetched messages are dropped
+    # (budget-bound) — fetching more won't surface them; point to the session.
+    msgs = [_msg("assistant", "x" * 400, "2026-07-18T09:00:00+00:00") for _ in range(18)]
+    text, markup = build_session_tail_view(_SESSION, msgs, total=50, window=18, tzname="UTC")
     assert not any(c.startswith("sesstail:") for c in _cbs(markup))
     assert "open the session for the rest" in text
+
+
+def test_tail_newest_gets_the_most_budget():
+    import re
+    # Long messages so the budget binds; the newest must get the largest share.
+    msgs = [
+        _msg("user", "O" * 1500, "2026-07-18T09:00:00+00:00"),
+        _msg("assistant", "O" * 1500, "2026-07-18T09:01:00+00:00"),
+        _msg("user", "O" * 1500, "2026-07-18T09:02:00+00:00"),
+        _msg("assistant", "N" * 2000, "2026-07-18T09:03:00+00:00"),
+    ]
+    text, _m = build_session_tail_view(_SESSION, msgs, total=4, window=8, tzname="UTC")
+    bodies = re.findall(r"<blockquote expandable>(.*?)</blockquote>", text, re.S)
+    assert bodies[-1].count("N") >= 2000                       # newest shown in full
+    assert all(len(b) < len(bodies[-1]) for b in bodies[:-1])  # newest is the largest
+
+
+def test_tail_uses_expandable_blockquote_and_escapes_html():
+    msgs = [_msg("assistant", "<b>&danger</b>", "2026-07-18T09:00:00+00:00")]
+    text, _m = build_session_tail_view(_SESSION, msgs, total=1, window=6, tzname="UTC")
+    assert "<blockquote expandable>" in text     # native collapse/expand
+    assert "&lt;b&gt;&amp;danger&lt;/b&gt;" in text  # content HTML-escaped
+
+
+def test_tail_stays_within_telegram_message_limit():
+    msgs = [_msg("assistant", "y" * 1000, "2026-07-18T09:00:00+00:00") for _ in range(30)]
+    text, _m = build_session_tail_view(_SESSION, msgs, total=30, window=30, tzname="UTC")
+    assert len(text) <= 4096
 
 
 def test_tail_empty_session():


### PR DESCRIPTION
Makes `/sessions` a native, mobile-friendly way to see, switch, and catch up on sessions — replacing the old plain-text id list.

## 1. Inline-keyboard session switching
- one **tap-to-switch** button per session (current marked ✓); the id rides in `callback_data` (`sess:<id>`) — no id copy-paste on mobile;
- a **➕ New session** button that starts a fresh session **without stopping the current one** (unlike `/new`). Output is bound per-session (`engine._active_channel[session_id]`), so a session you switch away from keeps running and still delivers to the chat;
- **empty (0-message) sessions are hidden** — not useful switch targets; the list stops counting once the keyboard is full.

## 2. Catch-up history tail on switch
Switching to a session — especially a background one you weren't following — shows its recent history so you can catch up:
- **native chat order** — oldest at the top, most recent at the bottom;
- each message body is an **expandable blockquote** (Bot API 7.0+): long messages collapse to a few lines and **expand in place on tap** — no hard truncation;
- **newest-priority budget**: the most recent message (usually the important one) gets the largest share and is never starved; older messages fill the remainder newest-first. The budget is measured on the assembled, HTML-escaped string, so entity expansion can't push the card past Telegram's 4096-char limit;
- each line carries a **timestamp in the user's timezone** (`config.timezone`), matching the Telegram client;
- **⬆️ Load more** fetches more older history (informational; never changes routing); **🗂 Sessions** returns to the list. No LLM recap by design — ask inside the session.

> Note: honouring the switch for a long-idle session (so the next message actually routes there) is the companion core fix in the session-stickiness PR.

## Reuse (no new infrastructure)
`InlineKeyboardButton`/`Markup` (as in `notifications/service.py`); the single existing `CallbackQueryHandler`, extended with `sess:`/`sesstail:` branches; router helpers `list_sessions`/`switch_session`/`create_session`/`get_last_session` + thin new `get_session`/`get_session_messages`/`count_session_messages` over `engine.db`.

`/session <id>` text command kept for back-compat. Only interactive (telegram/web) sessions are listed; `callback_data` guarded against the 64-byte cap.

## Tests
`tests/test_telegram_sessions.py` (19 tests): switch-list (current-marked, ids in callback_data, New button, empty-session exclusion, keyboard cap) and tail (native order, timezone conversion, expandable blockquote + HTML escaping, newest-priority budget, load-more windowing, 4096-limit safety). Full suite: **1565 passed, 2 skipped**. Backend-only.
