### PR TITLE
Fix blank web UI on first load when no password is configured

### DIFF
--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -45,7 +45,9 @@ export const useAuthStore = create<AuthState>((set) => ({
           // No password configured — auto-login
           const { token } = await api.login('');
           setToken(token);
-          set({ authenticated: true });
+          // checking must be cleared here too — App renders null while it
+          // is true, so leaving it set blanks the app after auto-login.
+          set({ authenticated: true, checking: false });
           return;
         }
       } catch {


### PR DESCRIPTION
On a deployment with no password configured, a fresh browser loads the web UI, auto-logs in, and then sits on a blank page. A manual reload fixes it, which makes it look like a flaky first paint rather than a state bug.

`checking` starts as `!getToken()`, so it is `true` for any browser without a stored token, and `App.tsx` renders `null` while it is set:

```ts
checking: !getToken(),
...
if (checking) return null;
```

Every branch of `checkAuth()` clears it — the auth-required path, the success path, the failure path — except the auto-login branch taken when `authStatus()` reports `auth_required: false`. That one sets `authenticated: true` and returns with `checking` still `true`, so the app never renders. The reload "fix" works only because a token now exists, which makes `checking` start `false` and skips the check entirely.

## Fix

Clear `checking` on that branch too, like every other exit from `checkAuth()`.

Reproduces with `auth.password` unset and cleared site data; after the change the UI renders immediately on first load.
