### PR TITLE
pairing: write state atomically with private permissions

### DIFF
--- a/nerve/pairing.py
+++ b/nerve/pairing.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import secrets
 import time
 from pathlib import Path
 
 from nerve import paths
+from nerve.utils.fs import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -45,13 +45,7 @@ def _read_state() -> dict | None:
 
 
 def _write_state(state: dict) -> None:
-    path = _pairing_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(state), encoding="utf-8")
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
+    atomic_write_text(_pairing_path(), json.dumps(state), mode=0o600)
 
 
 def generate_pairing_code() -> str:

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 
 import nerve.pairing as pairing
+import pytest
 from nerve.pairing import (
     MAX_ATTEMPTS,
     clear_pairing_code,
@@ -33,6 +35,32 @@ class TestGenerate:
         clear_pairing_code()
         code = get_or_create_pairing_code()
         assert read_pairing_code() == code
+
+    def test_state_is_private_if_path_chmod_fails(self, monkeypatch):
+        def fail_chmod(*args, **kwargs):
+            raise OSError("chmod failed")
+
+        monkeypatch.setattr(os, "chmod", fail_chmod)
+        previous_umask = os.umask(0)
+        try:
+            generate_pairing_code()
+        finally:
+            os.umask(previous_umask)
+
+        assert pairing._pairing_path().stat().st_mode & 0o777 == 0o600
+
+    def test_failed_replace_preserves_existing_state(self, monkeypatch):
+        code = generate_pairing_code()
+
+        def fail_replace(*args, **kwargs):
+            raise OSError("replace failed")
+
+        monkeypatch.setattr(os, "replace", fail_replace)
+        with pytest.raises(OSError, match="replace failed"):
+            generate_pairing_code()
+
+        assert read_pairing_code() == code
+        assert list(pairing._pairing_path().parent.glob(".telegram_pairing.*.tmp")) == []
 
 
 class TestVerify:


### PR DESCRIPTION
## Summary

- write Telegram pairing state through the existing atomic filesystem helper
- apply owner-only permissions before secret content is written
- preserve the previous valid state and clean up temporary files if replacement fails

## Test plan

- `.venv/bin/python -m pytest -q tests/test_pairing.py tests/test_utils_fs.py`
- broader suite: 2939 passed