### PR TITLE
Fix memU write starvation: scope the event-date sweep, retry lock contention and rate limits

### DIFF
--- a/nerve/agent/tools/handlers/memory.py
+++ b/nerve/agent/tools/handlers/memory.py
@@ -435,13 +435,27 @@ async def memorize_handler(ctx: ToolContext, args: dict) -> ToolResult:
         return ToolResult.text(f"Memorized: {content}{suffix}")
     if memu_down:
         return ToolResult.text(
-            "⚠️ NOT saved — MEMORY BACKEND DOWN (transient proxy/auth error). "
-            "The fact was NOT stored; retry shortly. If it persists, `nerve restart` "
-            f"clears a stuck proxy cooldown. ({memu_err})"
+            "⚠️ NOT saved — MEMORY BACKEND UNAVAILABLE (transient infrastructure "
+            "error — NOT a judgment on the content). The fact was NOT stored; "
+            f"retry shortly. ({memu_err})"
         )
     if memu_err is not None:
         return ToolResult.text(f"Error: {memu_err}")
-    return ToolResult.text("Failed to memorize.")
+    # memorize_file returned False without raising — pull the underlying
+    # cause from bridge metrics so the agent sees an infrastructure error,
+    # not an unexplained "refusal".
+    cause = ""
+    try:
+        stats = getattr(ctx.memory_bridge, "_metrics", None)
+        op_stats = stats.ops.get("memorize_file") if stats else None
+        if op_stats and op_stats.last_error:
+            cause = f" (last error: {op_stats.last_error})"
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return ToolResult.text(
+        f"Failed to memorize{cause}. This is an infrastructure failure, "
+        "not a content refusal — retry later or keep the fact elsewhere."
+    )
 
 
 async def memory_update_handler(ctx: ToolContext, args: dict) -> ToolResult:

--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -11,11 +11,12 @@ import ctypes
 import gc
 import json
 import logging
+import random
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Coroutine
 from zoneinfo import ZoneInfo
@@ -68,6 +69,18 @@ def _is_transient_llm_error(exc: BaseException) -> bool:
     # Belt-and-suspenders: the proxy's stuck-cooldown signature regardless of
     # how the status surfaced.
     return "auth_unavailable" in low
+
+
+def _is_sqlite_locked_error(exc: BaseException) -> bool:
+    """True if ``exc`` is SQLite lock contention — worth retrying.
+
+    Matches both the raw ``sqlite3.OperationalError`` message and the
+    SQLAlchemy-wrapped form (``(sqlite3.OperationalError) database is
+    locked``). Lock contention means another writer held the database
+    past ``busy_timeout``; the write never happened, so a retry is safe.
+    """
+    msg = str(exc).lower()
+    return "database is locked" in msg or "database table is locked" in msg
 
 
 # Semantic dedup threshold — set from config at init time.
@@ -1339,6 +1352,23 @@ class MemUBridge:
         except Exception as exc:
             logger.warning("memU WAL setup skipped: %s", exc)
 
+        # Best-effort WAL truncate at startup: long-lived readers (recall
+        # scans, backups) can starve passive checkpoints until the WAL grows
+        # to GBs, which makes every commit slow. Startup is the one moment
+        # this process has no other memU connections, so a TRUNCATE
+        # checkpoint can usually reclaim the backlog.
+        try:
+            conn = _sqlite3.connect(db_path, timeout=30)
+            conn.execute("PRAGMA busy_timeout=30000")
+            res = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            conn.close()
+            logger.info(
+                "memU WAL startup checkpoint: blocked=%s wal_pages=%s checkpointed=%s",
+                *(res if res else ("?", "?", "?")),
+            )
+        except Exception as exc:
+            logger.warning("memU WAL startup checkpoint skipped: %s", exc)
+
     def _attach_engine_pragmas(self) -> None:
         """Per-connection pragmas for memU's SQLAlchemy engine.
 
@@ -1347,7 +1377,9 @@ class MemUBridge:
         connection via the ``connect`` event.  ``synchronous=NORMAL`` is
         the recommended pairing with WAL (fsync on checkpoint, not on every
         commit); ``busy_timeout`` stops concurrent writers from failing
-        fast with "database is locked".
+        fast with "database is locked"; ``journal_size_limit`` lets
+        checkpoints truncate a ballooned WAL back to a sane size instead
+        of leaving a multi-GB file behind forever.
         """
         try:
             from sqlalchemy import event
@@ -1357,14 +1389,18 @@ class MemUBridge:
             @event.listens_for(engine, "connect")
             def _set_pragmas(dbapi_conn, _record):  # pragma: no cover - thin
                 cursor = dbapi_conn.cursor()
-                cursor.execute("PRAGMA busy_timeout=10000")
+                cursor.execute("PRAGMA busy_timeout=30000")
                 cursor.execute("PRAGMA synchronous=NORMAL")
+                cursor.execute("PRAGMA journal_size_limit=67108864")  # 64 MiB
                 cursor.close()
 
             # Recycle connections opened before the listener existed
             # (table-creation during MemoryService init).
             engine.dispose()
-            logger.info("memU engine pragmas attached (busy_timeout, synchronous=NORMAL)")
+            logger.info(
+                "memU engine pragmas attached (busy_timeout=30s, "
+                "synchronous=NORMAL, journal_size_limit=64MiB)"
+            )
         except Exception as exc:
             logger.warning("Could not attach memU engine pragmas: %s", exc)
 
@@ -1875,6 +1911,19 @@ class MemUBridge:
     # Per-call timeout for individual LLM requests (chat, embed, etc.).
     _LLM_CALL_TIMEOUT = 120
 
+    # _resolve_event_dates_sync scoping. Only items created within this
+    # window that were never stamped with ``extra.mentioned_at`` are swept.
+    # Historically the sweep matched EVERY ``happened_at IS NULL`` row —
+    # and non-events keep happened_at NULL *by design*, so each conversation
+    # memorize rewrote the entire non-event corpus in one write transaction
+    # (388K rows / minutes holding the SQLite write lock on a large fleet
+    # instance, starving every concurrent memorize into "database is
+    # locked"). The window covers items persisted by this or a recently
+    # cancelled pipeline; the cap bounds the worst case.
+    _DATE_SWEEP_WINDOW_HOURS = 24
+    _DATE_SWEEP_MAX_ROWS = 2000
+    _DATE_SWEEP_COMMIT_EVERY = 500
+
     def _make_bedrock_client(self, chat_model: str) -> _BedrockLLMClient:
         """Create a _BedrockLLMClient using Nerve's provider config."""
         return _BedrockLLMClient(
@@ -1956,10 +2005,14 @@ class MemUBridge:
                     # memU otherwise fails fast with SDK retries disabled
                     # (see max_retries=0 above), so a transient proxy/auth blip
                     # (503/429/auth_unavailable) that the agent SDK rides out via
-                    # its own retries takes memory down instead. Retry a few
-                    # times with short backoff on transient errors only; keep the
-                    # per-attempt wait_for so genuine hangs still fail fast.
-                    _RETRY_BACKOFFS = (0.5, 1.5, 3.0)
+                    # its own retries takes memory down instead. Retry with
+                    # backoff on transient errors only; keep the per-attempt
+                    # wait_for so genuine hangs still fail fast. The schedule
+                    # is long enough to ride out sustained rate-limit storms
+                    # (e.g. a shared Bedrock guardrail TPS quota under fleet
+                    # load), and jittered so concurrent pipelines don't
+                    # re-collide in lockstep.
+                    _RETRY_BACKOFFS = (1.0, 3.0, 8.0, 20.0)
                     for _attempt in range(len(_RETRY_BACKOFFS) + 1):
                         t0 = time.monotonic()
                         try:
@@ -2000,6 +2053,19 @@ class MemUBridge:
                             # it loudly as MemoryBackendUnavailable.
                             if _is_transient_llm_error(_e) and _attempt < len(_RETRY_BACKOFFS):
                                 _delay = _RETRY_BACKOFFS[_attempt]
+                                # Honor an explicit Retry-After when present
+                                # (capped — a huge server value must not park
+                                # the pipeline).
+                                try:
+                                    _hdrs = getattr(
+                                        getattr(_e, "response", None), "headers", None,
+                                    )
+                                    _ra = float(_hdrs.get("retry-after")) if _hdrs and _hdrs.get("retry-after") else 0.0
+                                    if _ra > 0:
+                                        _delay = max(_delay, min(_ra, 60.0))
+                                except (TypeError, ValueError, AttributeError):
+                                    pass
+                                _delay *= 0.75 + random.random() * 0.5  # ±25% jitter
                                 logger.warning(
                                     "memU LLM transient error [%s] attempt %d/%d: %s — retrying in %.1fs",
                                     _prof, _attempt + 1, len(_RETRY_BACKOFFS) + 1, _e, _delay,
@@ -2161,6 +2227,7 @@ class MemUBridge:
 
         attempt = 0
         last_error = ""
+        locked_exc: Exception | None = None
 
         while attempt <= self._MEMORIZE_MAX_RETRIES:
             op_id = self._metrics.begin_op("memorize_file", file_path)
@@ -2267,6 +2334,24 @@ class MemUBridge:
                         logger.info("Resetting LLM clients and retrying in %ds...", delay)
                         await self._reset_llm_clients()
                         await asyncio.sleep(delay)
+                elif _is_sqlite_locked_error(e):
+                    # SQLite write-lock contention: another writer held the
+                    # database past busy_timeout. The write did not happen,
+                    # so retrying the pipeline is safe (semantic dedup
+                    # absorbs re-extracted items). No LLM client reset —
+                    # this is a DB-side condition.
+                    elapsed = time.monotonic() - t0
+                    last_error = f"database locked after {elapsed:.0f}s: {e}"
+                    locked_exc = e
+                    logger.error(
+                        "memU memorize_file hit SQLite lock contention %sfor %s: %s",
+                        label + " " if label else "", file_path, e,
+                    )
+                    self._metrics.end_op(op_id, success=False, error=last_error)
+                    if attempt < self._MEMORIZE_MAX_RETRIES:
+                        delay = self._MEMORIZE_RETRY_DELAY * (2 ** attempt)
+                        logger.info("Retrying after lock contention in %ds...", delay)
+                        await asyncio.sleep(delay)
                 else:
                     last_error = str(e)
                     logger.error("memU memorize_file failed %sfor %s: %s", label + " " if label else "", file_path, e)
@@ -2282,6 +2367,12 @@ class MemUBridge:
 
         logger.error("memU memorize_file gave up after %d attempts for %s", attempt, file_path)
         await asyncio.to_thread(self._release_memory)
+        if locked_exc is not None:
+            # Exhausted retries on lock contention: surface loudly so the
+            # tool layer reports "backend busy", not a silent failure.
+            raise MemoryBackendUnavailable(
+                f"memory backend busy (SQLite write-lock contention): {locked_exc}"
+            ) from locked_exc
         return False
 
     async def memorize_conversation(self, session_id: str, messages: list[dict]) -> bool:
@@ -2381,23 +2472,48 @@ class MemUBridge:
         )
 
     def _resolve_event_dates_sync(self, conversation_ts: str) -> None:
-        """Synchronous implementation of event date resolution."""
+        """Synchronous implementation of event date resolution.
+
+        Scoped to recent, never-stamped items (see the ``_DATE_SWEEP_*``
+        constants): non-events keep ``happened_at`` NULL forever, so an
+        unscoped ``happened_at IS NULL`` sweep grows with the corpus and
+        rewrites every non-event row on every conversation memorize —
+        holding the SQLite write lock for minutes on a large database.
+        The ``mentioned_at`` substring guard also makes the sweep
+        idempotent: an item is stamped once, when first seen, instead of
+        being rewritten (and its ``mentioned_at`` overwritten) forever.
+        """
         import sqlite3
 
         db_path = self.config.memory.sqlite_dsn.replace("sqlite:///", "")
         try:
-            db = sqlite3.connect(db_path, timeout=10)
+            db = sqlite3.connect(db_path, timeout=30)
             db.row_factory = sqlite3.Row
+            db.execute("PRAGMA busy_timeout=30000")
             db.execute("PRAGMA synchronous=NORMAL")
 
+            cutoff = (
+                datetime.now(timezone.utc)
+                - timedelta(hours=self._DATE_SWEEP_WINDOW_HOURS)
+            ).strftime("%Y-%m-%d %H:%M:%S")
             rows = db.execute(
                 "SELECT id, memory_type, summary, extra "
-                "FROM memu_memory_items WHERE happened_at IS NULL"
+                "FROM memu_memory_items "
+                "WHERE happened_at IS NULL "
+                "  AND (created_at IS NULL OR created_at >= ?) "
+                "  AND (extra IS NULL OR instr(extra, '\"mentioned_at\"') = 0) "
+                "ORDER BY created_at DESC LIMIT ?",
+                (cutoff, self._DATE_SWEEP_MAX_ROWS),
             ).fetchall()
 
             if not rows:
                 db.close()
                 return
+            if len(rows) >= self._DATE_SWEEP_MAX_ROWS:
+                logger.warning(
+                    "Event date sweep hit its %d-row cap — stamping the newest slice only",
+                    self._DATE_SWEEP_MAX_ROWS,
+                )
 
             # Convert UTC timestamp to user's local date
             try:
@@ -2419,15 +2535,27 @@ class MemUBridge:
                 except Exception as e:
                     logger.warning("LLM date resolution failed, falling back to conversation date: %s", e)
 
-            # Update event items
+            # Update event items + stamp mentioned_at, committing in small
+            # batches so the write transaction never holds the write lock
+            # long enough to starve concurrent memorize pipelines.
+            pending = 0
+
+            def _commit_batch(force: bool = False) -> None:
+                nonlocal pending
+                if pending and (force or pending >= self._DATE_SWEEP_COMMIT_EVERY):
+                    db.commit()
+                    pending = 0
+
             for item_id, summary in event_items:
                 happened_at = resolved_dates.get(item_id) or conv_date
                 db.execute(
                     "UPDATE memu_memory_items SET happened_at = ? WHERE id = ?",
                     (happened_at, item_id),
                 )
+                pending += 1
+                _commit_batch()
 
-            # Set mentioned_at on ALL items (events + non-events)
+            # Set mentioned_at on ALL swept items (events + non-events)
             for row in rows:
                 item_id = row["id"]
                 extra = json.loads(row["extra"]) if row["extra"] else {}
@@ -2436,8 +2564,10 @@ class MemUBridge:
                     "UPDATE memu_memory_items SET extra = ? WHERE id = ?",
                     (json.dumps(extra, ensure_ascii=False), item_id),
                 )
+                pending += 1
+                _commit_batch()
 
-            db.commit()
+            _commit_batch(force=True)
             db.close()
             logger.debug(
                 "Resolved dates for %d items (%d events via LLM, %d non-events left NULL)",

--- a/tests/test_memu_bridge.py
+++ b/tests/test_memu_bridge.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,10 +12,12 @@ import pytest_asyncio
 
 from nerve.config import MemoryConfig, NerveConfig
 from nerve.memory.memu_bridge import (
+    MemoryBackendUnavailable,
     MemUBridge,
     _KNOWLEDGE_CUSTOM_RULES,
     _KNOWLEDGE_CUSTOM_EXAMPLES,
     _SEMANTIC_DEDUP_THRESHOLD,
+    _is_sqlite_locked_error,
 )
 
 
@@ -66,8 +69,8 @@ def _insert_items(db_path: str, items: list[dict]) -> None:
     db = sqlite3.connect(db_path)
     for item in items:
         db.execute(
-            "INSERT INTO memu_memory_items (id, resource_id, memory_type, summary, happened_at, extra) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO memu_memory_items (id, resource_id, memory_type, summary, happened_at, extra, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 item["id"],
                 item.get("resource_id", "res-1"),
@@ -75,6 +78,7 @@ def _insert_items(db_path: str, items: list[dict]) -> None:
                 item["summary"],
                 item.get("happened_at"),
                 json.dumps(item.get("extra", {})),
+                item.get("created_at"),
             ),
         )
     db.commit()
@@ -225,6 +229,93 @@ class TestResolveEventDatesSync:
         assert extra["content_hash"] == "abc123"
         assert extra["reinforcement_count"] == 3
         assert extra["mentioned_at"] == "2026-02-27"
+
+    def test_sweep_skips_old_and_already_stamped_items(self, tmp_path):
+        """The sweep is scoped: items outside the recency window and items
+        already carrying ``mentioned_at`` are never rewritten. This is the
+        fix for the unbounded whole-corpus rewrite that held the SQLite
+        write lock for minutes per conversation on large databases."""
+        config = _make_config(tmp_path)
+        db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+        _create_memu_schema(db_path)
+        _insert_items(db_path, [
+            # Ancient item (outside the 24h window) — must NOT be touched.
+            {"id": "old-1", "memory_type": "profile", "summary": "Old fact",
+             "created_at": "2020-01-01 00:00:00.000000"},
+            # Already stamped — must NOT be re-stamped.
+            {"id": "stamped-1", "memory_type": "knowledge", "summary": "Known fact",
+             "extra": {"mentioned_at": "2026-01-15"}},
+            # Fresh, unstamped — must be stamped.
+            {"id": "fresh-1", "memory_type": "behavior", "summary": "New habit"},
+        ])
+
+        bridge = MemUBridge(config)
+        bridge._resolve_event_dates_sync("2026-02-27T10:00:00")
+
+        items = _read_items(db_path)
+        assert "mentioned_at" not in json.loads(items["old-1"]["extra"])
+        assert json.loads(items["stamped-1"]["extra"])["mentioned_at"] == "2026-01-15"
+        assert json.loads(items["fresh-1"]["extra"])["mentioned_at"] == "2026-02-27"
+
+    def test_sweep_is_idempotent(self, tmp_path):
+        """Running the sweep twice keeps the FIRST mentioned_at stamp."""
+        config = _make_config(tmp_path)
+        db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+        _create_memu_schema(db_path)
+        _insert_items(db_path, [
+            {"id": "prof-1", "memory_type": "profile", "summary": "A fact"},
+        ])
+
+        bridge = MemUBridge(config)
+        bridge._resolve_event_dates_sync("2026-02-27T10:00:00")
+        bridge._resolve_event_dates_sync("2026-03-05T10:00:00")
+
+        items = _read_items(db_path)
+        assert json.loads(items["prof-1"]["extra"])["mentioned_at"] == "2026-02-27"
+
+    def test_sweep_commits_in_batches(self, tmp_path, monkeypatch):
+        """All rows are stamped even when the batch size forces multiple
+        commits mid-sweep."""
+        config = _make_config(tmp_path)
+        db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+        _create_memu_schema(db_path)
+        _insert_items(db_path, [
+            {"id": f"item-{i}", "memory_type": "knowledge", "summary": f"Fact {i}"}
+            for i in range(5)
+        ])
+
+        bridge = MemUBridge(config)
+        monkeypatch.setattr(bridge, "_DATE_SWEEP_COMMIT_EVERY", 2)
+        bridge._resolve_event_dates_sync("2026-02-27T10:00:00")
+
+        items = _read_items(db_path)
+        assert len(items) == 5
+        for item in items.values():
+            assert json.loads(item["extra"])["mentioned_at"] == "2026-02-27"
+
+    def test_sweep_row_cap_takes_newest(self, tmp_path, monkeypatch):
+        """When the cap is hit, only the newest rows are processed."""
+        config = _make_config(tmp_path)
+        db_path = config.memory.sqlite_dsn.replace("sqlite:///", "")
+        _create_memu_schema(db_path)
+        now = datetime.now(timezone.utc)
+        _insert_items(db_path, [
+            {"id": "newest", "memory_type": "knowledge", "summary": "n",
+             "created_at": now.strftime("%Y-%m-%d %H:%M:%S.%f")},
+            {"id": "newer", "memory_type": "knowledge", "summary": "n",
+             "created_at": (now - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M:%S.%f")},
+            {"id": "oldest", "memory_type": "knowledge", "summary": "n",
+             "created_at": (now - timedelta(minutes=10)).strftime("%Y-%m-%d %H:%M:%S.%f")},
+        ])
+
+        bridge = MemUBridge(config)
+        monkeypatch.setattr(bridge, "_DATE_SWEEP_MAX_ROWS", 2)
+        bridge._resolve_event_dates_sync("2026-02-27T10:00:00")
+
+        items = _read_items(db_path)
+        assert "mentioned_at" in json.loads(items["newest"]["extra"])
+        assert "mentioned_at" in json.loads(items["newer"]["extra"])
+        assert "mentioned_at" not in json.loads(items["oldest"]["extra"])
 
 
 def _mock_anthropic(response_text: str) -> tuple[MagicMock, MagicMock]:
@@ -952,3 +1043,94 @@ class TestIndexedUpdateItemForwarding:
                         delattr(Repo, name)
                 else:
                     setattr(Repo, name, fn)
+
+
+class TestSqliteLockedClassifier:
+    """_is_sqlite_locked_error truth table."""
+
+    def test_raw_sqlite_message(self):
+        assert _is_sqlite_locked_error(sqlite3.OperationalError("database is locked"))
+
+    def test_sqlalchemy_wrapped_message(self):
+        assert _is_sqlite_locked_error(
+            Exception("(sqlite3.OperationalError) database is locked\n[SQL: UPDATE ...]")
+        )
+
+    def test_table_locked_variant(self):
+        assert _is_sqlite_locked_error(Exception("database table is locked: memu_memory_items"))
+
+    def test_unrelated_errors_not_matched(self):
+        assert not _is_sqlite_locked_error(Exception("no such table: foo"))
+        assert not _is_sqlite_locked_error(Exception("Error code: 429 - rate limited"))
+
+
+def _make_lock_test_bridge(tmp_path: Path) -> MemUBridge:
+    """Bridge wired for memorize_file tests: available, mocked service,
+    zero retry delay, no memU loop (inline _submit)."""
+    config = _make_config(tmp_path)
+    bridge = MemUBridge(config)
+    bridge._available = True
+    bridge._service = MagicMock()
+    bridge._MEMORIZE_RETRY_DELAY = 0
+    return bridge
+
+
+_LOCKED_ERR = "(sqlite3.OperationalError) database is locked"
+
+
+class TestMemorizeFileLockRetry:
+    """memorize_file retries SQLite lock contention instead of failing the
+    write outright (the "memU refused" failure mode under fleet load)."""
+
+    @pytest.mark.asyncio
+    async def test_lock_then_success_returns_true(self, tmp_path):
+        bridge = _make_lock_test_bridge(tmp_path)
+        bridge._service.memorize = AsyncMock(
+            side_effect=[Exception(_LOCKED_ERR), {"items": []}],
+        )
+
+        target = tmp_path / "note.txt"
+        target.write_text("knowledge: a fact")
+        ok = await bridge.memorize_file(str(target))
+
+        assert ok is True
+        assert bridge._service.memorize.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_lock_exhausted_raises_backend_unavailable(self, tmp_path):
+        bridge = _make_lock_test_bridge(tmp_path)
+        bridge._service.memorize = AsyncMock(side_effect=Exception(_LOCKED_ERR))
+
+        target = tmp_path / "note.txt"
+        target.write_text("knowledge: a fact")
+        with pytest.raises(MemoryBackendUnavailable, match="write-lock contention"):
+            await bridge.memorize_file(str(target))
+
+        # Initial attempt + _MEMORIZE_MAX_RETRIES retries
+        assert bridge._service.memorize.await_count == bridge._MEMORIZE_MAX_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_still_fails_fast(self, tmp_path):
+        bridge = _make_lock_test_bridge(tmp_path)
+        bridge._service.memorize = AsyncMock(side_effect=ValueError("bad payload"))
+
+        target = tmp_path / "note.txt"
+        target.write_text("knowledge: a fact")
+        ok = await bridge.memorize_file(str(target))
+
+        assert ok is False
+        assert bridge._service.memorize.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_llm_error_still_raises_backend_unavailable(self, tmp_path):
+        bridge = _make_lock_test_bridge(tmp_path)
+        bridge._service.memorize = AsyncMock(
+            side_effect=Exception("Error code: 429 - guardrail text units per second limit exceeded"),
+        )
+
+        target = tmp_path / "note.txt"
+        target.write_text("knowledge: a fact")
+        with pytest.raises(MemoryBackendUnavailable, match="unavailable"):
+            await bridge.memorize_file(str(target))
+
+        assert bridge._service.memorize.await_count == 1


### PR DESCRIPTION
## Problem

On a high-throughput instance (56 concurrent cron sessions), `memorize` calls fail in bulk with `(sqlite3.OperationalError) database is locked` — ~1,000 failures/day — and sessions see a bare `"Failed to memorize."`, which they misread as the memory backend *refusing* content.

## Root cause

`_resolve_event_dates_sync` runs after **every** conversation memorize and selects `WHERE happened_at IS NULL` with no scoping. Non-event items keep `happened_at` NULL *by design*, so the sweep grows with the corpus: on a 457K-item database it rewrote **388,924 rows inside one implicit write transaction** on the `memu-blocking` thread — holding the SQLite write lock for minutes, per conversation, at a measured ~50% duty cycle. Every concurrent memorize pipeline then exhausted `busy_timeout` and died. It also *re-stamped* `extra.mentioned_at` on the whole corpus every run (churning the WAL to 1.6 GB and overwriting first-mention dates with the latest sweep date).

Diagnosis was confirmed live: `/proc/locks` showed the WAL write lock (byte 120) held by the nerve process while the memU loop sat idle in `epoll`, and py-spy caught single `create_resource` commits blocked 15–77 s behind the sweep.

Secondary: memU-internal LLM calls had no headroom for sustained provider rate-limit storms (e.g. a shared Bedrock guardrail TPS cap), and lock failures were returned as an unexplained generic failure with no retry.

## Fix

**`_resolve_event_dates_sync`** (the core fix)
- Scope the sweep to items created in the last 24h that were never stamped with `mentioned_at` (substring guard — no JSON parse on scan), newest-first, capped at 2,000 rows.
- Commit in batches of 500 so no write transaction holds the lock long.
- Makes the sweep idempotent: `mentioned_at` is now a first-seen stamp instead of being overwritten forever.
- `busy_timeout=30s` on the raw connection.

**`memorize_file`**
- Retry SQLite lock contention with the existing backoff schedule (the write never happened, and semantic dedup absorbs re-extracted items — same semantics as the existing timeout retry). No LLM client reset for DB-side errors.
- If retries are exhausted, raise `MemoryBackendUnavailable` so the tool layer reports *backend busy* loudly instead of returning a silent `False`.

**LLM transient retry (`_timeout_chat`)**
- Backoff schedule extended (1/3/8/20 s) with ±25% jitter so concurrent pipelines don't re-collide in lockstep; honors `Retry-After` (capped at 60 s).

**Engine pragmas / WAL hygiene**
- `busy_timeout` 10s → 30s; add `journal_size_limit=64MiB` so checkpoints can shrink a ballooned WAL.
- Best-effort `wal_checkpoint(TRUNCATE)` at startup — the one moment the process holds no other memU connections — to reclaim multi-GB WAL backlogs.

**Tool layer (`memorize` handler)**
- Failure results now carry the underlying cause and state explicitly that it is an infrastructure failure, **not a content refusal** — so agents stop inventing "memU refused" semantics.

## Tests

- Sweep scoping (old/stamped items untouched, fresh items stamped), idempotency, batch commits, row cap.
- Lock classifier truth table; `memorize_file` lock-retry success, exhaustion → `MemoryBackendUnavailable`, non-transient fail-fast, transient-LLM raise.
- Full suite: 1,697 passed.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*