### PR TITLE
Fail loudly when two migrations share a version number

### DIFF
--- a/nerve/db/migrations/runner.py
+++ b/nerve/db/migrations/runner.py
@@ -12,10 +12,33 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 
 
+def _check_no_duplicate_versions(items: list[tuple[int, str]]) -> None:
+    """Raise ``RuntimeError`` if two migration files share a version.
+
+    ``run_migrations`` skips anything at or below the recorded schema
+    version, so when two files claim the same number one silently wins and
+    the other never runs — on every database, forever, with no error. The
+    symptom surfaces much later as a missing column or index, and which of
+    the two is missing depends on filesystem iteration order.
+
+    Failing loudly at import is the lesser evil: the collision is a
+    packaging mistake, and it is cheap to fix once you know it happened.
+    """
+    seen: dict[int, str] = {}
+    for version, name in items:
+        if version in seen:
+            raise RuntimeError(
+                f"Duplicate migration version {version}: "
+                f"{seen[version]!r} and {name!r}. Renumber one of them."
+            )
+        seen[version] = name
+
+
 def discover_migrations() -> list[tuple[int, str]]:
     """Scan the migrations package for vNNN_*.py files.
 
-    Returns sorted list of (version, module_name) tuples.
+    Returns sorted list of (version, module_name) tuples. Raises if two
+    files share a version number.
     """
     migrations_dir = Path(__file__).parent
     results: list[tuple[int, str]] = []
@@ -28,6 +51,7 @@ def discover_migrations() -> list[tuple[int, str]]:
             except ValueError:
                 continue
     results.sort(key=lambda x: x[0])
+    _check_no_duplicate_versions(results)
     return results
 
 

--- a/tests/test_migrations_runner.py
+++ b/tests/test_migrations_runner.py
@@ -1,0 +1,50 @@
+"""Tests for the migration runner's duplicate-version guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from nerve.db.migrations.runner import (
+    _check_no_duplicate_versions,
+    discover_migrations,
+)
+
+
+class TestNoDuplicateVersions:
+    def test_unique_versions_ok(self):
+        _check_no_duplicate_versions([(1, "v001_a"), (2, "v002_b"), (3, "v003_c")])
+
+    def test_duplicate_raises(self):
+        with pytest.raises(RuntimeError, match="Duplicate migration version 27"):
+            _check_no_duplicate_versions([(27, "v027_alpha"), (27, "v027_beta")])
+
+    def test_duplicate_at_zero(self):
+        with pytest.raises(RuntimeError, match="Duplicate migration version 0"):
+            _check_no_duplicate_versions([(0, "v000_x"), (0, "v000_y")])
+
+    def test_error_names_both_files(self):
+        # Without both names the maintainer still has to go hunting for
+        # which two files collided.
+        with pytest.raises(RuntimeError) as exc:
+            _check_no_duplicate_versions([(5, "v005_first"), (5, "v005_second")])
+        assert "v005_first" in str(exc.value)
+        assert "v005_second" in str(exc.value)
+
+    def test_triplicate_reports_the_first_collision(self):
+        with pytest.raises(RuntimeError, match="Duplicate migration version 9"):
+            _check_no_duplicate_versions(
+                [(9, "v009_a"), (9, "v009_b"), (9, "v009_c")]
+            )
+
+    def test_current_migrations_have_no_duplicates(self):
+        # Regression check on the real on-disk set, so a collision added
+        # later fails here rather than silently at a user's startup.
+        discovered = discover_migrations()
+        versions = [v for v, _ in discovered]
+        assert len(versions) == len(set(versions)), (
+            f"Duplicate versions in nerve/db/migrations/: {discovered}"
+        )
+
+    def test_discovery_still_returns_sorted_versions(self):
+        versions = [v for v, _ in discover_migrations()]
+        assert versions == sorted(versions)


### PR DESCRIPTION
`run_migrations` skips anything at or below the recorded schema version, so if two files claim the same number, one silently wins and the other **never runs** — on every database, forever, with no error.

It surfaces much later as a missing column or index, and which of the two is missing depends on filesystem iteration order, so it reproduces on some machines and not others. The traceback you eventually get points at the query, not at the migration that never ran.

The collision is easy to introduce: two branches each add the next migration in parallel, both merge, and now two files sit at the same version. Nothing in the runner objects.

## Fix

`discover_migrations()` now raises on a collision, naming both files.

Failing at import is the lesser evil here: a duplicate version is a packaging mistake that takes seconds to fix once it is named, whereas a silently skipped migration costs hours and can leave data half-migrated in the meantime.

## Tests

`tests/test_migrations_runner.py` is new — there were no runner tests. Beyond the guard itself it includes a regression check that the real on-disk migration set has no duplicates, so a collision introduced later fails in CI rather than at a user's startup.

113 tests pass.
