### PR TITLE
Add `nerve restart --resume` to continue a session across a restart

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -64,7 +64,7 @@ from nerve.agent.tools import (
 # keep working. The new runtime path uses ``self.registry`` + a
 # per-session ``ToolContext`` and ignores those globals.
 from nerve.agent.tools import init_tools
-from nerve.config import NerveConfig, load_mcp_servers
+from nerve.config import NerveConfig, RESUME_QUEUE_FILE, load_mcp_servers
 from nerve.db import Database
 from nerve.observability.langfuse import attributes as lf_attrs
 from nerve.skills.manager import SkillManager
@@ -73,6 +73,16 @@ logger = logging.getLogger(__name__)
 
 
 _SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+# Injected as an internal turn when a session is resumed after a
+# ``nerve restart --resume`` (see AgentEngine.resume_enrolled_sessions).
+_RESUME_AFTER_RESTART_PROMPT = (
+    "The Nerve daemon was restarted while you were in the middle of a task. "
+    "Continue from where you left off — pick up the work you were doing before "
+    "the restart. If you triggered the restart yourself, confirm it succeeded "
+    "and carry on."
+)
+
 
 def _sanitize_surrogates(s: str) -> str:
     """Remove orphaned UTF-16 surrogates that break JSON serialization.
@@ -1353,6 +1363,91 @@ class AgentEngine:
         await self.sessions.transition(session_id, SessionStatus.CREATED)
         session = await self.db.get_session(session_id)
         return session
+
+    async def resume_enrolled_sessions(self) -> int:
+        """Re-drive sessions enrolled via ``nerve restart --resume`` on startup.
+
+        The CLI appends session ids to :data:`RESUME_QUEUE_FILE` before a
+        restart. Here we read them once, delete the file immediately (so a
+        resume that itself restarts re-enrolls cleanly and no id is ever
+        re-run), then drive one internal "continue" turn per still-resumable
+        session. Ids that no longer exist, are archived, belong to another
+        runtime (satellite ``source="external"``), or have no SDK session to
+        resume are skipped. ``internal=True`` keeps the synthetic trigger out
+        of the transcript while the assistant's continuation is persisted and
+        broadcast normally, and the preserved ``sdk_session_id`` restores full
+        context via the SDK's resume — exactly like :meth:`resume_session`.
+
+        Runs as a startup background task (never blocks the event loop set-up)
+        and returns the number of sessions resumed.
+        """
+        try:
+            raw = RESUME_QUEUE_FILE.read_text()
+        except FileNotFoundError:
+            return 0
+        except OSError as e:
+            logger.warning(
+                "Resume-after-restart: could not read %s: %s", RESUME_QUEUE_FILE, e,
+            )
+            return 0
+
+        # Drain the queue up front so a resumed turn that triggers another
+        # restart re-enrolls into a clean file and ids are never double-run.
+        with contextlib.suppress(FileNotFoundError):
+            RESUME_QUEUE_FILE.unlink()
+
+        seen: set[str] = set()
+        ids: list[str] = []
+        for line in raw.splitlines():
+            sid = line.strip()
+            if sid and sid not in seen:
+                seen.add(sid)
+                ids.append(sid)
+        if not ids:
+            return 0
+
+        resumed = 0
+        for sid in ids:
+            session = await self.db.get_session(sid)
+            if not session:
+                logger.info(
+                    "Resume-after-restart: session %s no longer exists — skipping", sid,
+                )
+                continue
+            if session.get("status") == SessionStatus.ARCHIVED.value:
+                logger.info(
+                    "Resume-after-restart: session %s is archived — skipping", sid,
+                )
+                continue
+            if session.get("source") == "external":
+                logger.info(
+                    "Resume-after-restart: session %s is a satellite — skipping", sid,
+                )
+                continue
+            if not session.get("sdk_session_id"):
+                logger.info(
+                    "Resume-after-restart: session %s has no resumable SDK session"
+                    " — skipping", sid,
+                )
+                continue
+            try:
+                logger.info("Resume-after-restart: continuing session %s", sid)
+                await self.run(
+                    session_id=sid,
+                    user_message=_RESUME_AFTER_RESTART_PROMPT,
+                    source=session.get("source") or "web",
+                    internal=True,
+                )
+                resumed += 1
+            except Exception as e:
+                logger.warning(
+                    "Resume-after-restart: session %s failed: %s",
+                    sid, e, exc_info=True,
+                )
+
+        if resumed:
+            logger.info("Resume-after-restart: resumed %d session(s)", resumed)
+        return resumed
 
     # ------------------------------------------------------------------ #
     #  Tool-result helpers                                                 #

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import click
 
 from nerve.config import (
+    RESUME_QUEUE_FILE,
     load_config,
     resolve_config_dir,
     set_config,
@@ -361,15 +362,43 @@ def stop(ctx: click.Context) -> None:
 
 
 @main.command()
+@click.option(
+    "--resume",
+    "resume_ids",
+    multiple=True,
+    metavar="SESSION_ID",
+    help=(
+        "Session id to auto-resume once the daemon is back (repeatable). The "
+        "fresh daemon re-drives an interrupted turn for each id that still has "
+        "a resumable SDK session."
+    ),
+)
 @click.pass_context
-def restart(ctx: click.Context) -> None:
+def restart(ctx: click.Context, resume_ids: tuple[str, ...]) -> None:
     """Restart the Nerve daemon.
 
     Spawns a detached helper process that stops the old daemon and starts a
     new one.  This ensures restarts work even when triggered from *inside*
     the running daemon (e.g. via the Telegram bot / agent), because the
     helper runs in its own session and survives the parent's death.
+
+    ``--resume SESSION_ID`` enrolls one or more sessions to be continued after
+    the restart: their ids are written to the resume queue now, and the fresh
+    daemon re-drives each interrupted turn on startup.
     """
+    # Enroll ids before anything else so the queue file is on disk — and
+    # survives even a hard kill — by the time the new instance reads it.
+    # Append mode lets concurrent enrollments from different sessions coexist.
+    # Written for every mode (normal / Docker / systemd) since all restart the
+    # daemon. Invalid/dead ids are skipped by the daemon-side drainer.
+    if resume_ids:
+        ids = [s.strip() for s in resume_ids if s.strip()]
+        if ids:
+            RESUME_QUEUE_FILE.parent.mkdir(parents=True, exist_ok=True)
+            with open(RESUME_QUEUE_FILE, "a") as fh:
+                fh.writelines(f"{sid}\n" for sid in ids)
+            click.echo(f"Will resume {len(ids)} session(s) after restart.")
+
     config = ctx.obj["config"]
     # Already resolved via the waterfall (flag → env → cwd → pointer), so
     # this is an absolute path that doesn't depend on the caller's CWD.

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -20,6 +20,12 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+# Runtime queue of session ids to auto-resume after ``nerve restart --resume``.
+# The CLI appends ids here (synchronously, before triggering the restart) and
+# the fresh daemon drains it on startup. Kept next to the other ~/.nerve runtime
+# state (pid/log/db) and independent of ``-c`` so writer and reader always agree.
+RESUME_QUEUE_FILE = Path("~/.nerve/resume-after-restart").expanduser()
+
 
 def _deep_merge(base: dict, override: dict) -> dict:
     """Recursively merge override into base, returning a new dict."""

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -464,6 +464,11 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error("Failed to send startup notification: %s", e)
 
+    # Re-drive any sessions enrolled via `nerve restart --resume`. Runs as a
+    # background task so a (possibly long) resumed turn never blocks startup;
+    # the engine, notification service and channels are all wired by now.
+    asyncio.create_task(_engine.resume_enrolled_sessions())
+
     yield
 
     # Stop the loopback listener before the manager so no new requests

--- a/tests/test_mcp_http_integration.py
+++ b/tests/test_mcp_http_integration.py
@@ -63,6 +63,7 @@ def app_with_mcp(tmp_path, monkeypatch):
     fake_engine.sessions.run_cleanup = AsyncMock(return_value={})
     fake_engine.run_memorization_sweep = AsyncMock(return_value={})
     fake_engine.run_idle_client_sweep = AsyncMock()
+    fake_engine.resume_enrolled_sessions = AsyncMock(return_value=0)
 
     db_path = tmp_path / "test.db"
 

--- a/tests/test_resume_after_restart.py
+++ b/tests/test_resume_after_restart.py
@@ -1,0 +1,164 @@
+"""Tests for `nerve restart --resume`: CLI enrollment + the startup drainer
+(AgentEngine.resume_enrolled_sessions)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+
+from nerve import cli
+from nerve.agent.engine import AgentEngine, _RESUME_AFTER_RESTART_PROMPT
+from nerve.agent.sessions import SessionStatus
+
+
+# --------------------------------------------------------------------------- #
+#  Daemon side: AgentEngine.resume_enrolled_sessions                          #
+# --------------------------------------------------------------------------- #
+
+def _engine_with(sessions_by_id: dict) -> AgentEngine:
+    """Bare AgentEngine stub exercising only resume_enrolled_sessions' deps."""
+    engine = AgentEngine.__new__(AgentEngine)
+
+    async def _get_session(sid):
+        return sessions_by_id.get(sid)
+
+    engine.db = SimpleNamespace(get_session=AsyncMock(side_effect=_get_session))
+    engine.run = AsyncMock(return_value="ok")
+    return engine
+
+
+def _session(sid, *, status="idle", source="web", sdk="sdk-"):
+    return {
+        "id": sid,
+        "status": status,
+        "source": source,
+        "sdk_session_id": (sdk + sid) if sdk is not None else None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_no_queue_file_is_noop(tmp_path):
+    qf = tmp_path / "resume-after-restart"  # never created
+    engine = _engine_with({})
+    with patch("nerve.agent.engine.RESUME_QUEUE_FILE", qf):
+        assert await engine.resume_enrolled_sessions() == 0
+    engine.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resumes_valid_session_and_drains_file(tmp_path):
+    qf = tmp_path / "resume-after-restart"
+    qf.write_text("S1\n")
+    engine = _engine_with({"S1": _session("S1")})
+    with patch("nerve.agent.engine.RESUME_QUEUE_FILE", qf):
+        n = await engine.resume_enrolled_sessions()
+    assert n == 1
+    assert not qf.exists()  # queue drained up front
+    engine.run.assert_awaited_once()
+    kwargs = engine.run.await_args.kwargs
+    assert kwargs["session_id"] == "S1"
+    assert kwargs["internal"] is True
+    assert kwargs["source"] == "web"
+    assert kwargs["user_message"] == _RESUME_AFTER_RESTART_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_skips_missing_archived_external_and_no_sdk(tmp_path):
+    qf = tmp_path / "resume-after-restart"
+    qf.write_text("\n".join(["missing", "arch", "ext", "nosdk", "good"]) + "\n")
+    sessions = {
+        "arch": _session("arch", status=SessionStatus.ARCHIVED.value),
+        "ext": _session("ext", source="external"),
+        "nosdk": _session("nosdk", sdk=None),
+        "good": _session("good"),
+        # "missing" intentionally absent from the DB
+    }
+    engine = _engine_with(sessions)
+    with patch("nerve.agent.engine.RESUME_QUEUE_FILE", qf):
+        n = await engine.resume_enrolled_sessions()
+    assert n == 1
+    engine.run.assert_awaited_once()
+    assert engine.run.await_args.kwargs["session_id"] == "good"
+
+
+@pytest.mark.asyncio
+async def test_dedupes_and_ignores_blank_lines(tmp_path):
+    qf = tmp_path / "resume-after-restart"
+    qf.write_text("S1\nS1\n  S1  \n\n")
+    engine = _engine_with({"S1": _session("S1")})
+    with patch("nerve.agent.engine.RESUME_QUEUE_FILE", qf):
+        n = await engine.resume_enrolled_sessions()
+    assert n == 1
+    engine.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_uses_session_source(tmp_path):
+    qf = tmp_path / "resume-after-restart"
+    qf.write_text("T1\n")
+    engine = _engine_with({"T1": _session("T1", source="telegram")})
+    with patch("nerve.agent.engine.RESUME_QUEUE_FILE", qf):
+        await engine.resume_enrolled_sessions()
+    assert engine.run.await_args.kwargs["source"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_one_failure_does_not_block_others(tmp_path):
+    qf = tmp_path / "resume-after-restart"
+    qf.write_text("bad\ngood\n")
+    engine = _engine_with({"bad": _session("bad"), "good": _session("good")})
+
+    async def _run(**kwargs):
+        if kwargs["session_id"] == "bad":
+            raise RuntimeError("boom")
+        return "ok"
+
+    engine.run = AsyncMock(side_effect=_run)
+    with patch("nerve.agent.engine.RESUME_QUEUE_FILE", qf):
+        n = await engine.resume_enrolled_sessions()
+    assert n == 1  # only "good" counted; "bad" swallowed
+    assert engine.run.await_count == 2
+    assert not qf.exists()
+
+
+# --------------------------------------------------------------------------- #
+#  CLI side: `nerve restart --resume` writes the queue for all modes          #
+# --------------------------------------------------------------------------- #
+
+def _invoke_restart(tmp_path, resume_ids):
+    qf = tmp_path / "resume-after-restart"
+    logf = tmp_path / "nerve.log"
+    with patch("nerve.cli._is_docker_mode", return_value=False), \
+         patch("nerve.cli._is_systemd_managed", return_value=False), \
+         patch("nerve.cli._get_daemon_status", return_value=(False, None)), \
+         patch("nerve.cli.subprocess.Popen", MagicMock()), \
+         patch("nerve.cli.LOG_FILE", logf), \
+         patch("nerve.cli.RESUME_QUEUE_FILE", qf):
+        ctx = click.Context(cli.restart)
+        ctx.obj = {
+            "config": SimpleNamespace(deployment="server"),
+            "config_dir": str(tmp_path),
+            "verbose": False,
+        }
+        ctx.invoke(cli.restart, resume_ids=resume_ids)
+    return qf
+
+
+def test_restart_resume_writes_queue(tmp_path):
+    qf = _invoke_restart(tmp_path, ("S1", "S2"))
+    assert qf.read_text() == "S1\nS2\n"
+
+
+def test_restart_resume_appends(tmp_path):
+    qf = tmp_path / "resume-after-restart"
+    qf.write_text("EXISTING\n")
+    _invoke_restart(tmp_path, ("S3",))
+    assert qf.read_text() == "EXISTING\nS3\n"
+
+
+def test_restart_without_resume_writes_nothing(tmp_path):
+    qf = _invoke_restart(tmp_path, ())
+    assert not qf.exists()


### PR DESCRIPTION
## Problem

When a session restarts the daemon mid-turn (common while developing something that needs a restart), the in-flight turn is abandoned. Shutdown preserves the SDK conversation (`sdk_session_id`), but nothing re-issues the interrupted turn on startup — so the work silently stops until a new message arrives.

## Change

`nerve restart --resume <SESSION_ID>` (repeatable) enrolls sessions to be continued after the restart:

- The CLI appends the id(s) to an on-disk queue (`~/.nerve/resume-after-restart`) **before** triggering the restart, so the enrollment is durable and crash-safe (it survives even a hard kill).
- On startup the daemon drains the queue and drives one **internal** "continue where you left off" turn per still-resumable session, reusing the preserved `sdk_session_id` to restore full context — the same resume mechanism as `resume_session`. `internal=True` keeps the synthetic trigger out of the transcript while the assistant's continuation is persisted and broadcast normally.
- The queue file is deleted up front (so no id is ever re-run), and ids that no longer exist, are archived, are satellites (`source="external"`), or have no resumable SDK session are skipped.

There is no global switch or per-session policy: a session is resumed **iff** it was explicitly enrolled via `--resume`.

## Usage

```
nerve restart --resume <SESSION_ID>
```

## Testing

- New `tests/test_resume_after_restart.py` covers the drainer (parse / dedup / skip conditions / up-front drain / one-failure-isolation) and the CLI enqueue across modes.
- Full suite green (`.venv/bin/pytest tests/`); updated the MCP HTTP integration fixture to stub the new lifespan call.
- Backend-only — no frontend build needed.
