### PR TITLE
Add Opus 5 support: pricing, effort, model_aliases, default opus model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,11 +32,17 @@ timezone: America/New_York
 
 # Agent
 agent:
-  model: claude-opus-4-8         # Primary model for conversations
+  model: claude-opus-5           # Primary model for conversations
   # Use claude-fable-5 for Anthropic's most capable (Mythos-class) model.
-  # Note: ~2x the cost of Opus 4.8 ($10/$50 per MTok in/out).
+  # Note: ~2x the cost of Opus 5 ($10/$50 per MTok in/out).
   cron_model: claude-sonnet-4-6  # Cheaper model for cron jobs
   title_model: claude-haiku-4-5-20251001  # Session title generation
+  # Model-alias remapping for the CLI: short aliases ("opus") used in
+  # Agent/Workflow tool model options and skill frontmatter resolve to the
+  # mapped ID. Supported: opus, sonnet, haiku, fable. opus → claude-opus-5
+  # is the built-in default (not applied on Bedrock); "" unsets an alias.
+  # model_aliases:
+  #   opus: claude-opus-5
   max_turns: 50                  # Max agentic turns per request
   max_concurrent: 32             # Max concurrent agent sessions
   background_agent_permissions: true  # Background sub-agents (Agent run_in_background) get the same tool permissions as foreground; false denies their Write/Edit/Bash
@@ -48,7 +54,7 @@ agent:
     max_tokens: 1024
     timeout_seconds: 45
   # For Bedrock, use model IDs like:
-  #   model: us.anthropic.claude-opus-4-8
+  #   model: us.anthropic.claude-opus-5
   #   cron_model: us.anthropic.claude-sonnet-4-6
   #   title_model: us.anthropic.claude-haiku-4-5-20251001-v1:0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,8 +36,9 @@ from any working directory:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `agent.model` | string | `claude-opus-4-8` | Primary model for conversations |
+| `agent.model` | string | `claude-opus-5` | Primary model for conversations |
 | `agent.cron_model` | string | `claude-sonnet-4-6` | Model for cron jobs (cheaper) |
+| `agent.model_aliases` | map | `{opus: claude-opus-5}` | Alias → model ID remapping for the CLI (emitted as `ANTHROPIC_DEFAULT_<ALIAS>_MODEL` env vars). Aliases (`opus`, `sonnet`, `haiku`, `fable`) used in Agent/Workflow tool model options, skill frontmatter, and cron overrides resolve to the mapped ID. Entries merge over the built-in `opus → claude-opus-5` default (not applied on Bedrock — set geo-prefixed IDs explicitly there); `""` unsets an alias |
 | `agent.max_turns` | int | `50` | Max agentic turns per request |
 | `agent.max_concurrent` | int | `32` | Max concurrent agent sessions |
 | `agent.cache_ttl` | string | `"5m"` | Prompt-cache write TTL policy: `5m` (status quo), `1h` (always request the 1-hour TTL), or `auto` (per session at client-build time: sparse-cadence sessions — persistent crons, wakeup loops, spaced chats — get `1h`; dense sessions stay on `5m`). Per-cron-job override via `cache_ttl` in jobs.yaml. See `nerve/agent/cache_policy.py` |

--- a/docs/plans.md
+++ b/docs/plans.md
@@ -109,7 +109,7 @@ Defined in `~/.nerve/cron/jobs.yaml` as `task-planner`:
 - **Schedule:** Every 4 hours (`0 */4 * * *`)
 - **Session mode:** Persistent (keeps context for revisions)
 - **Context rotation:** Weekly (168 hours)
-- **Model:** claude-opus-4-8
+- **Model:** claude-opus-5
 
 The planner is a standard persistent cron job — no special service or engine code needed.
 

--- a/nerve/agent/backends/claude.py
+++ b/nerve/agent/backends/claude.py
@@ -87,6 +87,17 @@ except ImportError:  # pragma: no cover - depends on SDK version
 # kernel limit to leave room for env/argv overhead.
 SYSTEM_PROMPT_INLINE_MAX = 100_000  # bytes
 
+# CLI env vars that remap model *aliases* (the short names accepted by the
+# Agent/Workflow tools' model option, skill frontmatter, `--model opus`,
+# etc.) to concrete model IDs. Consumed by the Claude Code CLI at process
+# start; emitted from agent.model_aliases config in ``_build_env``.
+_MODEL_ALIAS_ENV_VARS: dict[str, str] = {
+    "opus": "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "sonnet": "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "haiku": "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "fable": "ANTHROPIC_DEFAULT_FABLE_MODEL",
+}
+
 
 # ------------------------------------------------------------------ #
 #  SDK message → normalized events                                     #
@@ -558,6 +569,28 @@ class ClaudeBackend:
                 env["ANTHROPIC_BASE_URL"] = (
                     f"http://{config.proxy.host}:{config.proxy.port}"
                 )
+        # Model-alias remapping: short aliases ("opus", "sonnet", ...) used
+        # in Agent/Workflow tool model options, skill frontmatter, and cron
+        # overrides resolve INSIDE the CLI via ANTHROPIC_DEFAULT_<ALIAS>_MODEL
+        # env vars. Nerve defaults "opus" → claude-opus-5 (skipped on Bedrock,
+        # where model IDs need a geo prefix — set agent.model_aliases with
+        # explicit prefixed IDs there). User-configured aliases merge over
+        # the default; an empty value unsets it (CLI built-in mapping wins).
+        aliases: dict[str, str] = {}
+        if not config.provider.is_bedrock:
+            aliases["opus"] = "claude-opus-5"
+        aliases.update(config.agent.model_aliases)
+        for alias, target in aliases.items():
+            env_name = _MODEL_ALIAS_ENV_VARS.get(alias.strip().lower())
+            if env_name is None:
+                logger.warning(
+                    "Unknown model alias %r in agent.model_aliases "
+                    "(supported: %s) — ignored",
+                    alias, ", ".join(sorted(_MODEL_ALIAS_ENV_VARS)),
+                )
+                continue
+            if target:
+                env[env_name] = str(target)
         return env
 
     def _build_mcp_servers(self, session_id: str) -> dict[str, Any]:
@@ -755,6 +788,8 @@ class ClaudeBackend:
     # pattern used by MODEL_PRICING in nerve/db/usage.py.
     _MODEL_EFFORT_LEVELS: dict[str, tuple[str, ...]] = {
         "fable-5":    ("low", "medium", "high", "xhigh", "max"),
+        "opus-5":     ("low", "medium", "high", "xhigh", "max"),
+        "sonnet-5":   ("low", "medium", "high", "xhigh", "max"),
         "opus-4-8":   ("low", "medium", "high", "xhigh", "max"),
         "opus-4-7":   ("low", "medium", "high", "xhigh", "max"),
         "opus-4-6":   ("low", "medium", "high", "max"),

--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -988,7 +988,7 @@ class SetupWizard:
         click.echo()
         click.secho(
             f"  → Model IDs will use the '{prefix}.' inference-profile prefix\n"
-            f"    (e.g. {prefix}.anthropic.claude-opus-4-8) based on region {region}.",
+            f"    (e.g. {prefix}.anthropic.claude-opus-5) based on region {region}.",
             fg="green",
         )
         click.echo()
@@ -1917,7 +1917,7 @@ class SetupWizard:
             "timezone": tz,
             "deployment": self.choices.deployment,
             "agent": {
-                "model": "claude-opus-4-8",
+                "model": "claude-opus-5",
                 "cron_model": "claude-sonnet-4-6",
                 "max_turns": 50,
                 "max_concurrent": 32,
@@ -1983,7 +1983,7 @@ class SetupWizard:
             # The prefix is geography-scoped (us./eu./apac.) and must match
             # the configured region or every call 400s.
             geo = bedrock_geo_prefix(self.choices.aws_region)
-            config["agent"]["model"] = f"{geo}.anthropic.claude-opus-4-8"
+            config["agent"]["model"] = f"{geo}.anthropic.claude-opus-5"
             config["agent"]["cron_model"] = f"{geo}.anthropic.claude-sonnet-4-6"
             config["agent"]["title_model"] = f"{geo}.anthropic.claude-haiku-4-5-20251001-v1:0"
             config["memory"]["recall_model"] = f"{geo}.anthropic.claude-sonnet-4-6"

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -145,9 +145,17 @@ class AgentConfig:
     # Wakeup turns fire on existing sessions and inherit their stored
     # backend — this only affects freshly minted cron/hook sessions.
     cron_backend: str = ""
-    model: str = "claude-opus-4-8"
+    model: str = "claude-opus-5"
     cron_model: str = "claude-sonnet-4-6"
     title_model: str = "claude-haiku-4-5-20251001"  # Session title generation
+    # Model-alias remapping for the Claude CLI subprocess: alias → model ID,
+    # emitted as ANTHROPIC_DEFAULT_<ALIAS>_MODEL env vars so short aliases
+    # ("opus" in Agent/Workflow tool calls, skill frontmatter, cron model
+    # overrides) resolve to the mapped model. Supported aliases: opus,
+    # sonnet, haiku, fable. Nerve defaults opus → claude-opus-5 on
+    # non-Bedrock providers; entries here merge over that default, and an
+    # empty value ("") unsets it (falls back to the CLI's built-in mapping).
+    model_aliases: dict[str, str] = field(default_factory=dict)
     max_turns: int = 100
     max_concurrent: int = 32
     thinking: str = "max"       # max, high, medium, low, disabled, adaptive, or number (budget_tokens)
@@ -204,9 +212,13 @@ class AgentConfig:
         return cls(
             backend=str(d.get("backend", "claude")).strip().lower(),
             cron_backend=str(d.get("cron_backend") or "").strip().lower(),
-            model=d.get("model", "claude-opus-4-8"),
+            model=d.get("model", "claude-opus-5"),
             cron_model=d.get("cron_model", "claude-sonnet-4-6"),
             title_model=d.get("title_model", "claude-haiku-4-5-20251001"),
+            model_aliases={
+                str(k): str(v or "")
+                for k, v in (d.get("model_aliases") or {}).items()
+            },
             max_turns=d.get("max_turns", 100),
             max_concurrent=d.get("max_concurrent", 32),
             thinking=str(d.get("thinking", "max")),

--- a/nerve/db/usage.py
+++ b/nerve/db/usage.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 # Key: canonical model short-name substring → (input, output, cache_read,
 # cache_write_5m, cache_write_1h, web_search_per_req)
 MODEL_PRICING: dict[str, tuple[float, float, float, float, float, float]] = {
-    "fable-5":    (10,  50, 1.00, 12.50, 20.00, 0.01),  # Fable 5 (Mythos-class, ~2x Opus 4.8)
+    "fable-5":    (10,  50, 1.00, 12.50, 20.00, 0.01),  # Fable 5 (Mythos-class, ~2x Opus)
+    "opus-5":     (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 5 standard (verified 2026-07-28)
+    "sonnet-5":   (3,   15, 0.30,  3.75,  6.00, 0.01),  # Sonnet 5 standard (verified 2026-07-28)
     "opus-4-8":   (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 4.8 standard
     "opus-4-7":   (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 4.7 standard
     "opus-4-6":   (5,   25, 0.50,  6.25, 10.00, 0.01),  # Opus 4.6 standard

--- a/tests/test_cache_policy.py
+++ b/tests/test_cache_policy.py
@@ -165,7 +165,9 @@ class TestResolveAutoCadence:
 # Backend env wiring — the switch reaches the CLI subprocess iff resolved 1h
 # ---------------------------------------------------------------------------
 
-def _make_env_backend(is_bedrock: bool = False) -> ClaudeBackend:
+def _make_env_backend(
+    is_bedrock: bool = False, aliases: dict[str, str] | None = None
+) -> ClaudeBackend:
     config = SimpleNamespace(
         provider=SimpleNamespace(
             is_bedrock=is_bedrock, aws_region="", aws_profile="",
@@ -173,6 +175,7 @@ def _make_env_backend(is_bedrock: bool = False) -> ClaudeBackend:
         ),
         proxy=SimpleNamespace(enabled=False, host="", port=0),
         effective_api_key="",
+        agent=SimpleNamespace(model_aliases=aliases or {}),
     )
     return ClaudeBackend(SimpleNamespace(config=config))
 
@@ -197,6 +200,56 @@ def test_build_env_1h_bedrock_sets_bedrock_flag():
 def test_build_env_default_is_5m():
     env = _make_env_backend()._build_env()
     assert "ENABLE_PROMPT_CACHING_1H" not in env
+
+
+# ---------------------------------------------------------------------------
+# Model-alias env emission (agent.model_aliases → ANTHROPIC_DEFAULT_*_MODEL)
+# ---------------------------------------------------------------------------
+
+def test_build_env_default_opus_alias_maps_to_opus_5():
+    # No config → Nerve's built-in default: the "opus" alias resolves to
+    # claude-opus-5 in every spawned CLI (Agent/Workflow model options etc.).
+    env = _make_env_backend()._build_env()
+    assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-5"
+
+
+def test_build_env_alias_config_overrides_default():
+    env = _make_env_backend(aliases={"opus": "claude-opus-4-8"})._build_env()
+    assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-4-8"
+
+
+def test_build_env_alias_empty_value_unsets_default():
+    # Explicit "" opts out — CLI falls back to its built-in mapping.
+    env = _make_env_backend(aliases={"opus": ""})._build_env()
+    assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
+
+
+def test_build_env_extra_alias_merges_over_default():
+    env = _make_env_backend(aliases={"sonnet": "claude-sonnet-5"})._build_env()
+    assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "claude-sonnet-5"
+    # The built-in opus default survives a partial user mapping.
+    assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-5"
+
+
+def test_build_env_bedrock_skips_default_alias():
+    # Bare model IDs 400 on Bedrock (geo prefix required) — no implicit
+    # default there.
+    env = _make_env_backend(is_bedrock=True)._build_env()
+    assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
+
+
+def test_build_env_bedrock_explicit_alias_respected():
+    env = _make_env_backend(
+        is_bedrock=True, aliases={"opus": "us.anthropic.claude-opus-5"}
+    )._build_env()
+    assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "us.anthropic.claude-opus-5"
+
+
+def test_build_env_unknown_alias_ignored():
+    env = _make_env_backend(aliases={"turbo": "claude-x"})._build_env()
+    assert not any("TURBO" in k for k in env)
+    # Known defaults unaffected by the bad entry.
+    assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "claude-opus-5"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -226,3 +226,26 @@ class TestAppendTelegramAllowedUser:
         append_telegram_allowed_user(tmp_path, 42)
         mode = stat.S_IMODE(os.stat(tmp_path / "config.local.yaml").st_mode)
         assert mode == 0o600
+
+
+class TestModelDefaultsAndAliases:
+    def test_default_model_is_opus_5(self):
+        from nerve.config import AgentConfig
+
+        cfg = AgentConfig.from_dict({})
+        assert cfg.model == "claude-opus-5"
+        assert cfg.model_aliases == {}
+
+    def test_model_aliases_parsed_and_normalized(self):
+        from nerve.config import AgentConfig
+
+        cfg = AgentConfig.from_dict(
+            {"model_aliases": {"opus": "claude-opus-5", "sonnet": None}}
+        )
+        # None/falsy values normalize to "" (explicit unset marker).
+        assert cfg.model_aliases == {"opus": "claude-opus-5", "sonnet": ""}
+
+    def test_model_aliases_key_recognized_by_validator(self):
+        # Guard: agent.model_aliases must not trip unknown-key warnings.
+        merged = {"agent": {"model_aliases": {"opus": "claude-opus-5"}}}
+        assert validate_config_keys(merged) == []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,6 +22,14 @@ from nerve.config import AgentConfig, NerveConfig
         ("max",    "claude-fable-5",            "max"),
         ("xhigh",  "claude-fable-5",            "xhigh"),
         ("low",    "claude-fable-5",            "low"),
+        # Opus 5 supports the full ladder (verified via Models API 2026-07-28)
+        ("max",    "claude-opus-5",             "max"),
+        ("xhigh",  "claude-opus-5",             "xhigh"),
+        ("xhigh",  "claude-opus-5-20260720",    "xhigh"),
+        ("max",    "us.anthropic.claude-opus-5", "max"),
+        # Sonnet 5 supports the full ladder (unlike Sonnet 4.6's high cap)
+        ("max",    "claude-sonnet-5",           "max"),
+        ("xhigh",  "claude-sonnet-5",           "xhigh"),
         # Opus 4.8 supports every level (same ladder as 4.7)
         ("max",    "claude-opus-4-8",           "max"),
         ("xhigh",  "claude-opus-4-8",           "xhigh"),

--- a/tests/test_usage_cache_ttl.py
+++ b/tests/test_usage_cache_ttl.py
@@ -191,6 +191,36 @@ class TestPricing:
         assert c5m == 12.50
         assert c1h == 20.00
 
+    def test_opus_5_rates(self):
+        # Anchor: Opus 5 — same tier as 4.8 (verified against published
+        # pricing 2026-07-28). Base $5/MTok in, $25/MTok out, 5m write =
+        # 1.25x = $6.25/MTok, 1h write = 2.00x = $10.00/MTok.
+        from nerve.db.usage import _get_pricing
+        p_in, p_out, _, c5m, c1h, _ = _get_pricing("claude-opus-5")
+        assert p_in == 5
+        assert p_out == 25
+        assert c5m == 6.25
+        assert c1h == 10.00
+
+    def test_opus_5_dated_id_resolves_to_opus_5_tier(self):
+        # Substring precedence: a dated Opus 5 ID must hit the "opus-5"
+        # key — not any 4.x key, and not the silent DEFAULT fallback.
+        from nerve.db.usage import MODEL_PRICING, _get_pricing
+        assert _get_pricing("claude-opus-5-20260720") == MODEL_PRICING["opus-5"]
+
+    def test_opus_4_5_does_not_bleed_into_opus_5(self):
+        # "opus-5" must not substring-match claude-opus-4-5 (or vice versa).
+        from nerve.db.usage import MODEL_PRICING, _get_pricing
+        assert _get_pricing("claude-opus-4-5-20251101") == MODEL_PRICING["opus-4-5"]
+
+    def test_sonnet_5_rates(self):
+        # Sonnet 5 gets its own tier; sonnet 4.x keeps resolving to
+        # "sonnet-4"; old-style claude-3-5-sonnet must NOT hit "sonnet-5".
+        from nerve.db.usage import MODEL_PRICING, _get_pricing
+        assert _get_pricing("claude-sonnet-5") == MODEL_PRICING["sonnet-5"]
+        assert _get_pricing("claude-sonnet-4-6") == MODEL_PRICING["sonnet-4"]
+        assert _get_pricing("claude-3-5-sonnet-20241022") != MODEL_PRICING["sonnet-5"]
+
 
 class TestEstimateCost:
     def test_falls_back_to_5m_when_split_absent(self):


### PR DESCRIPTION
## What

- **MODEL_PRICING**: add `opus-5` ($5/$25 per MTok) and `sonnet-5` ($3/$15) entries — rates verified against published pricing 2026-07-28. Substring-precedence tests guard `claude-opus-5-YYYYMMDD` vs the 4.x keys.
- **Effort ladder**: `opus-5` and `sonnet-5` support the full `low…max` ladder — verified via the Models API capabilities endpoint (note: sonnet-5 gains `xhigh`/`max` over sonnet-4-6).
- **`agent.model_aliases` config** (new): alias → model ID map emitted as `ANTHROPIC_DEFAULT_<ALIAS>_MODEL` env vars to the CLI subprocess, so short aliases (`opus` in Agent/Workflow tool model options, skill frontmatter, cron overrides) resolve to the mapped model. Built-in default: `opus → claude-opus-5` (skipped on Bedrock, where IDs need a geo prefix; `""` unsets an alias).
- **Defaults**: `agent.model` default, bootstrap-generated configs, example config, and docs move `claude-opus-4-8` → `claude-opus-5`.

## Why

Opus 5 turns were resolving to the silent `DEFAULT_PRICING` fallback — and workflow-run dollar budgets now enforce against that metering. This is Step 1 ("stop the bleeding") of the model-pricing reliability task; the structural fixes (unknown-model loudness, config-overlay pricing) are a separate follow-up.

No cost backfill needed: `DEFAULT_PRICING` happens to equal the opus-5 tier, so historical opus-5 turns were metered correctly by accident.

## Verification

- E2E: `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-5` + `--model opus` → response `modelUsage` = `claude-opus-5` (CLI 2.1.207)
- Workflow-tool probe: `agent(..., {model: 'claude-opus-5'})` runs on Opus 5 (transcript-verified)
- Full suite: 1766 passed

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*