### PR TITLE
Review loops: workdir UI, auto-created cwd, full MCP surface for ultracode workers

### DIFF
--- a/nerve/agent/backends/codex/backend.py
+++ b/nerve/agent/backends/codex/backend.py
@@ -97,31 +97,6 @@ _MISSING_THREAD_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Ultracode workers are non-interactive and therefore cannot safely inherit
-# every mutating Nerve tool under an unconditional MCP approval. Keep the
-# child surface useful for context/research while making future tools fail
-# closed until explicitly reviewed.
-_ULTRACODE_CHILD_NERVE_TOOLS = (
-    "session_context",
-    "memory_recall",
-    "memory_expand_category",
-    "conversation_history",
-    "memory_records_by_date",
-    "task_search",
-    "task_list",
-    "task_read",
-    "task_status_list",
-    "plan_list",
-    "plan_read",
-    "skill_list",
-    "skill_get",
-    "skill_read_reference",
-    "sync_status",
-    "list_sources",
-    "read_source",
-)
-
-
 def _is_missing_thread_error(error: CodexRpcError) -> bool:
     """Return True only for a positively identified missing thread.
 
@@ -590,24 +565,28 @@ class CodexClient(AgentClient):
         config_overrides = backend.build_config_overrides(spec)
         env = backend.build_env(spec)
         if backend.codex.ultracode.enabled:
-            # Child workers need Nerve's MCP bridge, but not the parent's
-            # external MCP servers.  Besides reducing startup overhead, this
-            # prevents third-party credentials from being copied into
-            # NERVE_CODEX_CHILD_CONFIG and then exposed in worker argv.
+            # Child workers inherit the parent session's FULL MCP surface —
+            # the Nerve bridge and external servers alike — with the same
+            # permissions as the session itself (no worker-side tool
+            # allowlist). Secrets still never touch worker argv: external
+            # server configs reference synthetic environment names that the
+            # stdio launcher resolves at server spawn.
             child_overrides = [
                 value for value in config_overrides
-                if value.startswith("mcp_servers.nerve.")
+                if value.startswith("mcp_servers.")
             ]
-            # Ultracode is non-interactive (approval_policy=never). Explicitly
-            # approve the trusted, session-scoped Nerve server or Codex marks
-            # every child MCP call as "user cancelled".
-            child_overrides.append(
-                'mcp_servers.nerve.default_tools_approval_mode="approve"'
-            )
-            child_overrides.append(
-                "mcp_servers.nerve.enabled_tools="
-                + json.dumps(_ULTRACODE_CHILD_NERVE_TOOLS)
-            )
+            # Ultracode is non-interactive (approval_policy=never), so every
+            # inherited server needs an explicit approval mode or Codex marks
+            # its child MCP calls as "user cancelled". Keep any mode the
+            # parent already carries (parity); default the rest to approve.
+            names = {
+                value.removeprefix("mcp_servers.").split(".", 1)[0]
+                for value in child_overrides
+            }
+            for name in sorted(names):
+                prefix = f"mcp_servers.{name}.default_tools_approval_mode="
+                if not any(v.startswith(prefix) for v in child_overrides):
+                    child_overrides.append(prefix + '"approve"')
             env["NERVE_CODEX_CHILD_CONFIG"] = json.dumps(child_overrides)
             port = backend._deps.gateway_port()
             if port:

--- a/nerve/agent/backends/codex/worker_wrapper.py
+++ b/nerve/agent/backends/codex/worker_wrapper.py
@@ -9,8 +9,6 @@ import urllib.error
 import urllib.request
 from uuid import uuid4
 
-from nerve.agent.backends.codex.mcp_stdio_wrapper import EXTERNAL_MCP_ENV_PREFIX
-
 
 def _worker_token(worker_id: str) -> str:
     url = os.environ.get("NERVE_MCP_WORKER_TOKEN_URL", "")
@@ -71,12 +69,9 @@ def main() -> int:
     env["NERVE_ULTRACODE_WORKER_ID"] = worker_id
     # Prevent nested plugin refreshes even if upstream defaults change.
     env["ULTRACODE_NO_AUTO_UPDATE"] = "1"
-    # The parent app-server needs synthetic external-MCP credential variables,
-    # but Ultracode workers have no external MCP configuration and must not
-    # inherit the corresponding secrets.
-    for key in tuple(env):
-        if key.startswith(EXTERNAL_MCP_ENV_PREFIX):
-            env.pop(key, None)
+    # Workers inherit the parent's external MCP servers, so the synthetic
+    # credential variables stay in the environment — the stdio MCP launcher
+    # maps and strips them at server spawn (never in argv).
     argv = [real_bin, *_inject_config_overrides(sys.argv[1:], overrides)]
     os.execvpe(real_bin, argv, env)
     return 127

--- a/nerve/agent/tools/handlers/review_loops.py
+++ b/nerve/agent/tools/handlers/review_loops.py
@@ -52,8 +52,8 @@ REVIEW_LOOP_START_SCHEMA = {
         "cwd": {
             "type": "string",
             "description": (
-                "Shared workspace for all legs (must exist). Defaults to "
-                "this session's cwd, then the global workspace."
+                "Shared workspace for all legs (created if missing). "
+                "Defaults to this session's cwd, then the global workspace."
             ),
             "default": "",
         },

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -183,7 +183,15 @@ async def create_session(req: SessionCreateRequest, user: dict = Depends(require
     if req.cwd:
         path = Path(req.cwd).expanduser().resolve()
         if not path.is_dir():
-            raise HTTPException(status_code=400, detail=f"Working directory not found: {path}")
+            # Auto-create missing workdirs (review loops and chats may
+            # target a fresh scratch directory).
+            try:
+                path.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Cannot create working directory {path}: {e}",
+                ) from e
         cwd = str(path)
     selected_backend = deps.engine._backends[backend]
     model = selected_backend.default_model(req.source)

--- a/nerve/workflows/review_loop.py
+++ b/nerve/workflows/review_loop.py
@@ -364,10 +364,12 @@ class ReviewLoopService:
             path = Path(cwd).expanduser()
             try:
                 path = path.resolve()
+                if not path.is_dir():
+                    # Auto-create missing workdirs — loops often target a
+                    # fresh scratch directory that should simply exist.
+                    path.mkdir(parents=True, exist_ok=True)
             except OSError as e:
                 raise ReviewLoopError(f"invalid cwd: {e}") from e
-            if not path.is_dir():
-                raise ReviewLoopError(f"cwd is not a directory: {path}")
             cwd = str(path)
         else:
             cwd = str(self.config.workspace)

--- a/tests/test_review_loops.py
+++ b/tests/test_review_loops.py
@@ -960,3 +960,38 @@ class TestReviewLoopTools:
         result2 = await rls._dispatch_decision({}, loop["id"], "accept", None)
         assert result2.ok
         assert (await db.get_review_loop(loop["id"]))["status"] == "passed"
+
+
+# --------------------------------------------------------------------------- #
+#  Workdir handling                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+class TestCreateLoopCwd:
+    async def test_missing_cwd_is_created(self, db, engine, tmp_path):
+        cfg = _make_config(tmp_path)
+        runs = WorkflowRunService(cfg, db, engine)
+        rls = ReviewLoopService(cfg, db, engine, runs)
+        target = tmp_path / "fresh" / "nested"
+        assert not target.exists()
+        loop = await rls.create_loop(
+            goal="g", verifier="- a", session_id=None,
+            cwd=str(target), autostart=False,
+        )
+        assert target.is_dir()
+        assert loop["cwd"] == str(target.resolve())
+
+    async def test_cwd_conflicting_with_file_is_rejected(
+        self, db, engine, tmp_path,
+    ):
+        occupied = tmp_path / "occupied"
+        occupied.write_text("not a directory")
+        cfg = _make_config(tmp_path)
+        runs = WorkflowRunService(cfg, db, engine)
+        rls = ReviewLoopService(cfg, db, engine, runs)
+        with pytest.raises(ReviewLoopError, match="invalid cwd"):
+            await rls.create_loop(
+                goal="g", verifier="- a", session_id=None,
+                cwd=str(occupied), autostart=False,
+            )

--- a/tests/test_review_loops.py
+++ b/tests/test_review_loops.py
@@ -154,6 +154,20 @@ async def _wait_status(db, loop_id: str, statuses: tuple[str, ...], timeout: flo
     )
 
 
+async def _wait_awaited(mock, timeout: float = 8.0) -> None:
+    """Wait for an AsyncMock to be awaited. The status CAS flips BEFORE the
+    decision card is proposed (single-winner transition; a card death in the
+    gap is covered by the reconcile tick), so tests that observe the parked
+    status must not assert the card synchronously — that's a race on slow
+    runners."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if mock.await_count:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("mock was never awaited")
+
+
 @pytest_asyncio.fixture
 async def engine(db):
     return _make_engine(db)
@@ -436,7 +450,7 @@ class TestReviewLoopService:
         loop = await rls.create_loop(goal="g", verifier="- a", session_id=obs)
         parked = await _wait_status(db, loop["id"], ("awaiting_user",))
         assert parked["failure_reason"] == "gamed"
-        engine.notification_service.propose_action.assert_awaited()
+        await _wait_awaited(engine.notification_service.propose_action)
 
     async def test_budget_too_low_escalates_and_accept_decision(self, db, engine, services):
         runs, rls = services

--- a/tests/test_ultracode_integration.py
+++ b/tests/test_ultracode_integration.py
@@ -88,22 +88,31 @@ def test_worker_wrapper_is_owner_only(tmp_path):
     assert "worker_wrapper import main" in wrapper.read_text()
 
 
-def test_child_environment_inherits_mcp_without_persisting_token(tmp_path):
+def test_child_environment_inherits_full_mcp_without_persisting_token(tmp_path):
+    external = McpServerConfig(
+        name="external_http", type="http", url="https://mcp.invalid/",
+        headers={"Authorization": "http-secret-value"},
+    )
     cfg = _config(tmp_path)
-    backend = _backend(cfg)
+    backend = _backend(cfg, [external])
     from nerve.agent.backends.codex.backend import CodexClient
 
     client = CodexClient(backend, _spec(cfg))
     env = client._transport._env
     child = json.loads(env["NERVE_CODEX_CHILD_CONFIG"])
     assert any(value.startswith("mcp_servers.nerve.url=") for value in child)
+    # Workers inherit the parent session's full MCP surface: external
+    # servers included, no worker-side tool allowlist, and every server
+    # pre-approved (workers are non-interactive and cannot answer prompts).
+    assert any(value.startswith("mcp_servers.external_http.") for value in child)
     assert 'mcp_servers.nerve.default_tools_approval_mode="approve"' in child
-    enabled = next(
-        value for value in child
-        if value.startswith("mcp_servers.nerve.enabled_tools=")
+    assert (
+        'mcp_servers.external_http.default_tools_approval_mode="approve"'
+        in child
     )
-    assert "session_context" in enabled
-    assert "task_create" not in enabled
+    assert not any("enabled_tools" in value for value in child)
+    # Secrets stay env-referenced — never inline in the child config.
+    assert all("http-secret-value" not in value for value in child)
     assert all("parent-s1" not in value for value in child)
     assert env["ULTRACODE_NO_AUTO_UPDATE"] == "1"
     assert env["CODEX_CLI_PATH"].endswith("codex-worker")
@@ -146,7 +155,7 @@ def test_worker_wrapper_exchanges_token_and_injects_config(monkeypatch):
     assert captured["env"]["ULTRACODE_NO_AUTO_UPDATE"] == "1"
 
 
-def test_external_mcp_secrets_are_env_referenced_and_stripped_from_worker(
+def test_external_mcp_secrets_are_env_referenced_and_inherited_by_worker(
     tmp_path, monkeypatch,
 ):
     stdio = McpServerConfig(
@@ -202,7 +211,12 @@ def test_external_mcp_secrets_are_env_referenced_and_stripped_from_worker(
     monkeypatch.setattr(worker_wrapper.os, "execvpe", fake_exec)
     with pytest.raises(RuntimeError, match="stop"):
         worker_wrapper.main()
-    assert all(name not in captured["env"] for name in secret_names)
+    # Workers inherit the parent's external MCP servers, so the synthetic
+    # credential variables must survive into the worker environment — the
+    # stdio launcher maps + strips them later, at MCP server spawn.
+    assert {captured["env"].get(name) for name in secret_names} == {
+        "stdio-secret-value", "http-secret-value",
+    }
 
 
 def test_stdio_mcp_wrapper_maps_synthetic_secret_only_for_server(monkeypatch):

--- a/web/src/components/Chat/ReviewLoopPanel.tsx
+++ b/web/src/components/Chat/ReviewLoopPanel.tsx
@@ -115,6 +115,18 @@ export function ReviewLoopPanel({ disabled }: { disabled?: boolean }) {
 
           {advancedOpen && (
             <div className="grid grid-cols-2 gap-3 pt-1 border-t border-border-subtle">
+              <div className="space-y-1 col-span-2">
+                <div className={labelCls}>Workdir — shared workspace for all legs (created if missing)</div>
+                <input
+                  type="text"
+                  value={rl.cwd}
+                  onChange={(e) => setRL({ cwd: e.target.value })}
+                  placeholder="default: the global workspace"
+                  disabled={disabled || starting}
+                  className={inputCls + ' font-mono'}
+                  spellCheck={false}
+                />
+              </div>
               <div className="space-y-1">
                 <div className={labelCls}>Implementer engine</div>
                 <select

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -53,12 +53,13 @@ export interface NewChatReviewLoop {
   verifierEngine: string;
   verifierModel: string;
   maxIterations: string;          // '' = config default
+  cwd: string;                    // '' = global workspace; created if missing
 }
 
 export const EMPTY_REVIEW_LOOP: NewChatReviewLoop = {
   goal: '', verifier: '', budget: '', adoption: 'no',
   implementerEngine: '', implementerModel: '',
-  verifierEngine: '', verifierModel: '', maxIterations: '',
+  verifierEngine: '', verifierModel: '', maxIterations: '', cwd: '',
 };
 
 export type QuoteAction = 'add' | 'remove' | 'improve' | 'question' | 'note';
@@ -587,8 +588,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
           } : {}),
         }
       : null;
+    // The loop's workdir rides the session-level cwd (the loop inherits the
+    // observer session's cwd server-side); only sent when a loop is bound.
+    const rlCwd = rlPayload && rl ? rl.cwd.trim() || undefined : undefined;
     const real: Session = await api.createSession(
-      undefined, get().newChatBackend, undefined, rlPayload,
+      undefined, get().newChatBackend, rlCwd, rlPayload,
     );
     set((state) => {
       const drafts = { ...state.drafts };


### PR DESCRIPTION
Follow-ups from the first cross-vendor review-loop runs:

**1. Ultracode workers inherit the parent session's full MCP surface.** The child config previously carried only `mcp_servers.nerve.*` plus a read-only tool allowlist (`_ULTRACODE_CHILD_NERVE_TOOLS`), and the worker wrapper stripped the synthetic external-MCP credential env. Workers now get the same permissions as the session itself: all `mcp_servers.*` overrides (external servers included), no worker-side allowlist, and the credential env survives into workers (secrets remain env-referenced — the stdio launcher still maps/strips them at server spawn, never argv). Every inherited server gets `default_tools_approval_mode="approve"` unless the parent already carries a mode — workers are non-interactive and cannot answer approval prompts. The 2h worker-scoped token exchange is unchanged (attribution, not permissions).

**2. Loop workdirs are auto-created.** `create_loop` and `POST /api/sessions` now `mkdir -p` a missing cwd instead of rejecting it (a path that exists as a file is still an error).

**3. Workdir field in the review-loop panel.** New input in the advanced section; rides the session-level `cwd` on session create (the loop inherits the observer session's cwd server-side — plumbing already existed, the UI just never exposed it). `review_loop_start` tool description updated to match.

Tests: allowlist/strip tests rewritten for the new contract, new `TestCreateLoopCwd` (auto-create + file-conflict rejection). Full suite: 1768 passed. `npm run build` done.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*