### PR TITLE
web: clear `checking` on the passwordless auto-login path

### DIFF
--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -45,7 +45,9 @@ export const useAuthStore = create<AuthState>((set) => ({
           // No password configured — auto-login
           const { token } = await api.login('');
           setToken(token);
-          set({ authenticated: true });
+          // checking must be cleared here too — App renders null while it
+          // is true, so leaving it set blanks the app after auto-login.
+          set({ authenticated: true, checking: false });
           return;
         }
       } catch {


### PR DESCRIPTION
## What

On a deployment with no password configured, a fresh browser loads the web UI, auto-logs in, and then sits on a blank page. A manual reload fixes it.

The root cause: `checking` starts as `!getToken()` (true for any browser without a stored token), so `App.tsx` renders `null` while it is set. The `checkAuth()` branch that handles the passwordless auto-login path sets `authenticated: true` but never clears `checking`, leaving the app stuck on a blank screen after a successful login.

## Fix

Clear `checking: false` alongside `authenticated: true` in the auto-login branch.

## Why

Correct UX — the app should render immediately after auto-login on a passwordless instance.

Rebased on current upstream/main (2026-07-30).