### PR TITLE
Starred sessions bypass the session list limit

### DIFF
--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -598,7 +598,11 @@ class SessionManager:
     async def list_sessions(
         self, limit: int = 50, include_archived: bool = False,
     ) -> list[dict]:
-        """List sessions, most recently updated first."""
+        """List sessions, most recently updated first.
+
+        Starred sessions are always included; ``limit`` only bounds the
+        non-starred ones.
+        """
         return await self.db.list_sessions(
             limit=limit, include_archived=include_archived,
         )

--- a/nerve/db/sessions.py
+++ b/nerve/db/sessions.py
@@ -48,13 +48,29 @@ class SessionStore:
     async def list_sessions(
         self, limit: int = 50, include_archived: bool = False,
     ) -> list[dict]:
+        """List sessions, most recently updated first.
+
+        Starred sessions are always included regardless of ``limit``;
+        the limit only bounds the non-starred ones.
+        """
         if include_archived:
-            query = "SELECT * FROM sessions ORDER BY updated_at DESC LIMIT ?"
-            params = (limit,)
+            query = (
+                "SELECT * FROM sessions"
+                " WHERE starred = 1"
+                "    OR id IN (SELECT id FROM sessions WHERE starred = 0"
+                "              ORDER BY updated_at DESC LIMIT ?)"
+                " ORDER BY updated_at DESC"
+            )
         else:
-            query = "SELECT * FROM sessions WHERE status != 'archived' ORDER BY updated_at DESC LIMIT ?"
-            params = (limit,)
-        async with self.db.execute(query, params) as cursor:
+            query = (
+                "SELECT * FROM sessions"
+                " WHERE (starred = 1 AND status != 'archived')"
+                "    OR id IN (SELECT id FROM sessions"
+                "              WHERE starred = 0 AND status != 'archived'"
+                "              ORDER BY updated_at DESC LIMIT ?)"
+                " ORDER BY updated_at DESC"
+            )
+        async with self.db.execute(query, (limit,)) as cursor:
             return [dict(row) async for row in cursor]
 
     async def count_sessions(self, include_archived: bool = False) -> int:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -186,6 +186,52 @@ class TestListSessions:
         assert "list-a2" in ids
         assert "list-arch2" in ids
 
+    async def test_starred_bypasses_limit(self, db: Database):
+        """Starred sessions are returned even when older than the last-N
+        cutoff; the limit only applies to non-starred sessions."""
+        import asyncio
+
+        await db.create_session("lim-starred")
+        await db.update_session_fields("lim-starred", {"starred": 1})
+        for i in range(3):
+            await asyncio.sleep(0.01)
+            await db.create_session(f"lim-{i}")
+
+        sessions = await db.list_sessions(limit=2)
+        ids = [s["id"] for s in sessions]
+        # Starred session is older than the 2 most recent but still listed
+        assert "lim-starred" in ids
+        # The 2 most recent non-starred sessions fill the limit
+        assert "lim-2" in ids
+        assert "lim-1" in ids
+        # Older non-starred session falls off, as before
+        assert "lim-0" not in ids
+        # Results stay sorted by updated_at DESC
+        assert ids == ["lim-2", "lim-1", "lim-starred"]
+
+    async def test_starred_bypasses_limit_include_archived(self, db: Database):
+        import asyncio
+
+        await db.create_session("slim-starred", status="archived")
+        await db.update_session_fields("slim-starred", {"starred": 1})
+        for i in range(2):
+            await asyncio.sleep(0.01)
+            await db.create_session(f"slim-{i}")
+
+        sessions = await db.list_sessions(limit=1, include_archived=True)
+        ids = [s["id"] for s in sessions]
+        assert "slim-starred" in ids
+        assert "slim-1" in ids
+        assert "slim-0" not in ids
+
+    async def test_starred_archived_stays_hidden(self, db: Database):
+        """The starred bypass does not leak archived sessions into the
+        default (non-archived) listing."""
+        await db.create_session("arch-star", status="archived")
+        await db.update_session_fields("arch-star", {"starred": 1})
+        sessions = await db.list_sessions(include_archived=False)
+        assert "arch-star" not in [s["id"] for s in sessions]
+
 
 @pytest.mark.asyncio
 class TestSessionEvents:


### PR DESCRIPTION
## Problem

The sessions sidebar only renders the last N sessions (`db.list_sessions` caps at the 50 most recently updated). A starred session that hasn't been touched recently falls out of that window and silently disappears from the UI — defeating the point of starring it.

## Change

`Database.list_sessions` now always includes starred sessions; the `limit` only bounds the non-starred ones:

- non-archived listing: all starred non-archived sessions ∪ the N most recent non-starred sessions
- `include_archived=True`: same shape without the archived filter
- an archived starred session still stays hidden from the default listing (the bypass doesn't leak archived rows)
- results remain sorted by `updated_at DESC`

No frontend change needed — the sidebar already pins starred sessions into their own section from whatever `GET /api/sessions` returns; the cutoff was purely server-side.

## Tests

Added to `TestListSessions`: starred-beyond-limit is returned (and non-starred tail still cut), same for `include_archived=True`, and archived+starred stays hidden by default. Full suite: 1579 passed.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)