### PR TITLE
Raise default agent.max_concurrent from 4 to 32

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,7 +38,7 @@ agent:
   cron_model: claude-sonnet-4-6  # Cheaper model for cron jobs
   title_model: claude-haiku-4-5-20251001  # Session title generation
   max_turns: 50                  # Max agentic turns per request
-  max_concurrent: 4              # Max concurrent agent sessions
+  max_concurrent: 32             # Max concurrent agent sessions
   background_agent_permissions: true  # Background sub-agents (Agent run_in_background) get the same tool permissions as foreground; false denies their Write/Edit/Bash
   # First-prompt rewrite — the web UI can refine the opening message of a
   # new chat with a fast model, preview it, and send only after approval.

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,7 +39,7 @@ from any working directory:
 | `agent.model` | string | `claude-opus-4-8` | Primary model for conversations |
 | `agent.cron_model` | string | `claude-sonnet-4-6` | Model for cron jobs (cheaper) |
 | `agent.max_turns` | int | `50` | Max agentic turns per request |
-| `agent.max_concurrent` | int | `4` | Max concurrent agent sessions |
+| `agent.max_concurrent` | int | `32` | Max concurrent agent sessions |
 | `agent.cache_ttl` | string | `"5m"` | Prompt-cache write TTL policy: `5m` (status quo), `1h` (always request the 1-hour TTL), or `auto` (per session at client-build time: sparse-cadence sessions — persistent crons, wakeup loops, spaced chats — get `1h`; dense sessions stay on `5m`). Per-cron-job override via `cache_ttl` in jobs.yaml. See `nerve/agent/cache_policy.py` |
 | `agent.cache_ttl_excluded_models` | list | `[]` | Model-name substrings that never request the 1h TTL |
 | `agent.prompt_rewrite.enabled` | bool | `true` | Offer the first-prompt rewrite feature in the web UI (per-user toggle lives in the composer) |

--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -1957,7 +1957,7 @@ class SetupWizard:
                 "model": "claude-opus-4-8",
                 "cron_model": "claude-sonnet-4-6",
                 "max_turns": 50,
-                "max_concurrent": 4,
+                "max_concurrent": 32,
                 "thinking": "max",
                 "effort": "max",
                 "context_1m": True,

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -145,7 +145,7 @@ class AgentConfig:
     cron_model: str = "claude-sonnet-4-6"
     title_model: str = "claude-haiku-4-5-20251001"  # Session title generation
     max_turns: int = 100
-    max_concurrent: int = 4
+    max_concurrent: int = 32
     thinking: str = "max"       # max, high, medium, low, disabled, adaptive, or number (budget_tokens)
     effort: str = "max"         # max, xhigh, high, medium, low
     # Effort for cron- and hook-sourced turns (sensing / triage work). These
@@ -204,7 +204,7 @@ class AgentConfig:
             cron_model=d.get("cron_model", "claude-sonnet-4-6"),
             title_model=d.get("title_model", "claude-haiku-4-5-20251001"),
             max_turns=d.get("max_turns", 100),
-            max_concurrent=d.get("max_concurrent", 4),
+            max_concurrent=d.get("max_concurrent", 32),
             thinking=str(d.get("thinking", "max")),
             effort=str(d.get("effort", "max")),
             cron_effort=str(d.get("cron_effort", "medium")),


### PR DESCRIPTION
## Why

`engine.run()` holds a global `asyncio.Semaphore(agent.max_concurrent)` for the **entire duration of an agent turn**. With the default of 4, a handful of concurrent long-running sessions (e.g. several deep investigations, Claude + Codex side by side, plus cron jobs — all competing for the same pool) saturate every slot. Any further message — to an existing session, the first turn of a brand-new session, or a scheduled cron turn — parks silently at the semaphore: no `session_running` broadcast, no message persistence, no title, no streaming. To the user the instance looks unwritable until a long turn finishes and frees a slot (observed queue delays of 8+ minutes).

Turns are almost entirely I/O-bound (awaiting the backend CLI subprocess), so a much higher ceiling is safe; 32 keeps the semaphore as a runaway backstop rather than a throughput limiter.

## Changes

- `nerve/config.py`: `AgentConfig.max_concurrent` default `4` → `32` (dataclass default + loader fallback)
- `nerve/bootstrap.py`: setup-wizard generated config → `32`
- `config.example.yaml`, `docs/config.md`: documented default → `32`

Existing configs with an explicit `max_concurrent` are unaffected.

## Testing

- Full suite: 1588 passed, 2 skipped.

## Follow-up (not in this PR)

The silent-queueing UX is a separate issue: messages waiting on the semaphore aren't persisted or acknowledged, so users can't tell "queued" from "broken" (and queued messages are lost on restart). Worth persisting the user message and broadcasting a queued state before semaphore acquisition.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*