### PR TITLE
Accept top-level YAML lists in the cron job loader

### DIFF
--- a/nerve/cron/jobs.py
+++ b/nerve/cron/jobs.py
@@ -201,9 +201,25 @@ def load_jobs(jobs_file: Path) -> list[CronJob]:
         logger.error("Failed to load cron jobs from %s: %s", jobs_file, e)
         return []
 
-    jobs_data = data.get("jobs", [])
     if isinstance(data, list):
         jobs_data = data
+    elif isinstance(data, dict):
+        jobs_data = data.get("jobs", [])
+    else:
+        logger.warning(
+            "Invalid cron jobs file %s: expected a mapping or list, got %s",
+            jobs_file,
+            type(data).__name__,
+        )
+        return []
+
+    if not isinstance(jobs_data, list):
+        logger.warning(
+            "Invalid cron jobs file %s: expected 'jobs' to be a list, got %s",
+            jobs_file,
+            type(jobs_data).__name__,
+        )
+        return []
 
     jobs = []
     for item in jobs_data:

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -973,6 +973,46 @@ class TestRunGates:
 
 
 # ---------------------------------------------------------------------------
+# Job loading
+# ---------------------------------------------------------------------------
+
+class TestLoadJobs:
+    def test_accepts_top_level_list(self, tmp_path):
+        from nerve.cron.jobs import load_jobs
+
+        yaml_file = tmp_path / "jobs.yaml"
+        yaml_file.write_text(
+            "- id: hourly-review\n"
+            "  schedule: 1h\n"
+            "  prompt: Review pending tasks\n",
+            encoding="utf-8",
+        )
+
+        jobs = load_jobs(yaml_file)
+
+        assert len(jobs) == 1
+        assert jobs[0].id == "hourly-review"
+        assert jobs[0].schedule == "1h"
+        assert jobs[0].prompt == "Review pending tasks"
+
+    @pytest.mark.parametrize(
+        ("content", "message"),
+        [
+            ("invalid\n", "expected a mapping or list, got str"),
+            ("jobs: invalid\n", "expected 'jobs' to be a list, got str"),
+        ],
+    )
+    def test_rejects_invalid_structure(self, tmp_path, caplog, content, message):
+        from nerve.cron.jobs import load_jobs
+
+        yaml_file = tmp_path / "jobs.yaml"
+        yaml_file.write_text(content, encoding="utf-8")
+
+        assert load_jobs(yaml_file) == []
+        assert message in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # Prompt files (prompt_file)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`load_jobs()` contains a branch for top-level YAML lists, but calls `data.get("jobs", [])` before reaching it. A file like this therefore raises `AttributeError` instead of loading the job:

```yaml
- id: hourly-review
  schedule: 1h
  prompt: Review pending tasks
```

The loader also assumes every other root and every `jobs` value has the expected collection type, allowing malformed YAML structures to fail during loading.

## Changes

- inspect the YAML root before accessing mapping keys
- accept both a top-level list and the existing `jobs:` mapping
- reject invalid root and job-collection types with a warning
- add focused regression coverage for accepted and rejected structures

## Testing

- exercised `load_jobs()` with list, invalid-root, and invalid-collection inputs
- compiled the changed Python files
- ran `git diff --check`