### PR TITLE
Persist the composer's model pick at session creation

### DIFF
--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from nerve.agent.backends.base import BackendError
 from nerve.agent.interactive import get_awaiting_ids
 from nerve.config import get_config
 from nerve.gateway.auth import require_auth
@@ -78,6 +79,11 @@ class SessionCreateRequest(BaseModel):
     # Agent backend for this session ("claude" | "codex"). Persisted
     # immediately; metadata keeps the override only for old readers.
     backend: str | None = None
+    # Model for this session's turns (the composer's picker choice).
+    # Empty/None → the backend's default. Persisted at creation so the
+    # header's model badge is right from the first render — per-message
+    # overrides on the WS path can still change it later.
+    model: str | None = None
     cwd: str | None = None
     # Optional review loop attached at creation: this session becomes the
     # loop's observer (milestones land here; cwd is the shared workspace).
@@ -194,7 +200,19 @@ async def create_session(req: SessionCreateRequest, user: dict = Depends(require
                 ) from e
         cwd = str(path)
     selected_backend = deps.engine._backends[backend]
-    model = selected_backend.default_model(req.source)
+    requested_model = (req.model or "").strip()
+    if requested_model:
+        # Same optional-validation seam the engine uses per turn: backends
+        # that can cheaply reject a model (codex) do so here, before a row
+        # with an unservable model is minted; claude accepts any ID (Ollama
+        # models ride the claude backend, so the list is open-ended).
+        validate_model = getattr(selected_backend, "validate_model", None)
+        if validate_model is not None:
+            try:
+                await validate_model(requested_model)
+            except BackendError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+    model = requested_model or selected_backend.default_model(req.source)
     session_id = str(uuid.uuid4())[:8]
     session = await deps.engine.sessions.get_or_create(
         session_id, title=req.title, source=req.source, metadata=metadata,

--- a/tests/test_session_create_model.py
+++ b/tests/test_session_create_model.py
@@ -1,0 +1,130 @@
+"""HTTP route tests for POST /api/sessions with a model override.
+
+The composer's model picker sends its choice at session creation so the
+session row (and the header's model badge) carries the picked model from
+the first render — instead of the backend default until the first turn
+resolves the override. Pattern mirrors test_workflow_routes.py.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from nerve.agent.backends.base import BackendError
+from nerve.db import Database
+
+
+class FakeClaudeBackend:
+    """Accepts any model — no validate_model, like the real claude backend."""
+
+    name = "claude"
+
+    def default_model(self, source: str) -> str:
+        return "claude-fable-5"
+
+
+class FakeCodexBackend:
+    name = "codex"
+
+    def default_model(self, source: str) -> str:
+        return "gpt-5.6-sol"
+
+    async def preflight(self) -> dict[str, Any]:
+        return {"available": True, "models": ["gpt-5.6-sol"]}
+
+    async def validate_model(self, model: str) -> None:
+        if model != "gpt-5.6-sol":
+            raise BackendError(f"Model {model!r} is not available")
+
+
+class FakeSessionManager:
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+    async def get_or_create(self, session_id: str, **kwargs) -> dict:
+        return await self.db.create_session(
+            session_id,
+            title=kwargs.get("title"),
+            source=kwargs.get("source", "web"),
+            metadata=kwargs.get("metadata"),
+            backend=kwargs.get("backend", "claude"),
+            model=kwargs.get("model"),
+            cwd=kwargs.get("cwd"),
+        )
+
+
+@pytest.mark.asyncio
+class TestCreateSessionModel:
+    @pytest_asyncio.fixture
+    async def setup(self, db: Database, tmp_path):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        import nerve.config as cfg_mod
+        from nerve.config import NerveConfig
+        from nerve.gateway.routes._deps import init_deps
+        from nerve.gateway.routes.sessions import router as sessions_router
+
+        cfg = NerveConfig()
+        cfg.workspace = tmp_path
+        cfg.auth.jwt_secret = ""  # require_auth becomes a no-op
+        cfg_mod._config = cfg
+
+        engine = SimpleNamespace(
+            _backends={
+                "claude": FakeClaudeBackend(),
+                "codex": FakeCodexBackend(),
+            },
+            config=cfg,
+            sessions=FakeSessionManager(db),
+        )
+        init_deps(engine=engine, db=db)  # type: ignore[arg-type]
+
+        app = FastAPI()
+        app.include_router(sessions_router)
+        yield SimpleNamespace(client=TestClient(app), db=db)
+
+        cfg_mod._config = None
+
+    async def test_model_persisted_at_creation(self, setup):
+        resp = setup.client.post(
+            "/api/sessions",
+            json={"backend": "claude", "model": "claude-opus-5"},
+        )
+        assert resp.status_code == 200
+        session = resp.json()
+        assert session["model"] == "claude-opus-5"
+        row = await setup.db.get_session(session["id"])
+        assert row["model"] == "claude-opus-5"
+
+    async def test_omitted_model_falls_back_to_backend_default(self, setup):
+        resp = setup.client.post("/api/sessions", json={"backend": "claude"})
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "claude-fable-5"
+
+    async def test_blank_model_falls_back_to_backend_default(self, setup):
+        resp = setup.client.post(
+            "/api/sessions", json={"backend": "claude", "model": "   "},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "claude-fable-5"
+
+    async def test_codex_validates_model(self, setup):
+        resp = setup.client.post(
+            "/api/sessions",
+            json={"backend": "codex", "model": "claude-opus-5"},
+        )
+        assert resp.status_code == 400
+        assert "not available" in resp.json()["detail"]
+
+    async def test_codex_accepts_known_model(self, setup):
+        resp = setup.client.post(
+            "/api/sessions",
+            json={"backend": "codex", "model": "gpt-5.6-sol"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "gpt-5.6-sol"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -274,12 +274,16 @@ export const api = {
   searchSessions: (q: string) =>
     request<{ sessions: any[] }>(`/sessions/search?q=${encodeURIComponent(q)}`),
   getSession: (id: string) => request<any>(`/sessions/${id}`),
-  createSession: (title?: string, backend?: string | null, cwd?: string | null, reviewLoop?: ReviewLoopCreatePayload | null) =>
+  createSession: (title?: string, backend?: string | null, cwd?: string | null, reviewLoop?: ReviewLoopCreatePayload | null, model?: string | null) =>
     request<any>('/sessions', {
       method: 'POST',
       body: JSON.stringify({
         title,
         ...(backend ? { backend } : {}),
+        // Composer's model pick — persisted on the session row at creation
+        // so the header badge is right from the first render (omitted →
+        // the backend's default model).
+        ...(model ? { model } : {}),
         ...(cwd ? { cwd } : {}),
         ...(reviewLoop ? { review_loop: reviewLoop } : {}),
       }),

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -591,8 +591,13 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // The loop's workdir rides the session-level cwd (the loop inherits the
     // observer session's cwd server-side); only sent when a loop is bound.
     const rlCwd = rlPayload && rl ? rl.cwd.trim() || undefined : undefined;
+    // Composer's model pick for the chosen backend — sent at creation so
+    // the session row (and the header badge) carries it from the start,
+    // instead of the backend default until the first turn resolves it.
+    const effBackend = get().newChatBackend ?? get().backendDefault ?? 'claude';
+    const pickedModel = get().selectedModels[effBackend] ?? undefined;
     const real: Session = await api.createSession(
-      undefined, get().newChatBackend, rlCwd, rlPayload,
+      undefined, get().newChatBackend, rlCwd, rlPayload, pickedModel,
     );
     set((state) => {
       const drafts = { ...state.drafts };


### PR DESCRIPTION
## Problem

Follow-up to #222. Start a new chat with a non-default model picked (e.g. `claude-opus-5` while `agent.model` is another model) and the chat header shows the **default** model for the whole first turn. The turn genuinely runs on the picked model — requested model, observed serving model, and billed usage all agree — the badge is just stale.

Cause: `POST /api/sessions` always stamped the new row with `backend.default_model(source)`. The picker's choice only rides the first WS message, gets persisted onto the session mid-turn, and the UI's session list only refreshes at turn end (`loadSessions()` in the `done` handler). The same staleness existed for Codex sessions before #222 — the Claude picker just made it visible.

## Fix

- `SessionCreateRequest.model` (optional): the composer's pick, persisted on the row at creation. Blank/omitted → backend default, as before.
- Validated through the same optional seam the engine uses per turn: backends exposing `validate_model` (Codex) reject unservable models with a 400 before a row is minted; Claude stays open-ended (Ollama models ride the claude backend).
- Frontend: `ensureRealSession` passes `selectedModels[effectiveBackend]` to `api.createSession`, so the session (and header badge) is born with the right model. Per-message overrides on the WS path are unchanged — mid-session switching still works.

## Tests

- New `tests/test_session_create_model.py` (HTTP-level): model persisted at creation, omitted/blank fallback to backend default, codex validation 400 + accept path.
- Full suite: 1785 passed. `npm run build` clean.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*