### PR TITLE
Sort session list purely by updated_at

### DIFF
--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -320,8 +320,10 @@ class SessionManager:
         await self.db.set_channel_session(channel_key, session_id)
         # An explicit switch is a deliberate choice: the next inbound message must
         # route to this session regardless of how long it has been idle. Mark it
-        # freshly active (this also bumps updated_at) so get_active_session's
-        # sticky-period check honours the switch instead of minting a new session.
+        # freshly active so get_active_session's sticky-period check honours the
+        # switch instead of minting a new session. Only last_activity_at moves —
+        # updated_at means "last message activity", so merely opening a chat
+        # never reorders the session list.
         await self.db.update_session_fields(
             session_id,
             {"last_activity_at": datetime.now(timezone.utc).isoformat()},

--- a/nerve/db/migrations/v040_updated_at_from_messages.py
+++ b/nerve/db/migrations/v040_updated_at_from_messages.py
@@ -1,0 +1,73 @@
+"""V40: Realign ``sessions.updated_at`` to actual last-message time.
+
+``updated_at`` now means "last message activity" and drives the session
+list order exclusively. Historically every ``update_session_fields``
+call auto-bumped it, so incidental writes polluted the ordering: opening
+a chat (``set_active_session``'s stickiness bookkeeping), star/rename,
+status flips, memorization watermarks. The visible symptom was chats
+teleporting to the top of the sidebar merely because they were clicked,
+or because a background sweep touched them.
+
+The auto-bump is removed alongside this migration; here we repair the
+stored values by resetting each session's ``updated_at`` to its latest
+message timestamp. Sessions with no messages keep their current value
+(creation time).
+
+Format note: ``messages.created_at`` is mixed-format — SQLite
+``CURRENT_TIMESTAMP`` ("YYYY-MM-DD HH:MM:SS") for native inserts, ISO
+8601 for externally-ingested rows with preserved timestamps. MAX() over
+mixed formats is unreliable lexicographically (space sorts before 'T'),
+so values are normalized to 'T'-form in SQL before MAX, then re-parsed
+in Python and written back as timezone-aware UTC ISO — the same format
+the ``add_message*`` bumps use.
+
+Idempotent: re-running recomputes the same values.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+def _to_utc_iso(raw: str) -> str | None:
+    """Normalize a 'T'-form timestamp string to timezone-aware UTC ISO."""
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        # Naive timestamps in this DB are UTC (SQLite CURRENT_TIMESTAMP).
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    async with db.execute(
+        "SELECT session_id, MAX(REPLACE(created_at, ' ', 'T')) "
+        "FROM messages WHERE created_at IS NOT NULL GROUP BY session_id"
+    ) as cur:
+        rows = await cur.fetchall()
+
+    repaired = skipped = 0
+    for session_id, last_ts in rows:
+        iso = _to_utc_iso(last_ts) if last_ts else None
+        if iso is None:
+            skipped += 1
+            continue
+        await db.execute(
+            "UPDATE sessions SET updated_at = ? WHERE id = ?",
+            (iso, session_id),
+        )
+        repaired += 1
+
+    await db.commit()
+    logger.info(
+        "V40 migration: realigned updated_at to last message time for %d "
+        "sessions (%d unparseable timestamps skipped)",
+        repaired, skipped,
+    )

--- a/nerve/db/sessions.py
+++ b/nerve/db/sessions.py
@@ -146,6 +146,12 @@ class SessionStore:
 
         Returns ``None`` when no allowed field is present. Shared by
         :meth:`update_session_fields` and :meth:`update_session_metadata`.
+
+        Deliberately does NOT touch ``updated_at``: it means "last message
+        activity" and is bumped only by the ``add_message*`` methods (and
+        the explicit :meth:`touch_session`). Metadata writes — status flips,
+        open/switch bookkeeping, star/rename, memorization watermarks — must
+        not reorder the session list.
         """
         allowed = {
             "status", "sdk_session_id", "connected_at", "last_activity_at",
@@ -161,8 +167,6 @@ class SessionStore:
                 params.append(value)
         if not set_clauses:
             return None
-        set_clauses.append("updated_at = ?")
-        params.append(datetime.now(timezone.utc).isoformat())
         params.append(session_id)
         return (
             f"UPDATE sessions SET {', '.join(set_clauses)} WHERE id = ?",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -156,14 +156,19 @@ class TestUpdateSessionFields:
         session = await db.get_session("upd-4")
         assert session["sdk_session_id"] is None
 
-    async def test_update_touches_updated_at(self, db: Database):
+    async def test_update_does_not_touch_updated_at(self, db: Database):
+        """updated_at means "last message activity": metadata writes (status
+        flips, star/rename, watermarks) must not reorder the session list.
+        Only message inserts (and the explicit touch_session) bump it."""
         await db.create_session("upd-5")
         before = (await db.get_session("upd-5"))["updated_at"]
         import asyncio
         await asyncio.sleep(0.01)
-        await db.update_session_fields("upd-5", {"status": "active"})
-        after = (await db.get_session("upd-5"))["updated_at"]
-        assert after >= before
+        await db.update_session_fields("upd-5", {"status": "active", "starred": 1})
+        assert (await db.get_session("upd-5"))["updated_at"] == before
+        # A real message DOES bump it.
+        await db.add_message("upd-5", "user", "hello")
+        assert (await db.get_session("upd-5"))["updated_at"] > before
 
 
 @pytest.mark.asyncio

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useRef, useEffect, useCallback, useLayoutEffect } fr
 import { Link } from 'react-router-dom';
 import { Plus, X, MessageSquare, ChevronRight, ChevronDown, Bot, Loader2, Search, Hammer, MoreHorizontal, Star, Pencil, Trash2 } from 'lucide-react';
 import type { Session, AgentStatus } from '../../types/chat';
-import { groupByDate } from '../../utils/dateGroups';
+import { groupByDate, parseTimestamp } from '../../utils/dateGroups';
 import { useChatStore } from '../../stores/chatStore';
 
 /** Strip leading '#' and 'Implement: ' prefixes from generated titles. */
@@ -184,18 +184,21 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
 
   const activeIsRunning = agentStatus.state !== 'idle';
 
-  // Split running and starred conversations to pin them at the top
-  const { pinnedRunning, pinnedStarred, restConversations } = useMemo(() => {
+  // Split running conversations to pin them at the top. Everything else —
+  // starred included — stays in one flat list ordered purely by updated_at
+  // (starring keeps a session in the list past the fetch limit; it does not
+  // pin or reorder it). Sort explicitly rather than trusting API array order
+  // so local updated_at bumps (e.g. clicking a chat) reorder consistently.
+  const { pinnedRunning, restConversations } = useMemo(() => {
     const running: Session[] = [];
-    const starred: Session[] = [];
     const rest: Session[] = [];
     for (const s of conversations) {
       const isRunning = s.id === activeSession ? activeIsRunning : !!s.is_running;
       if (isRunning) running.push(s);
-      else if (s.starred) starred.push(s);
       else rest.push(s);
     }
-    return { pinnedRunning: running, pinnedStarred: starred, restConversations: rest };
+    rest.sort((a, b) => parseTimestamp(b.updated_at).getTime() - parseTimestamp(a.updated_at).getTime());
+    return { pinnedRunning: running, restConversations: rest };
   }, [conversations, activeSession, activeIsRunning]);
 
   const groupedConversations = useMemo(() => groupByDate(restConversations), [restConversations]);
@@ -370,28 +373,8 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
               </div>
             )}
 
-            {/* Pinned starred sessions */}
-            {pinnedStarred.length > 0 && (
-              <div>
-                <div className="px-3 pt-2 pb-0.5">
-                  <span className="text-[10px] text-yellow-600/70 font-medium">Starred</span>
-                </div>
-                {pinnedStarred.map((s) => (
-                  <SessionItem
-                    key={s.id}
-                    session={s}
-                    isActive={s.id === activeSession}
-                    isRunning={false}
-                    onDelete={onDelete}
-                    onRename={renameSession}
-                    onToggleStar={toggleStar}
-                  />
-                ))}
-              </div>
-            )}
-
             {/* Normal date-grouped view */}
-            {groupedConversations.length === 0 && pinnedRunning.length === 0 && pinnedStarred.length === 0 && !virtualSession && (
+            {groupedConversations.length === 0 && pinnedRunning.length === 0 && !virtualSession && (
               <div className="px-3 py-2 text-[11px] text-text-faint">No conversations yet</div>
             )}
 

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -184,21 +184,26 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
 
   const activeIsRunning = agentStatus.state !== 'idle';
 
-  // Split running conversations to pin them at the top. Everything else —
-  // starred included — stays in one flat list ordered purely by updated_at
-  // (starring keeps a session in the list past the fetch limit; it does not
-  // pin or reorder it). Sort explicitly rather than trusting API array order
-  // so local updated_at bumps (e.g. clicking a chat) reorder consistently.
-  const { pinnedRunning, restConversations } = useMemo(() => {
+  // Split running and starred conversations into their pinned groups at the
+  // top. Within every group the order is purely updated_at — which means
+  // "last message activity" (opening/starring a chat doesn't bump it), so
+  // browsing never reshuffles the list. Sort explicitly rather than trusting
+  // API array order to keep that invariant regardless of fetch shape.
+  const { pinnedRunning, pinnedStarred, restConversations } = useMemo(() => {
     const running: Session[] = [];
+    const starred: Session[] = [];
     const rest: Session[] = [];
     for (const s of conversations) {
       const isRunning = s.id === activeSession ? activeIsRunning : !!s.is_running;
       if (isRunning) running.push(s);
+      else if (s.starred) starred.push(s);
       else rest.push(s);
     }
-    rest.sort((a, b) => parseTimestamp(b.updated_at).getTime() - parseTimestamp(a.updated_at).getTime());
-    return { pinnedRunning: running, restConversations: rest };
+    const byUpdatedDesc = (a: Session, b: Session) =>
+      parseTimestamp(b.updated_at).getTime() - parseTimestamp(a.updated_at).getTime();
+    starred.sort(byUpdatedDesc);
+    rest.sort(byUpdatedDesc);
+    return { pinnedRunning: running, pinnedStarred: starred, restConversations: rest };
   }, [conversations, activeSession, activeIsRunning]);
 
   const groupedConversations = useMemo(() => groupByDate(restConversations), [restConversations]);
@@ -373,8 +378,29 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
               </div>
             )}
 
+            {/* Pinned starred sessions (ordered by last message activity —
+                stable while browsing, since opening a chat doesn't bump it) */}
+            {pinnedStarred.length > 0 && (
+              <div>
+                <div className="px-3 pt-2 pb-0.5">
+                  <span className="text-[10px] text-yellow-600/70 font-medium">Starred</span>
+                </div>
+                {pinnedStarred.map((s) => (
+                  <SessionItem
+                    key={s.id}
+                    session={s}
+                    isActive={s.id === activeSession}
+                    isRunning={false}
+                    onDelete={onDelete}
+                    onRename={renameSession}
+                    onToggleStar={toggleStar}
+                  />
+                ))}
+              </div>
+            )}
+
             {/* Normal date-grouped view */}
-            {groupedConversations.length === 0 && pinnedRunning.length === 0 && !virtualSession && (
+            {groupedConversations.length === 0 && pinnedRunning.length === 0 && pinnedStarred.length === 0 && !virtualSession && (
               <div className="px-3 py-2 text-[11px] text-text-faint">No conversations yet</div>
             )}
 

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -452,15 +452,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
     ws.switchSession(id);
-    // Opening a chat marks it freshly active server-side (set_active_session
-    // bumps updated_at). Mirror that locally so the sidebar — sorted purely by
-    // updated_at — reorders now rather than surprising on the next refetch.
-    const openedAt = new Date().toISOString();
-    set((s) => ({
-      sessions: s.sessions.map(sess =>
-        sess.id === id ? { ...sess, updated_at: openedAt } : sess,
-      ),
-    }));
+    // Note: opening a chat deliberately does NOT touch updated_at (locally or
+    // server-side) — updated_at means "last message activity", so browsing
+    // never reorders the session list.
     try {
       const data = await api.getMessages(id);
       const hydrated = data.messages.map(hydrateMessage);

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -452,6 +452,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
     ws.switchSession(id);
+    // Opening a chat marks it freshly active server-side (set_active_session
+    // bumps updated_at). Mirror that locally so the sidebar — sorted purely by
+    // updated_at — reorders now rather than surprising on the next refetch.
+    const openedAt = new Date().toISOString();
+    set((s) => ({
+      sessions: s.sessions.map(sess =>
+        sess.id === id ? { ...sess, updated_at: openedAt } : sess,
+      ),
+    }));
     try {
       const data = await api.getMessages(id);
       const hydrated = data.messages.map(hydrateMessage);

--- a/web/src/utils/dateGroups.ts
+++ b/web/src/utils/dateGroups.ts
@@ -1,4 +1,13 @@
 /**
+ * Parse a server timestamp into a Date. Handles both ISO 8601 strings and
+ * legacy SQLite "YYYY-MM-DD HH:MM:SS" strings (which are UTC but lack a
+ * timezone marker).
+ */
+export function parseTimestamp(input: string): Date {
+  return new Date(input.includes('T') ? input : input.replace(' ', 'T') + 'Z');
+}
+
+/**
  * Assign a human-readable group label based on when something was last updated.
  *
  * Today     → "Last hour" / "N hours ago"
@@ -12,7 +21,7 @@
 export function getDateGroup(updatedAt: string): string {
   if (!updatedAt) return 'Recent';
   const now = new Date();
-  const date = new Date(updatedAt.includes('T') ? updatedAt : updatedAt.replace(' ', 'T') + 'Z');
+  const date = parseTimestamp(updatedAt);
 
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const yesterdayStart = new Date(todayStart.getTime() - 86400000);
@@ -46,7 +55,7 @@ export function getDateGroup(updatedAt: string): string {
  */
 export function formatTimeAgo(input: string): string {
   if (!input) return '';
-  const date = new Date(input.includes('T') ? input : input.replace(' ', 'T') + 'Z');
+  const date = parseTimestamp(input);
   const diffMs = Date.now() - date.getTime();
   if (diffMs < 0) return 'just now';
   const minutes = Math.floor(diffMs / 60000);


### PR DESCRIPTION
## Problem

Clicking a starred session re-ordered it to the top of the sidebar. Root cause: every `update_session_fields` call auto-bumped `updated_at`, so *opening* a chat (stickiness bookkeeping in `set_active_session`), starring/renaming it, or background metadata writes (memorization watermarks, status flips) reordered the list. Recently-clicked chats piled up at the top of the Starred group.

## Fix

**`updated_at` now means "last message activity"**, and the sidebar orders every group purely by it — so browsing never reshuffles the list.

- **DB**: `_build_session_fields_update` no longer auto-bumps `updated_at`. It is bumped only by `add_message`/`add_message_idempotent` (and the explicit `touch_session`). Channel stickiness is unaffected — `set_active_session` still advances `last_activity_at`, which the sticky-period check reads first.
- **Migration v040**: realigns each session's `updated_at` to its latest message timestamp, repairing the historical pollution (normalizes mixed SQLite/ISO timestamp formats; sessions without messages keep their creation time). Idempotent.
- **SessionSidebar**: groups unchanged (Running → Starred → date-grouped rest), but each group is now explicitly sorted by `updated_at` instead of trusting API array order.
- **dateGroups**: extracted `parseTimestamp()` (ISO + legacy SQLite formats) and reused it for the sorts — mixed formats don't compare lexicographically.

## Testing

- `pytest`: 1579 passed; `test_update_does_not_touch_updated_at` asserts the new semantics (metadata writes don't bump, messages do)
- `npm run build` clean; no new lint issues
- Migration dry-run against a copy of a live DB: recently-clicked sessions drop back to their genuine last-message times
- Browser-verified: Starred group renders between Running and the date groups; clicking a chat no longer moves it

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*