### PR TITLE
Render date placeholders in notifications deterministically

### DIFF
--- a/nerve/config.py
+++ b/nerve/config.py
@@ -709,6 +709,11 @@ class NotificationsConfig:
         "high": "⚠️ ",
         "urgent": "🚨 ",
     })
+    # Output language for <YYYY-MM-DD> / <dow:> placeholders rendered into
+    # notification text: "en" (default), "ru", "de". Placeholder *parsing*
+    # stays multilingual regardless, since the source a weekday was copied
+    # from may be in any language. Unknown values fall back to English.
+    date_locale: str = "en"
 
     @classmethod
     def from_dict(cls, d: dict) -> NotificationsConfig:
@@ -721,6 +726,7 @@ class NotificationsConfig:
                 "high": "⚠️ ",
                 "urgent": "🚨 ",
             }),
+            date_locale=str(d.get("date_locale", "en")),
         )
 
 

--- a/nerve/notifications/date_render.py
+++ b/nerve/notifications/date_render.py
@@ -1,0 +1,233 @@
+"""Render ISO date placeholders in notification text.
+
+Models — especially in unattended cron sessions, where nobody is reading
+along — regularly miscompute weekdays for absolute dates, e.g. writing
+"24 June (Tue)" when 24 June is a Wednesday. Asking the model to "be more
+careful" or embedding a 14-day lookup table in the system prompt both fail:
+the first is unreliable, the second doesn't scale beyond two weeks.
+
+Instead, this module follows ``print(f"{x:.2f}")`` logic: the model
+declares semantic intent ("this is an event date") via a placeholder,
+and the code formats it deterministically.
+
+Syntax accepted in any notification ``title`` or ``body``:
+
+    <YYYY-MM-DD>           → "24 June (Wed)"
+    <YYYY-MM-DD HH:MM>     → "24 June (Wed), 19:00"
+
+If the placeholder date matches today / tomorrow / yesterday relative
+to the rendering ``now``, a relative label is prepended:
+
+    <2026-06-24>           (today)     → "today, 24 June (Wed)"
+    <2026-06-25 19:00>     (tomorrow)  → "tomorrow, 25 June (Thu), 19:00"
+    <2026-06-23>           (yesterday) → "yesterday, 23 June (Tue)"
+
+The relative-label arithmetic is done in Python from a known ``now``, so
+the failure mode that originally motivated this module — the model
+miscounting day deltas — cannot recur here.
+
+Weekday-name placeholder
+------------------------
+
+Source material often states a date as a bare weekday name with no calendar
+date — a shipping notice that says only "arriving Tuesday". Resolving that
+to an absolute date is the same day-delta arithmetic the model gets wrong,
+and it has a second failure mode: rather than compute the weekday, the model
+reuses whatever date it saw earlier in the thread. So the model may instead
+copy the weekday name verbatim into a placeholder and let the code resolve
+it:
+
+    <dow:Tuesday>          → nearest upcoming Tuesday, e.g. "21 July (Tue)"
+
+Resolution is deterministic: the nearest date whose weekday matches,
+counting forward from ``now`` (today itself counts if it matches). Weekday
+names in every supported locale are accepted, full or common short forms,
+independent of the output locale — the source the model copied from may be
+in any language. Combines with the relative label exactly like an absolute
+date, so a "Tuesday" that lands on tomorrow renders "tomorrow, 21 July
+(Tue)". Unrecognized names are left as-is.
+
+Malformed placeholders (impossible dates like ``<2026-02-31>``,
+out-of-range hours, wrong digits) are left untouched so the model sees
+its own broken output rather than a silent miscarriage.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+
+# Output locales. Month order matters: index = month - 1. Weekday order is
+# Python's: Mon=0 .. Sun=6.
+#
+# Only the *rendered* side is localized. Placeholder parsing below
+# (``_WEEKDAY_NAMES``) stays multilingual regardless of this setting, because
+# the source whose weekday the model copied may be in any language.
+#
+# English is the default; pick another with ``notifications.date_locale``.
+_LOCALES: dict[str, dict[str, object]] = {
+    "en": {
+        "months": (
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December",
+        ),
+        "weekdays": ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"),
+        "today": "today, ",
+        "tomorrow": "tomorrow, ",
+        "yesterday": "yesterday, ",
+    },
+    "ru": {
+        # Genitive: the day number governs the month name ("24 июня").
+        "months": (
+            "января", "февраля", "марта", "апреля", "мая", "июня",
+            "июля", "августа", "сентября", "октября", "ноября", "декабря",
+        ),
+        "weekdays": ("пн", "вт", "ср", "чт", "пт", "сб", "вс"),
+        "today": "сегодня, ",
+        "tomorrow": "завтра, ",
+        "yesterday": "вчера, ",
+    },
+    "de": {
+        "months": (
+            "Januar", "Februar", "März", "April", "Mai", "Juni",
+            "Juli", "August", "September", "Oktober", "November", "Dezember",
+        ),
+        "weekdays": ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"),
+        "today": "heute, ",
+        "tomorrow": "morgen, ",
+        "yesterday": "gestern, ",
+    },
+}
+
+DEFAULT_LOCALE = "en"
+
+
+def _locale(name: str | None) -> dict[str, object]:
+    """Locale table for ``name``, falling back to English for anything unknown."""
+    return _LOCALES.get((name or DEFAULT_LOCALE).lower(), _LOCALES[DEFAULT_LOCALE])
+
+# Weekday name → Python weekday index (Mon=0 .. Sun=6). Every locale above,
+# full and common short forms, since the source the model copied from may be
+# in any of them. All keys are lowercase; lookup lowercases its input.
+_WEEKDAY_NAMES = {
+    # Monday
+    "monday": 0, "mon": 0,
+    "понедельник": 0, "пн": 0,
+    "montag": 0, "mo": 0,
+    # Tuesday
+    "tuesday": 1, "tue": 1, "tues": 1,
+    "вторник": 1, "вт": 1,
+    "dienstag": 1, "di": 1,
+    # Wednesday
+    "wednesday": 2, "wed": 2,
+    "среда": 2, "ср": 2,
+    "mittwoch": 2, "mi": 2,
+    # Thursday
+    "thursday": 3, "thu": 3, "thur": 3, "thurs": 3,
+    "четверг": 3, "чт": 3,
+    "donnerstag": 3, "do": 3,
+    # Friday
+    "friday": 4, "fri": 4,
+    "пятница": 4, "пт": 4,
+    "freitag": 4, "fr": 4,
+    # Saturday
+    "saturday": 5, "sat": 5,
+    "суббота": 5, "сб": 5,
+    "samstag": 5, "sonnabend": 5, "sa": 5,
+    # Sunday
+    "sunday": 6, "sun": 6,
+    "воскресенье": 6, "вс": 6,
+    "sonntag": 6, "so": 6,
+}
+
+# Strict: 4-digit year, 2-digit month, 2-digit day, optional HH:MM time.
+# Wrapped in angle brackets so it never collides with markdown / HTML.
+_ISO_DATE_RE = re.compile(
+    r"<(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2}))?>"
+)
+
+# Weekday-name placeholder: <dow:Tuesday>. The name is captured loosely and
+# validated against _WEEKDAY_NAMES so unrecognized text is left untouched.
+_DOW_RE = re.compile(r"<dow:\s*([^\s>]+)\s*>", re.IGNORECASE)
+
+
+def render_iso_dates(
+    text: str,
+    now: Optional[datetime] = None,
+    locale: str = DEFAULT_LOCALE,
+) -> str:
+    """Replace ``<YYYY-MM-DD[ HH:MM]>`` placeholders with localized strings.
+
+    Args:
+        text: Notification title or body. Any string is safe — non-matching
+            text passes through untouched.
+        now: Reference time for the today/tomorrow/yesterday label. Defaults
+            to the current local time. Tests inject a fixed value.
+        locale: Output language for month names, weekday abbreviations and
+            the relative label. Unknown values fall back to English.
+
+    Returns:
+        Text with every well-formed placeholder rendered. Malformed
+        placeholders (impossible dates, bad hours) are left as-is.
+    """
+    if not text or "<" not in text:
+        return text
+
+    today = (now or datetime.now()).date()
+    loc = _locale(locale)
+    months: tuple = loc["months"]  # type: ignore[assignment]
+    weekdays: tuple = loc["weekdays"]  # type: ignore[assignment]
+
+    def _format(event: date, time_part: str = "") -> str:
+        """One absolute date, e.g. "today, 21 July (Tue), 19:00"."""
+        absolute = (
+            f"{event.day} {months[event.month - 1]} ({weekdays[event.weekday()]})"
+        )
+
+        delta_days = (event - today).days
+        relative = ""
+        if delta_days == 0:
+            relative = str(loc["today"])
+        elif delta_days == 1:
+            relative = str(loc["tomorrow"])
+        elif delta_days == -1:
+            relative = str(loc["yesterday"])
+
+        return f"{relative}{absolute}{time_part}"
+
+    def _replace_iso(match: re.Match) -> str:
+        year_s, month_s, day_s, hour_s, minute_s = match.groups()
+        try:
+            event = date(int(year_s), int(month_s), int(day_s))
+        except ValueError:
+            # Impossible date like 31 February — leave the placeholder
+            # visible so the model sees its own malformed output.
+            return match.group(0)
+
+        time_part = ""
+        if hour_s is not None:
+            try:
+                h, m = int(hour_s), int(minute_s)
+                if not (0 <= h <= 23 and 0 <= m <= 59):
+                    return match.group(0)
+                time_part = f", {h:02d}:{m:02d}"
+            except ValueError:
+                return match.group(0)
+
+        return _format(event, time_part)
+
+    def _replace_dow(match: re.Match) -> str:
+        target = _WEEKDAY_NAMES.get(match.group(1).strip().lower())
+        if target is None:
+            # Unrecognized weekday name — leave it visible.
+            return match.group(0)
+        # Nearest date whose weekday matches, counting forward from today
+        # (today itself counts if it already is that weekday).
+        days_ahead = (target - today.weekday()) % 7
+        return _format(today + timedelta(days=days_ahead))
+
+    text = _ISO_DATE_RE.sub(_replace_iso, text)
+    text = _DOW_RE.sub(_replace_dow, text)
+    return text

--- a/nerve/notifications/service.py
+++ b/nerve/notifications/service.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from nerve.notifications import handlers as _handlers
+from nerve.notifications.date_render import render_iso_dates
 
 if TYPE_CHECKING:
     from nerve.agent.engine import AgentEngine
@@ -229,6 +230,12 @@ class NotificationService:
                 stamped + counted as an override for audit.
         """
         notification_id = f"notif-{uuid.uuid4().hex[:8]}"
+        # Render <YYYY-MM-DD[ HH:MM]> placeholders before silence matching
+        # so rules can target the human-readable form ("24 June") and so
+        # persisted/delivered text matches what the user sees.
+        locale = self.config.notifications.date_locale
+        title = render_iso_dates(title, locale=locale)
+        body = render_iso_dates(body, locale=locale)
         match = await self._match_silence(title, body)
 
         if match and not force:
@@ -296,6 +303,9 @@ class NotificationService:
         the answer is injected as a user message into the originating session.
         """
         notification_id = f"ask-{uuid.uuid4().hex[:8]}"
+        locale = self.config.notifications.date_locale
+        title = render_iso_dates(title, locale=locale)
+        body = render_iso_dates(body, locale=locale)
         hours = expiry_hours or self.config.notifications.default_expiry_hours
         expires_at = (
             datetime.now(timezone.utc) + timedelta(hours=hours)
@@ -343,6 +353,9 @@ class NotificationService:
         Returns ``{"notification_id": <id>, "status": "sent"}``.
         """
         notification_id = f"approval-{uuid.uuid4().hex[:8]}"
+        locale = self.config.notifications.date_locale
+        title = render_iso_dates(title, locale=locale)
+        body = render_iso_dates(body, locale=locale)
 
         # Resolve options. Default to the registered dispatcher's
         # canonical set when none was passed. Falling back to the

--- a/tests/test_notification_date_render.py
+++ b/tests/test_notification_date_render.py
@@ -1,0 +1,310 @@
+"""Tests for ISO date placeholder rendering in notification text.
+
+The rendering layer fixes a recurring failure mode in cron-driven
+notifications: the model would write "24 June (Tue)" when 24 June 2026 is
+actually a Wednesday. We can't fix the arithmetic by asking nicely, so
+the model now declares intent via ``<YYYY-MM-DD>`` placeholders and
+``datetime.weekday()`` does the math.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from nerve.notifications.date_render import (
+    DEFAULT_LOCALE,
+    render_iso_dates,
+)
+
+
+# Fixed reference: 2026-06-24 was a Wednesday. The whole suite anchors
+# its "today/tomorrow/yesterday" assertions to this date so changes in
+# wall-clock time can't drift the expectations.
+_NOW = datetime(2026, 6, 24, 10, 0)
+
+
+class TestBasicRendering:
+    def test_plain_date_renders_with_weekday(self):
+        assert render_iso_dates("<2026-06-24>", now=_NOW) == "today, 24 June (Wed)"
+
+    def test_date_with_time(self):
+        assert render_iso_dates("<2026-06-24 19:00>", now=_NOW) == (
+            "today, 24 June (Wed), 19:00"
+        )
+
+    def test_iso_t_separator_also_accepted(self):
+        # The model occasionally writes the canonical ISO 8601 T separator —
+        # accept it so we don't punish well-formed input.
+        assert render_iso_dates("<2026-06-24T19:00>", now=_NOW) == (
+            "today, 24 June (Wed), 19:00"
+        )
+
+    def test_far_future_date_no_relative_label(self):
+        # Far enough that no "today/tomorrow/yesterday" applies.
+        assert render_iso_dates("<2027-01-15>", now=_NOW) == "15 January (Fri)"
+
+    def test_date_inside_sentence(self):
+        text = "Arriving <2026-06-24> at the pickup point"
+        expected = "Arriving today, 24 June (Wed) at the pickup point"
+        assert render_iso_dates(text, now=_NOW) == expected
+
+
+class TestRelativeLabels:
+    def test_today(self):
+        # 24 June 2026 == _NOW date
+        assert "today" in render_iso_dates("<2026-06-24>", now=_NOW)
+
+    def test_tomorrow(self):
+        assert render_iso_dates("<2026-06-25>", now=_NOW) == "tomorrow, 25 June (Thu)"
+
+    def test_yesterday(self):
+        assert render_iso_dates("<2026-06-23>", now=_NOW) == "yesterday, 23 June (Tue)"
+
+    def test_two_days_ahead_no_label(self):
+        # +2 days gets no label — relative-arithmetic territory we
+        # deliberately avoid. Absolute date only.
+        result = render_iso_dates("<2026-06-26>", now=_NOW)
+        assert result == "26 June (Fri)"
+
+    def test_two_days_back_no_label(self):
+        result = render_iso_dates("<2026-06-22>", now=_NOW)
+        assert result == "22 June (Mon)"
+
+
+class TestWeekdayArithmetic:
+    """Anchor the weekday math against known references.
+
+    These tests would have caught the original bug: 24 June 2026 is a
+    Wednesday, NOT a Tuesday. The model got this wrong; the renderer
+    must not.
+    """
+
+    @pytest.mark.parametrize("iso,expected_weekday", [
+        ("2026-06-22", "Mon"),
+        ("2026-06-23", "Tue"),
+        ("2026-06-24", "Wed"),
+        ("2026-06-25", "Thu"),
+        ("2026-06-26", "Fri"),
+        ("2026-06-27", "Sat"),
+        ("2026-06-28", "Sun"),
+        # Different month, different year — same arithmetic.
+        ("2027-12-31", "Fri"),
+        # Leap day in a real leap year — sanity check.
+        ("2028-02-29", "Tue"),
+    ])
+    def test_known_weekdays(self, iso, expected_weekday):
+        result = render_iso_dates(f"<{iso}>", now=_NOW)
+        assert f"({expected_weekday})" in result, (
+            f"{iso}: expected ({expected_weekday}) in {result!r}"
+        )
+
+
+class TestWeekdayNamePlaceholder:
+    """`<dow:Weekday>` resolves a bare weekday name to the nearest upcoming date.
+
+    Covers the second failure mode: given a source that says only "arriving
+    Tuesday", the model would reuse a stale date it had seen earlier in the
+    thread instead of computing which Tuesday was meant. Now it copies the
+    weekday name into a placeholder and the renderer does the arithmetic.
+    Anchored to Wed 2026-06-24 (_NOW).
+    """
+
+    def test_today_weekday_resolves_to_today(self):
+        # _NOW is a Wednesday.
+        assert render_iso_dates("<dow:Wednesday>", now=_NOW) == "today, 24 June (Wed)"
+
+    def test_tomorrow_weekday(self):
+        assert render_iso_dates("<dow:Thursday>", now=_NOW) == (
+            "tomorrow, 25 June (Thu)"
+        )
+
+    def test_next_tuesday_from_wednesday(self):
+        # From Wed 24 June, the next Tuesday is 30 June (6 days ahead), no label.
+        assert render_iso_dates("<dow:Tuesday>", now=_NOW) == "30 June (Tue)"
+
+    def test_next_monday_from_wednesday(self):
+        assert render_iso_dates("<dow:Monday>", now=_NOW) == "29 June (Mon)"
+
+    def test_resolves_from_an_arbitrary_reference_day(self):
+        # A notice that arrives Thu 16 July 2026 saying "arriving Tuesday".
+        now = datetime(2026, 7, 16, 5, 30)  # Thursday
+        assert render_iso_dates("<dow:Tuesday>", now=now) == "21 July (Tue)"
+
+    @pytest.mark.parametrize("name", ["Tuesday", "tuesday", "TUESDAY", "Tue", "tues"])
+    def test_english_forms_case_insensitive(self, name):
+        assert render_iso_dates(f"<dow:{name}>", now=_NOW) == "30 June (Tue)"
+
+    @pytest.mark.parametrize("name", ["Dienstag", "dienstag", "Di"])
+    def test_german_forms(self, name):
+        assert render_iso_dates(f"<dow:{name}>", now=_NOW) == "30 June (Tue)"
+
+    @pytest.mark.parametrize("name", ["вторник", "вт", "Вторник"])
+    def test_russian_forms(self, name):
+        assert render_iso_dates(f"<dow:{name}>", now=_NOW) == "30 June (Tue)"
+
+    def test_whitespace_tolerated(self):
+        assert render_iso_dates("<dow: Tuesday >", now=_NOW) == "30 June (Tue)"
+
+    def test_unrecognized_name_kept_as_placeholder(self):
+        text = "Arriving <dow:someday>"
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_inside_a_notification_body(self):
+        body = (
+            "📦 Order dispatched\n"
+            "🌿 Arriving <dow:Tuesday> at the pickup point\n"
+            "🌿 [Track it](https://example.com)"
+        )
+        now = datetime(2026, 7, 16, 5, 30)  # Thursday
+        result = render_iso_dates(body, now=now)
+        assert "Arriving 21 July (Tue) at the pickup point" in result
+        # Markdown link and emoji must survive untouched.
+        assert "📦" in result and "[Track it]" in result
+
+    def test_iso_and_dow_placeholders_coexist(self):
+        text = "Ordered <2026-06-25>, delivery <dow:Tuesday>"
+        result = render_iso_dates(text, now=_NOW)
+        assert "tomorrow, 25 June (Thu)" in result
+        assert "30 June (Tue)" in result
+
+
+class TestMonthNames:
+    @pytest.mark.parametrize("month_num,month_name", [
+        (1, "January"), (2, "February"), (3, "March"), (4, "April"),
+        (5, "May"), (6, "June"), (7, "July"), (8, "August"),
+        (9, "September"), (10, "October"), (11, "November"), (12, "December"),
+    ])
+    def test_all_months(self, month_num, month_name):
+        result = render_iso_dates(f"<2027-{month_num:02d}-15>", now=_NOW)
+        assert month_name in result
+
+
+class TestEdgeCases:
+    def test_empty_string(self):
+        assert render_iso_dates("", now=_NOW) == ""
+
+    def test_text_without_placeholders_unchanged(self):
+        text = "Just text, no dates. (Tue) stays put too."
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_invalid_date_kept_as_placeholder(self):
+        # 31 February doesn't exist — render must leave the placeholder
+        # visible so the model can see its own bad output rather than
+        # silently shipping something half-broken.
+        text = "Due: <2026-02-31>"
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_invalid_hour_kept_as_placeholder(self):
+        text = "At: <2026-06-24 25:00>"
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_invalid_minute_kept_as_placeholder(self):
+        text = "At: <2026-06-24 19:99>"
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_partial_placeholder_not_matched(self):
+        # Missing closing bracket — leave alone.
+        text = "Date: <2026-06-24"
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_html_like_tags_not_matched(self):
+        # The regex requires digits, so HTML tags pass through untouched.
+        text = "<div>Hello</div>"
+        assert render_iso_dates(text, now=_NOW) == text
+
+    def test_multiple_placeholders_in_one_string(self):
+        text = "From <2026-06-24> to <2026-06-26>"
+        result = render_iso_dates(text, now=_NOW)
+        assert "today, 24 June (Wed)" in result
+        assert "26 June (Fri)" in result
+
+    def test_none_text_returns_falsy(self):
+        # The service layer may pass empty title — make sure we don't crash.
+        assert render_iso_dates("", now=_NOW) == ""
+
+
+class TestRealWorldNotifications:
+    """End-to-end shape matching what a cron session actually emits."""
+
+    def test_dispatch_notice_today(self):
+        body = (
+            "📦 Order dispatched\n"
+            "🌿 Arriving <2026-06-24> at the pickup point\n"
+            "🌿 [Track it](https://example.com)"
+        )
+        result = render_iso_dates(body, now=_NOW)
+        # The original bug: this would have said "(Tue)". Verify it says "(Wed)".
+        assert "today, 24 June (Wed)" in result
+        assert "(Tue)" not in result
+        # Markdown link and emoji must survive untouched.
+        assert "📦" in result
+        assert "🌿" in result
+        assert "[Track it]" in result
+
+    def test_event_with_time(self):
+        body = "🎟 Concert\n🌿 <2026-06-26 19:00>, main hall"
+        result = render_iso_dates(body, now=_NOW)
+        assert "26 June (Fri), 19:00" in result
+
+    def test_yesterday_reminder(self):
+        body = "⏰ Deadline passed <2026-06-23>"
+        result = render_iso_dates(body, now=_NOW)
+        assert "yesterday, 23 June (Tue)" in result
+
+
+class TestDefaultNowFallback:
+    def test_default_now_does_not_crash(self):
+        # When no ``now`` is passed, the function reads the system clock.
+        # We can't assert the relative label, but we can assert the
+        # absolute date+weekday is correct.
+        result = render_iso_dates("<2030-01-01>")
+        # 2030-01-01 is a Tuesday.
+        assert "1 January (Tue)" in result
+
+
+# ---------------------------------------------------------------------------
+# Locale selection — the language is config, not a hardcode
+# ---------------------------------------------------------------------------
+
+
+class TestLocaleSelection:
+    """Output language comes from notifications.date_locale.
+
+    Placeholder *parsing* stays multilingual whatever the output locale is,
+    because the source the model copied a weekday from may be in any
+    language.
+    """
+
+    def test_module_default_is_english(self):
+        assert DEFAULT_LOCALE == "en"
+        assert render_iso_dates("<2026-06-24>", now=_NOW) == "today, 24 June (Wed)"
+
+    def test_german(self):
+        assert render_iso_dates("<2026-06-24>", now=_NOW, locale="de") == (
+            "heute, 24 Juni (Mi)"
+        )
+
+    def test_russian(self):
+        assert render_iso_dates("<2026-06-24>", now=_NOW, locale="ru") == (
+            "сегодня, 24 июня (ср)"
+        )
+
+    def test_unknown_locale_falls_back_to_english(self):
+        assert render_iso_dates("<2026-06-24>", now=_NOW, locale="klingon") == (
+            "today, 24 June (Wed)"
+        )
+
+    def test_none_locale_falls_back(self):
+        assert render_iso_dates("<2026-06-24>", now=_NOW, locale=None) == (
+            "today, 24 June (Wed)"
+        )
+
+    @pytest.mark.parametrize("locale", ["en", "ru", "de"])
+    def test_weekday_parsing_is_locale_independent(self, locale):
+        # A German weekday name resolves even when rendering in English.
+        out = render_iso_dates("<dow:Dienstag>", now=_NOW, locale=locale)
+        assert "<dow:" not in out
+        # 2026-06-24 is a Wednesday, so the next Tuesday is 30 June.
+        assert "30" in out


### PR DESCRIPTION
Models in unattended cron sessions regularly miscompute weekdays for absolute dates — writing "24 June (Tue)" when 24 June is a Wednesday. Asking the model to be careful is unreliable, and embedding a lookup table in the system prompt does not scale past a couple of weeks. Nobody is reading along in a cron turn, so the wrong weekday ships.

This follows `print(f"{x:.2f}")` logic instead: the model declares semantic intent via a placeholder and the code formats it.

    <YYYY-MM-DD>           -> 24 June (Wed)
    <YYYY-MM-DD HH:MM>     -> 24 June (Wed), 19:00
    <2026-06-24>  (today)  -> today, 24 June (Wed)

The relative label arithmetic runs in Python from a known `now`, so the failure mode that motivated this cannot recur.

## Weekday placeholder

Source material often states a date as a bare weekday name with no calendar date — "arriving Tuesday". Resolving that is the same arithmetic the model gets wrong, with a second failure mode on top: rather than compute the weekday, the model reuses a date it saw earlier in the thread. So the model may copy the name verbatim and let the code resolve it:

    <dow:Tuesday>          -> nearest upcoming Tuesday, e.g. 21 July (Tue)

Malformed placeholders (impossible dates, out-of-range hours) are left untouched, so the model sees its own broken output rather than a silent miscarriage.

## Locale

Output language is `notifications.date_locale` — en (default), ru, de. Unknown or None falls back to English rather than raising.

Placeholder *parsing* is deliberately multilingual regardless of that setting: `<dow:Dienstag>` resolves even when rendering in English, because the source the model copied it from may be in any language. Only the rendered side is localized.

Rendering is applied at the single entry point shared by `send_notification`, `ask_question` and `propose_action`, all three with the configured locale.

72 tests, covering the default, both fallbacks, and locale-independent parsing.
