### PR TITLE
Offer a model picker for Claude sessions, matching Codex

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,14 @@ agent:
   # is the built-in default (not applied on Bedrock); "" unsets an alias.
   # model_aliases:
   #   opus: claude-opus-5
+  # Claude models selectable in the web composer's model picker. The
+  # configured `model` above is always offered first; entries here extend
+  # the list. Unset → a built-in current-generation list (opus / sonnet /
+  # haiku). On Bedrock only models named in config are offered (Bedrock
+  # IDs are region-prefixed, so the bare built-ins would not resolve).
+  # models:
+  #   - claude-opus-5
+  #   - claude-sonnet-4-6
   max_turns: 50                  # Max agentic turns per request
   max_concurrent: 32             # Max concurrent agent sessions
   background_agent_permissions: true  # Background sub-agents (Agent run_in_background) get the same tool permissions as foreground; false denies their Write/Edit/Bash

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,7 @@ from any working directory:
 |-----|------|---------|-------------|
 | `agent.model` | string | `claude-opus-5` | Primary model for conversations |
 | `agent.cron_model` | string | `claude-sonnet-4-6` | Model for cron jobs (cheaper) |
+| `agent.models` | list | `[]` | Claude models offered in the composer's model picker. `agent.model` always leads; entries extend the list. Empty → a built-in current-generation list (opus / sonnet / haiku) on the direct Anthropic API; on Bedrock only configured models are offered |
 | `agent.model_aliases` | map | `{opus: claude-opus-5}` | Alias → model ID remapping for the CLI (emitted as `ANTHROPIC_DEFAULT_<ALIAS>_MODEL` env vars). Aliases (`opus`, `sonnet`, `haiku`, `fable`) used in Agent/Workflow tool model options, skill frontmatter, and cron overrides resolve to the mapped ID. Entries merge over the built-in `opus → claude-opus-5` default (not applied on Bedrock — set geo-prefixed IDs explicitly there); `""` unsets an alias |
 | `agent.max_turns` | int | `50` | Max agentic turns per request |
 | `agent.max_concurrent` | int | `32` | Max concurrent agent sessions |

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -134,6 +134,17 @@ class PromptRewriteConfig:
         )
 
 
+# Built-in fallback for the composer's Claude model picker when
+# ``agent.models`` is unset — the current-generation models Nerve itself
+# defaults to elsewhere in this file. Bare Anthropic API IDs: they do not
+# apply on Bedrock, where model IDs are region-prefixed.
+DEFAULT_CLAUDE_MODELS: tuple[str, ...] = (
+    "claude-opus-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+)
+
+
 @dataclass
 class AgentConfig:
     # Agent backend for NEW sessions: "claude" (Claude Agent SDK) or
@@ -156,6 +167,14 @@ class AgentConfig:
     # non-Bedrock providers; entries here merge over that default, and an
     # empty value ("") unsets it (falls back to the CLI's built-in mapping).
     model_aliases: dict[str, str] = field(default_factory=dict)
+    # Claude models selectable in the web composer's model picker
+    # (GET /api/models). The configured `model` above is always offered
+    # first; entries here extend the list (order-preserving, deduped).
+    # Empty → a built-in current-generation list (DEFAULT_CLAUDE_MODELS)
+    # on the direct Anthropic API; on Bedrock only the models named in
+    # config are offered (Bedrock IDs are region-prefixed, so the bare
+    # built-ins would not resolve there).
+    models: list[str] = field(default_factory=list)
     max_turns: int = 100
     max_concurrent: int = 32
     thinking: str = "max"       # max, high, medium, low, disabled, adaptive, or number (budget_tokens)
@@ -219,6 +238,11 @@ class AgentConfig:
                 str(k): str(v or "")
                 for k, v in (d.get("model_aliases") or {}).items()
             },
+            models=[
+                s for s in (
+                    str(m or "").strip() for m in (d.get("models") or [])
+                ) if s
+            ],
             max_turns=d.get("max_turns", 100),
             max_concurrent=d.get("max_concurrent", 32),
             thinking=str(d.get("thinking", "max")),
@@ -1566,6 +1590,26 @@ class NerveConfig:
         the Anthropic↔OpenAI translation layer Ollama is reached through).
         """
         return self.ollama.enabled and self.proxy.enabled
+
+    @property
+    def claude_models(self) -> list[str]:
+        """Selectable Claude chat models for the composer's model picker.
+
+        The configured default (``agent.model``) always leads; ``agent.models``
+        entries follow in config order (deduped). When ``agent.models`` is
+        unset, the built-in :data:`DEFAULT_CLAUDE_MODELS` list applies on the
+        direct Anthropic API. Bedrock model IDs are region-prefixed, so the
+        bare built-ins are skipped there — Bedrock offers only the models
+        named in config.
+        """
+        extras = self.agent.models or (
+            [] if self.provider.is_bedrock else list(DEFAULT_CLAUDE_MODELS)
+        )
+        ordered: list[str] = []
+        for m in (self.agent.model, *extras):
+            if m and m not in ordered:
+                ordered.append(m)
+        return ordered
 
     def create_anthropic_client(self, timeout: float = 60.0) -> Any:
         """Create an Anthropic client based on the configured provider.

--- a/nerve/gateway/routes/models.py
+++ b/nerve/gateway/routes/models.py
@@ -1,6 +1,8 @@
 """Model discovery routes — which chat models the UI can offer.
 
-Exposes the configured Anthropic chat model plus any locally-installed
+Exposes the selectable Claude models (``config.claude_models`` — the
+configured default plus ``agent.models`` or a built-in current-generation
+list), the Codex app-server's advertised models, and any locally-installed
 Ollama models (auto-discovered from the running Ollama server). The web
 composer's model picker calls GET /api/models to populate its options.
 
@@ -37,13 +39,14 @@ async def list_models(user: dict = Depends(require_auth)):
           "ollama": {"enabled", "routable", "available"}
         }
 
-    ``provider`` is ``"anthropic"`` or ``"ollama"``; the frontend formats
-    display labels. Discovery is best-effort — if the Ollama server is
-    unreachable the list simply contains no Ollama entries.
+    ``provider`` is ``"anthropic"``, ``"openai"`` or ``"ollama"``; the
+    frontend formats display labels. Discovery is best-effort — if the
+    Ollama server is unreachable the list simply contains no Ollama entries.
     """
     config = get_config()
     deps = get_deps()
     default_model = config.agent.model
+    claude_models = config.claude_models
 
     codex_backend = deps.engine._backends.get("codex")
     codex_preflight = (
@@ -56,7 +59,7 @@ async def list_models(user: dict = Depends(require_auth)):
     options = [
         {
             "id": "claude", "label": "Claude", "model": config.agent.model,
-            "models": [config.agent.model], "available": True,
+            "models": claude_models, "available": True,
         },
     ]
     options.append({
@@ -81,7 +84,8 @@ async def list_models(user: dict = Depends(require_auth)):
     }
 
     models: list[dict[str, str]] = [
-        {"id": default_model, "provider": "anthropic", "backend": "claude"},
+        {"id": model_id, "provider": "anthropic", "backend": "claude"}
+        for model_id in claude_models
     ]
     if codex_preflight.get("available"):
         models.extend({

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -249,3 +249,76 @@ class TestModelDefaultsAndAliases:
         # Guard: agent.model_aliases must not trip unknown-key warnings.
         merged = {"agent": {"model_aliases": {"opus": "claude-opus-5"}}}
         assert validate_config_keys(merged) == []
+
+
+class TestClaudeModels:
+    """config.claude_models — the composer's selectable Claude model list."""
+
+    def test_defaults_offer_current_generation(self):
+        from nerve.config import DEFAULT_CLAUDE_MODELS, NerveConfig
+
+        cfg = NerveConfig()
+        # The configured default always leads; the built-ins follow.
+        assert cfg.claude_models[0] == cfg.agent.model
+        for model_id in DEFAULT_CLAUDE_MODELS:
+            assert model_id in cfg.claude_models
+        # More than one entry → the web composer renders the picker.
+        assert len(cfg.claude_models) > 1
+
+    def test_configured_model_leads_and_dedupes(self):
+        from nerve.config import AgentConfig, NerveConfig
+
+        cfg = NerveConfig(agent=AgentConfig.from_dict({
+            "model": "claude-sonnet-4-6",
+            "models": ["claude-opus-5", "claude-sonnet-4-6"],
+        }))
+        assert cfg.claude_models == ["claude-sonnet-4-6", "claude-opus-5"]
+
+    def test_explicit_models_replace_builtins(self):
+        from nerve.config import AgentConfig, NerveConfig
+
+        cfg = NerveConfig(agent=AgentConfig.from_dict({
+            "model": "claude-fable-5",
+            "models": ["claude-opus-5"],
+        }))
+        assert cfg.claude_models == ["claude-fable-5", "claude-opus-5"]
+
+    def test_bedrock_offers_only_configured_models(self):
+        from nerve.config import AgentConfig, NerveConfig, ProviderConfig
+
+        cfg = NerveConfig(
+            provider=ProviderConfig(type="bedrock"),
+            agent=AgentConfig.from_dict(
+                {"model": "us.anthropic.claude-opus-5"}
+            ),
+        )
+        # Bare built-in IDs don't resolve on Bedrock — never advertised.
+        assert cfg.claude_models == ["us.anthropic.claude-opus-5"]
+
+    def test_bedrock_with_explicit_models(self):
+        from nerve.config import AgentConfig, NerveConfig, ProviderConfig
+
+        cfg = NerveConfig(
+            provider=ProviderConfig(type="bedrock"),
+            agent=AgentConfig.from_dict({
+                "model": "us.anthropic.claude-opus-5",
+                "models": ["us.anthropic.claude-sonnet-4-6"],
+            }),
+        )
+        assert cfg.claude_models == [
+            "us.anthropic.claude-opus-5",
+            "us.anthropic.claude-sonnet-4-6",
+        ]
+
+    def test_empty_entries_filtered(self):
+        from nerve.config import AgentConfig
+
+        cfg = AgentConfig.from_dict(
+            {"models": ["", None, "  claude-opus-5  "]}
+        )
+        assert cfg.models == ["claude-opus-5"]
+
+    def test_models_key_recognized_by_validator(self):
+        # Guard: agent.models must not trip unknown-key warnings.
+        merged = {"agent": {"models": ["claude-opus-5"]}}
+        assert validate_config_keys(merged) == []

--- a/tests/test_models_route.py
+++ b/tests/test_models_route.py
@@ -1,0 +1,130 @@
+"""HTTP route tests for ``GET /api/models`` (gateway/routes/models.py).
+
+Pattern mirrors test_workflow_routes.py: a minimal FastAPI app with the
+real router, auth disabled via an empty jwt_secret, and a fake engine
+carrying stub backends. The route must advertise the full selectable
+Claude model list (config.claude_models) — not just the configured
+default — so the composer's model picker renders for Claude sessions
+the same way it does for Codex.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+class FakeCodexBackend:
+    def __init__(self, preflight: dict[str, Any]):
+        self._preflight = preflight
+
+    async def preflight(self) -> dict[str, Any]:
+        return self._preflight
+
+
+@pytest.fixture
+def make_client():
+    """Factory: build a TestClient around a config + codex preflight stub."""
+    import nerve.config as cfg_mod
+
+    created: list[Any] = []
+
+    def _make(cfg=None, codex_preflight: dict[str, Any] | None = None):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from nerve.config import NerveConfig
+        from nerve.gateway.routes._deps import init_deps
+        from nerve.gateway.routes.models import router as models_router
+
+        cfg = cfg or NerveConfig()
+        # Auth dependency reads get_config().auth.jwt_secret — no secret
+        # makes require_auth a no-op.
+        cfg.auth.jwt_secret = ""
+        cfg_mod._config = cfg
+
+        backends: dict[str, Any] = {}
+        if codex_preflight is not None:
+            backends["codex"] = FakeCodexBackend(codex_preflight)
+        engine = SimpleNamespace(_backends=backends)
+        init_deps(engine=engine, db=None)  # type: ignore[arg-type]
+
+        app = FastAPI()
+        app.include_router(models_router)
+        client = TestClient(app)
+        created.append(client)
+        return client
+
+    yield _make
+
+    cfg_mod._config = None  # leave global state clean for other tests
+
+
+class TestListModels:
+    def test_claude_advertises_full_selectable_list(self, make_client):
+        """The picker needs >1 Claude entry — not just the default model."""
+        from nerve.config import get_config
+
+        client = make_client()
+        data = client.get("/api/models").json()
+
+        claude_models = [m for m in data["models"] if m["backend"] == "claude"]
+        assert [m["id"] for m in claude_models] == get_config().claude_models
+        assert len(claude_models) > 1
+        assert all(m["provider"] == "anthropic" for m in claude_models)
+        # The default leads the list and matches the advertised default.
+        assert claude_models[0]["id"] == data["defaults"]["claude"]
+
+    def test_claude_backend_option_lists_models(self, make_client):
+        from nerve.config import get_config
+
+        client = make_client()
+        data = client.get("/api/models").json()
+
+        claude_opt = next(
+            o for o in data["backends"]["options"] if o["id"] == "claude"
+        )
+        assert claude_opt["models"] == get_config().claude_models
+        assert claude_opt["available"] is True
+
+    def test_configured_models_reach_the_response(self, make_client):
+        from nerve.config import AgentConfig, NerveConfig
+
+        cfg = NerveConfig(agent=AgentConfig.from_dict({
+            "model": "claude-fable-5",
+            "models": ["claude-opus-5", "claude-haiku-4-5-20251001"],
+        }))
+        client = make_client(cfg=cfg)
+        data = client.get("/api/models").json()
+
+        claude_ids = [
+            m["id"] for m in data["models"] if m["backend"] == "claude"
+        ]
+        assert claude_ids == [
+            "claude-fable-5", "claude-opus-5", "claude-haiku-4-5-20251001",
+        ]
+
+    def test_codex_models_from_preflight(self, make_client):
+        client = make_client(codex_preflight={
+            "available": True, "models": ["gpt-5.6-sol", "gpt-5.6-mini"],
+        })
+        data = client.get("/api/models").json()
+
+        codex_models = [m for m in data["models"] if m["backend"] == "codex"]
+        assert [m["id"] for m in codex_models] == ["gpt-5.6-sol", "gpt-5.6-mini"]
+        assert all(m["provider"] == "openai" for m in codex_models)
+
+    def test_codex_unavailable_lists_no_codex_models(self, make_client):
+        client = make_client(codex_preflight={
+            "available": False, "reason": "codex binary not found",
+        })
+        data = client.get("/api/models").json()
+
+        assert [m for m in data["models"] if m["backend"] == "codex"] == []
+        codex_opt = next(
+            o for o in data["backends"]["options"] if o["id"] == "codex"
+        )
+        assert codex_opt["available"] is False
+        assert codex_opt["reason"] == "codex binary not found"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -253,8 +253,9 @@ export const api = {
 
   authStatus: () => request<{ auth_required: boolean }>('/auth/status'),
 
-  // Models — chat models offered to the composer's picker (Anthropic default
-  // plus any locally-installed Ollama models, auto-discovered server-side).
+  // Models — chat models offered to the composer's picker, per backend
+  // (the configured Claude list, Codex app-server models, and any
+  // locally-installed Ollama models, auto-discovered server-side).
   getModels: () =>
     request<{
       default: string;

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -127,8 +127,9 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
       .catch(() => setRewriteAvailable(false));
   }, []);
 
-  // Load selectable models once — the picker only renders when more than the
-  // default model is offered (i.e. local Ollama models are configured).
+  // Load selectable models once — the picker renders when the active backend
+  // offers more than one model (the configured Claude list, the Codex
+  // app-server's models, local Ollama models).
   useEffect(() => { loadModels(); }, [loadModels]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

When creating a new session with the **Codex** backend, the composer shows a model picker (populated from the app-server's `model/list` preflight). With the **Claude** backend there is no picker — `GET /api/models` only ever advertised the single configured `agent.model`, and the composer renders the picker only when a backend offers more than one model.

Everything downstream already supported it: the per-message `model` override on the WS message, the engine's resolution chain (`message override → session.model → backend default`), sticky persistence of the resolved model on the session, and mid-session client rebuild on model switch are all backend-agnostic.

## Fix

- **`agent.models` config** (new, optional): Claude models selectable in the composer. `agent.model` always leads the list; entries extend it (order-preserving, deduped).
- **`config.claude_models` property**: resolves the effective list. When `agent.models` is unset, a built-in current-generation fallback applies (`claude-opus-5`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001` — the same IDs Nerve defaults to elsewhere). On **Bedrock** the bare built-ins are skipped (IDs are region-prefixed there), so only models named in config are offered.
- **`GET /api/models`**: advertises the full Claude list in both the flat `models` array and `backends.options[claude].models`.
- Frontend: no functional change needed — the existing picker is generic; stale comments updated.

## Tests

- `TestClaudeModels` in `test_config_resolution.py` — property resolution: defaults, explicit list, dedup, Bedrock behavior, empty-entry filtering, config-key validator guard.
- New `tests/test_models_route.py` — HTTP-level: Claude list advertised (>1 entry so the picker renders), configured models reach the response, Codex preflight models, unavailable-Codex diagnostics.
- Full suite: 1780 passed. `npm run build` clean.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*