### PR TITLE
web: keep the chat composer typeable while a turn is running, persist drafts

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -308,11 +308,15 @@ export function ChatPage() {
           <InteractiveQuestionCard />
           <ApprovalCard />
 
+          {/* The composer stays typeable while a turn runs so a reply is never
+              lost mid-stream. `isStreaming` still swaps Send↔Stop and blocks
+              sending (canSend), so the text is just held as the session's draft
+              until the turn ends — a turn in progress is not a reason to block
+              typing, hence no `disabled`. */}
           <ChatInput
             onSend={sendMessage}
             onStop={stopSession}
             isStreaming={isStreaming}
-            disabled={isStreaming}
           />
         </div>
 

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api, setToken, clearToken, getToken } from '../api/client';
+import { clearAllDrafts } from './helpers/draftStorage';
 
 interface AuthState {
   authenticated: boolean;
@@ -30,6 +31,8 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   logout: () => {
     clearToken();
+    // Purge unsent drafts so nothing leaks to the next user on a shared browser.
+    clearAllDrafts();
     set({ authenticated: false });
   },
 

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -8,6 +8,7 @@ import { randomUUID } from '../utils/uuid';
 // Helpers
 import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './helpers/blockHelpers';
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
+import { loadDrafts, persistDraft, removeDraft, pruneDrafts } from './helpers/draftStorage';
 // Handlers
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleToolOutput, handleDone, handleStopped, handleError, handleWakeup, handleAutoTurn, handleModelChanged } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected, handleUserMessage } from './handlers/sessionHandlers';
@@ -207,7 +208,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sessions: [],
   activeSession: '',
   virtualSession: null,
-  drafts: {},
+  // Rehydrated from localStorage so unsent composer text survives a reload.
+  drafts: loadDrafts(),
   messages: [],
   streamingBlocks: [],
   isStreaming: false,
@@ -415,6 +417,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
     try {
       const { sessions } = await api.listSessions();
       set({ sessions });
+      // Reclaim persisted drafts whose session no longer exists (deleted or
+      // archived elsewhere) — but never the chat you're in or an unsent one.
+      const keep = new Set(sessions.map(s => s.id));
+      const { activeSession, virtualSession } = get();
+      if (activeSession) keep.add(activeSession);
+      if (virtualSession) keep.add(virtualSession.id);
+      pruneDrafts(keep);
     } catch (e) {
       console.error('Failed to load sessions:', e);
     }
@@ -527,6 +536,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       const carried = drafts[vs.id];
       delete drafts[vs.id];
       if (carried !== undefined) drafts[real.id] = carried;
+      // Mirror the carry in storage: the temp id's key is dead; the real id
+      // now owns the draft.
+      removeDraft(vs.id);
+      if (carried) persistDraft(real.id, carried);
       return {
         // Don't yank the view if the user navigated away during the POST.
         ...(state.activeSession === vs.id ? { activeSession: real.id } : {}),
@@ -548,6 +561,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const vs = get().virtualSession;
     if (!vs) return;
     set({ newChatBackend: null });
+    removeDraft(vs.id);
     set((s) => {
       const drafts = { ...s.drafts };
       delete drafts[vs.id];
@@ -562,11 +576,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   setDraft: (sessionId: string, text: string) =>
-    set((s) => ({ drafts: { ...s.drafts, [sessionId]: text } })),
+    set((s) => {
+      persistDraft(sessionId, text);
+      return { drafts: { ...s.drafts, [sessionId]: text } };
+    }),
 
   deleteSession: async (id: string) => {
     try {
       await api.deleteSession(id);
+      removeDraft(id);
+      set(s => { const drafts = { ...s.drafts }; delete drafts[id]; return { drafts }; });
       await get().loadSessions();
       if (get().activeSession === id) {
         // Switch to most recent remaining session

--- a/web/src/stores/helpers/draftStorage.ts
+++ b/web/src/stores/helpers/draftStorage.ts
@@ -1,0 +1,74 @@
+// Per-session composer draft persistence.
+//
+// Unsent composer text is kept per session in localStorage so a page reload,
+// tab close, or browser restart never loses what you were typing — a draft
+// lives until you send it, delete its session, or log out.
+//
+// One key per session (`nerve_draft_<id>`) rather than a single JSON blob so
+// two tabs editing *different* sessions can't clobber each other's drafts, and
+// per-session cleanup is a single removeItem. Every write is quota-safe: if
+// localStorage is full or disabled the draft simply stays in memory — typing
+// is never blocked.
+
+const PREFIX = 'nerve_draft_';
+
+const keyFor = (sessionId: string) => `${PREFIX}${sessionId}`;
+
+/** Collect the session ids of all persisted draft keys (safe if storage is off). */
+function draftKeys(): string[] {
+  const keys: string[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith(PREFIX)) keys.push(k);
+    }
+  } catch { /* storage unavailable */ }
+  return keys;
+}
+
+/** Read every persisted draft into a { sessionId: text } map (store hydration). */
+export function loadDrafts(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const k of draftKeys()) {
+    try {
+      const text = localStorage.getItem(k);
+      if (text) out[k.slice(PREFIX.length)] = text;
+    } catch { /* ignore a single unreadable key */ }
+  }
+  return out;
+}
+
+/** Write-through one session's draft. Empty/blank text removes the key. */
+export function persistDraft(sessionId: string, text: string): void {
+  if (!sessionId) return;
+  try {
+    if (text) localStorage.setItem(keyFor(sessionId), text);
+    else localStorage.removeItem(keyFor(sessionId));
+  } catch { /* quota exceeded / disabled — keep the in-memory draft only */ }
+}
+
+/** Drop one session's persisted draft (session deleted or virtual chat discarded). */
+export function removeDraft(sessionId: string): void {
+  if (!sessionId) return;
+  try { localStorage.removeItem(keyFor(sessionId)); } catch { /* ignore */ }
+}
+
+/**
+ * Drop persisted drafts whose session id is not in `keep` — reclaims drafts for
+ * sessions deleted or archived elsewhere (server-side, another tab, Telegram).
+ * Callers must include the active session and any unsent virtual chat in `keep`.
+ */
+export function pruneDrafts(keep: Set<string>): void {
+  for (const k of draftKeys()) {
+    if (!keep.has(k.slice(PREFIX.length))) {
+      try { localStorage.removeItem(k); } catch { /* ignore */ }
+    }
+  }
+}
+
+/** Wipe every persisted draft — the shared-browser safety control, run on logout. */
+export function clearAllDrafts(): void {
+  for (const k of draftKeys()) {
+    try { localStorage.removeItem(k); } catch { /* ignore */ }
+  }
+}


### PR DESCRIPTION
## Problem

In the web UI you cannot type into a session's composer while that session's
agent turn is running — the whole textarea is disabled for the entire turn.
So you can't jot down a follow-up while the agent is working, and if you
switch away the text is gone.

Root cause is one line: `ChatPage` passes `disabled={isStreaming}` to
`ChatInput`, and the textarea honors it (`disabled={disabled || rewriteActive}`).

## What changed (frontend only — no backend change)

**Part A — typeable while working.** Drop `disabled={isStreaming}`. The
textarea stays typeable during a turn; `isStreaming` still swaps Send↔Stop and
gates `canSend`, so **nothing is sent mid-turn** — Enter/Send stay disabled and
the text is simply held as the session's draft until the turn ends, at which
point Send re-enables and you send it yourself.

**Part B — durable per-session drafts.** The store already kept an in-memory
per-session `drafts` map (loaded on session switch, cleared on send), but it
didn't survive a page reload. It's now backed by `localStorage`, **one
`nerve_draft_<id>` key per session** (not a single blob) so two tabs editing
*different* sessions can't clobber each other, and per-session cleanup is a
single `removeItem`. New stateless helper `stores/helpers/draftStorage.ts`:
hydrate on init, write-through on each keystroke (blank text clears the key),
and every write is quota-safe — a full or disabled `localStorage` degrades to
in-memory only and never blocks typing.

## Cleanup / security

- **Prune orphans** in `loadSessions` — drop draft keys for sessions that no
  longer exist (deleted or archived elsewhere / another tab), keeping the
  active session and any unsent new chat.
- **Remove** a session's draft on delete and on virtual-chat discard.
- **Purge all drafts on logout** — the shared-browser safety control, so an
  unsent draft never leaks to the next user.

Draft text is bound to the `<textarea value>` (never rendered as HTML), so
there's no new XSS surface, and no draft content ever leaves the browser.

## Draft lifecycle

created/updated on keystroke → restored on session switch **and on reload** →
removed on send, session delete, virtual-chat discard, orphan-prune, or logout.

## Testing

- `npm run build` (tsc typecheck + vite) passes.
- `eslint` clean on all changed files (one pre-existing `no-explicit-any` in
  `authStore.login`, untouched by this PR).
- Manual: type during a running turn → text stays, Send stays disabled, sends
  after the turn ends; reload mid-draft → text restored; switch sessions →
  independent drafts; delete session / logout → drafts gone.

## Scope

There's a single composer (`ChatInput`) used for every session, so this covers
the whole web UI. Interactive-question / approval cards are separate ephemeral
prompts and are out of scope. Backend is untouched — proper mid-turn message
*queuing* would need server support and is intentionally not part of this PR.
