### PR TITLE
Fix CI hang: workflow route tests spawned exec tasks on the TestClient portal loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
   backend-tests:
     name: Backend tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # The suite finishes in ~1 minute; a hang should fail fast instead of
+    # burning the 6h default (bit us on 2026-07-27: a test awaiting a task
+    # on a dead TestClient portal loop parked two runs for 6h each).
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +54,7 @@ jobs:
   frontend-build:
     name: Frontend build (Vite)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web

--- a/nerve/workflows/service.py
+++ b/nerve/workflows/service.py
@@ -330,6 +330,18 @@ class WorkflowRunService:
         )
         if not flipped:
             return
+        self._spawn_execute(run_id)
+
+    def _spawn_execute(self, run_id: str) -> None:
+        """Spawn the run payload as a fire-and-forget task (test seam).
+
+        Route tests replace this to drive ``_execute`` on their own event
+        loop: under ``TestClient`` each request runs on an ephemeral
+        portal loop, so a task spawned here is cancelled mid-flight when
+        that portal shuts down — leaving futures bound to a dead loop
+        that hang whatever awaits them next (surfaced as a 6h CI hang in
+        test_workflow_routes).
+        """
         task = asyncio.create_task(
             self._execute(run_id), name=f"workflow-run-{run_id}",
         )

--- a/tests/test_workflow_routes.py
+++ b/tests/test_workflow_routes.py
@@ -71,17 +71,20 @@ class FakeEngine:
         pass
 
 
-async def _settle(service) -> None:
-    """Await spawned ``_execute`` tasks that live on the current loop.
+async def _drain(setup) -> None:
+    """Execute spawned run payloads on the current (test) event loop.
 
-    Tasks spawned during a TestClient request run on the request portal's
-    own loop and are already finalized (and popped from ``_exec_tasks``)
-    by the time the request returns — so this only really waits in the
-    direct ``service.start_run(...)`` case.
+    The fixture patches ``service._spawn_execute`` to only record run ids
+    instead of creating real fire-and-forget tasks: under ``TestClient``
+    each request runs on an ephemeral portal loop, and a task spawned
+    there may be cancelled mid-flight at request teardown — leaving
+    futures bound to a dead loop that hang whatever awaits them next
+    (the 6h CI hang). Driving ``_execute`` here keeps every await on one
+    live loop, deterministically. ``_execute`` may re-dispatch queued
+    runs, so drain until the spawn log is empty.
     """
-    tasks = [t for t in service._exec_tasks.values() if not t.done()]
-    if tasks:
-        await asyncio.gather(*tasks, return_exceptions=True)
+    while setup.spawned:
+        await setup.service._execute(setup.spawned.pop(0))
 
 
 @pytest.mark.asyncio
@@ -113,15 +116,22 @@ class TestWorkflowRunRoutes:
         service = WorkflowRunService(cfg, db, engine)  # type: ignore[arg-type]
         monkeypatch.setattr(workflows_mod, "_service", service)
 
+        # Record dispatched run ids instead of spawning tasks on the
+        # request's portal loop — tests execute them via _drain (above).
+        spawned: list[str] = []
+        monkeypatch.setattr(service, "_spawn_execute", spawned.append)
+
         app = FastAPI()
         app.include_router(wf_router)
         client = TestClient(app)
 
-        yield SimpleNamespace(
+        ns = SimpleNamespace(
             client=client, service=service, engine=engine, db=db, cfg=cfg,
+            spawned=spawned,
         )
+        yield ns
 
-        await _settle(service)
+        await _drain(ns)
         cfg_mod._config = None  # leave global state clean for other tests
 
     async def test_list_empty(self, setup):
@@ -144,7 +154,7 @@ class TestWorkflowRunRoutes:
         assert body["created_by"] == "api"
         assert body["spec"]["prompt"] == "fix issue #12 in myorg/myrepo"
 
-        await _settle(setup.service)
+        await _drain(setup)
 
         resp = setup.client.get("/api/workflow-runs")
         assert resp.status_code == 200
@@ -188,7 +198,7 @@ class TestWorkflowRunRoutes:
         })
         assert resp.status_code == 200
         run_id = resp.json()["id"]
-        await _settle(setup.service)
+        await _drain(setup)
 
         resp = setup.client.post(
             f"/api/workflow-runs/{run_id}/kill", json={"reason": "operator abort"},
@@ -211,7 +221,7 @@ class TestWorkflowRunRoutes:
             budget_usd=3.0,
             title="journal demo",
         )
-        await _settle(setup.service)
+        await _drain(setup)
 
         fresh = await setup.service.get_run(run["id"])
         assert fresh is not None
@@ -243,7 +253,7 @@ class TestWorkflowRunRoutes:
             spec={"prompt": "traversal check"},
             budget_usd=1.0,
         )
-        await _settle(setup.service)
+        await _drain(setup)
 
         # Point the row at a directory outside runs_dir; the endpoint must
         # refuse to read it and return the empty journal shape.


### PR DESCRIPTION
## Problem

Backend CI has hung for the full 6h job timeout twice — the `pufit/memu-write-reliability` PR run (https://github.com/ClickHouse/nerve/actions/runs/30301937630) and the main push after its merge (https://github.com/ClickHouse/nerve/actions/runs/30303434238). Both stalled right after `test_workflow_routes.py::TestWorkflowRunRoutes::test_kill_unknown_returns_404`; the next test in collection order, `test_kill_created_run_lands_terminal`, never completed.

## Root cause

`TestClient` runs each request on an ephemeral anyio portal event loop. `POST /api/workflow-runs` dispatches inside the request, so `_promote()`'s fire-and-forget `_execute` task was created **on that portal loop**. Usually the mock-backed payload finishes within the request; when it doesn't (slow runner), the task is cancelled mid-flight at portal teardown, leaving futures bound to a dead loop. The tests' `_settle` then gathers that task from the test's own loop and parks forever — the future's done-callback can only fire on the dead loop. The old `_settle` docstring even documented the timing assumption ("already finalized by the time the request returns").

Not dependency drift: the same commit passes locally (1697/1697 in ~30s) with the same resolved versions as the hung runs (incl. fastapi 0.140.7).

## Fix

- `WorkflowRunService._promote` now spawns the payload via a small `_spawn_execute(run_id)` seam — no production behavior change.
- The route tests patch the seam to record run ids and drive `_execute` on the **test's own event loop** (`_drain`, replacing `_settle`). No fire-and-forget task ever lives on a portal loop, so the timing window is gone entirely.
- CI hardening: `timeout-minutes: 15` on both jobs — a future hang fails in minutes instead of burning 6h of runner time (the suite normally finishes in ~1 min).

## Verification

- `tests/test_workflow_routes.py`: 11/11; stress-run 15× clean.
- Race-immunity probe: with `engine.run` artificially slowed to 0.3s (the exact condition that races portal teardown — reproducing the old assumption's failure mode), the previously-hanging tests pass deterministically.
- Full suite: **1697 passed in 29s**.
- `test_workflow_runs.py` also awaits `_exec_tasks`, but drives the service directly on the test loop (no TestClient) — unaffected.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*