### PR TITLE
Config Refactor Follow-Up Fixes

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -185,7 +185,9 @@ jobs:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
       # nerve is not published to PyPI: the bare name is an unrelated project.
-      - run: uv pip install --system "nerve @ git+https://github.com/ClickHouse/nerve"
+      # `uv tool install` because the runner's system interpreter is externally
+      # managed (PEP 668) and only the CLI is needed here.
+      - run: uv tool install "nerve @ git+https://github.com/ClickHouse/nerve"
       # Add --assume-lockdown if any instance served by this repo is locked and
       # the flag comes from the environment. Without it CI checks the unlocked
       # view and the lockdown checks never run. See "Lockdown" below.
@@ -359,7 +361,12 @@ This writes four files, never overwriting an existing one:
 - `.github/workflows/validate-config.yml`: the CI check, shown below.
 - `.gitignore`: keeps `config.local.yaml`, `.env`, `*.migrated`, databases and the
   like out of the shared repo. Secrets belong in the environment, referenced as
-  `${ENV_VAR}`.
+  `${ENV_VAR}`. It also excludes the agent's own runtime state — `MEMORY.md`,
+  `TASK.md`, `memory/` — which every workspace has and which the instance
+  rewrites for itself; the reviewed instruction files (`SOUL.md`, `IDENTITY.md`,
+  `USER.md`, `AGENTS.md`, `TOOLS.md`) are tracked. **A workspace that is also a
+  working directory may hold more than config**, so read `git status` before the
+  `git add -A` below rather than after the push.
 - `README.md`: a short explainer of the PR-based flow.
 - `config/settings.yaml`: the commented portable settings scaffold, if the
   workspace has none. An instance's workspace already has one; a bare directory
@@ -422,8 +429,15 @@ jobs:
       # validator at or ahead of the instance, which is the safe direction for
       # --strict-keys below: a newer validator knows every key the instance
       # reads. To check against one release instead, append a ref (nerve@v1.2.3).
+      #
+      # `uv tool install`, not `uv pip install --system`: the runner's system
+      # interpreter is externally managed (PEP 668), so --system is refused
+      # outright ("The interpreter at /usr is externally managed"). Only the
+      # `nerve` CLI is needed here, never an importable library, so a tool
+      # install in its own environment is both the idiomatic spelling and
+      # independent of what Python the runner image happens to ship.
       - uses: astral-sh/setup-uv@v6
-      - run: uv pip install --system "nerve @ git+https://github.com/ClickHouse/nerve"
+      - run: uv tool install "nerve @ git+https://github.com/ClickHouse/nerve"
 
       # The config repo root IS the workspace (it holds config/ and skills/).
       #

--- a/nerve/migrate.py
+++ b/nerve/migrate.py
@@ -74,6 +74,7 @@ from nerve import paths
 from nerve.config import (
     _deep_merge,
     _expand_path,
+    _is_within,
     _read_yaml_mapping,
     workspace_config_dir,
     workspace_settings_file,
@@ -229,6 +230,16 @@ _MACHINE_LOCAL_PATHS = frozenset({
     # path that exists on exactly one of them.
     "workflows.runs_dir",
 })
+
+
+# Cron settings naming a *file or directory* that :func:`_migrate_cron` is about
+# to move. They are dropped rather than rewritten: the whole point of the
+# workspace layout is that cron config resolves to ``<workspace>/config/cron``
+# (see :func:`nerve.config._resolve_cron_dir`), and a rewritten absolute path
+# would be a machine-local location baked into the file the docs say to commit —
+# wrong on the next box to sync it, and exactly what the config repo exists to
+# avoid.
+_MIGRATED_CRON_PATH_KEYS = ("jobs_file", "system_file", "gate_plugins_dir")
 
 
 @dataclass
@@ -533,7 +544,7 @@ def migrate(
     legacy_cron = Path(legacy_cron_dir) if legacy_cron_dir is not None else paths.cron_dir()
     report = MigrationReport(dry_run=dry_run) if report is None else report
 
-    _migrate_config_yaml(config_dir, workspace, report)
+    _migrate_config_yaml(config_dir, workspace, legacy_cron, report)
     _migrate_cron(workspace, legacy_cron, report)
     return report
 
@@ -557,7 +568,55 @@ def _settings_has_content(settings: Path) -> bool:
         return True
 
 
-def _migrate_config_yaml(config_dir: Path, workspace: Path, report: MigrationReport) -> None:
+def _drop_migrated_cron_paths(
+    raw: dict, legacy_cron: Path, report: MigrationReport
+) -> None:
+    """Drop cron path settings that point into the directory being migrated.
+
+    A legacy monolith that spelled its cron locations out —
+
+    .. code-block:: yaml
+
+        cron:
+          system_file: ~/.nerve/cron/system.yaml
+          jobs_file: ~/.nerve/cron/jobs.yaml
+
+    — is naming files that :func:`_migrate_cron` moves into the workspace,
+    leaving ``*.migrated`` breadcrumbs behind. Carried across unchanged, those
+    keys outlive the files they name and the daemon starts with **no jobs at
+    all**: nothing raises, because an absent cron file is a normal state for an
+    install that has none, so the only symptom is a log line nobody is watching
+    for and every scheduled job silently not running.
+
+    Dropping them restores the default, which is the workspace cron directory
+    the files just landed in. Only paths *inside* ``legacy_cron`` are dropped: a
+    pointer somewhere else is a deliberate choice about a location this
+    migration does not touch, and stays exactly as it was.
+
+    Note this is decided per key rather than from whether the copy went ahead.
+    When a workspace file already shadows a legacy one, :func:`_migrate_cron`
+    leaves the legacy copy in place and warns that the workspace's wins — so the
+    pointer is stale in that case too, just for the other reason.
+    """
+    cron = raw.get("cron")
+    if not isinstance(cron, dict):
+        return
+    for key in _MIGRATED_CRON_PATH_KEYS:
+        configured = _expand_path(cron.get(key))
+        if configured is None or not _is_within(configured, legacy_cron):
+            continue
+        cron.pop(key)
+        report.actions.append(
+            f"dropped cron.{key} ({configured}): it named a file this migration "
+            f"moved, so cron now resolves to the workspace config/cron/"
+        )
+    if not cron:
+        raw.pop("cron", None)
+
+
+def _migrate_config_yaml(
+    config_dir: Path, workspace: Path, legacy_cron: Path, report: MigrationReport
+) -> None:
     config_yaml = config_dir / "config.yaml"
     settings = workspace_settings_file(workspace)
 
@@ -603,6 +662,9 @@ def _migrate_config_yaml(config_dir: Path, workspace: Path, report: MigrationRep
             f"is honored only in {settings}, where it also stops the machine-local "
             "layers from being read. Set it there deliberately to lock this instance"
         )
+
+    # Before the split, so a stale pointer cannot land in either half.
+    _drop_migrated_cron_paths(raw, legacy_cron, report)
 
     # Split before scrubbing, so a machine-local value never reaches the tracked
     # file even as a ${VAR} placeholder. The machine half is left unscrubbed:

--- a/nerve/templates/config-repo/gitignore
+++ b/nerve/templates/config-repo/gitignore
@@ -28,6 +28,20 @@ config.local.yaml
 mcp-token
 certs/
 
+# The agent's own runtime state. Unlike the files above these are in *every*
+# workspace — `nerve init` writes MEMORY.md from the template manifest, and the
+# agent creates memory/ and rewrites MEMORY.md and TASK.md as it works — so the
+# runbook's `git add -A` would commit them on the very first push, and every
+# subsequent pull would fight the instance over its own scratchpad.
+#
+# This is the same line nerve draws for the agent's own proposals, where these
+# paths are refused as runtime state (_ALLOWED_ROOT_FILES in nerve/config_pr.py):
+# reviewing them would mean a pull request per thought. The reviewed instruction
+# files — SOUL.md, IDENTITY.md, USER.md, AGENTS.md, TOOLS.md — are tracked.
+/MEMORY.md
+/TASK.md
+/memory/
+
 # The nerve source checkout used by the CI validation workflow
 .nerve-src/
 

--- a/nerve/templates/config-repo/validate-config.yml
+++ b/nerve/templates/config-repo/validate-config.yml
@@ -40,8 +40,15 @@ jobs:
       # validator at or ahead of the instance, which is the safe direction for
       # --strict-keys below: a newer validator knows every key the instance
       # reads. To check against one release instead, append a ref (nerve@v1.2.3).
+      #
+      # `uv tool install`, not `uv pip install --system`: the runner's system
+      # interpreter is externally managed (PEP 668), so --system is refused
+      # outright ("The interpreter at /usr is externally managed"). Only the
+      # `nerve` CLI is needed here, never an importable library, so a tool
+      # install in its own environment is both the idiomatic spelling and
+      # independent of what Python the runner image happens to ship.
       - uses: astral-sh/setup-uv@v6
-      - run: uv pip install --system "nerve @ git+https://github.com/ClickHouse/nerve"
+      - run: uv tool install "nerve @ git+https://github.com/ClickHouse/nerve"
 
       # The config repo root IS the workspace (it holds config/ and skills/).
       #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
+# `packages` already takes everything under nerve/, nerve/templates/ included,
+# so there is no force-include here: adding that subtree a second time is what
+# hatchling rejects with "A second file is being added to the wheel archive at
+# the same path", which made the wheel unbuildable and `pip install` from git
+# impossible. Nothing caught it because every documented install is `pip install
+# -e .` from a clone and CI installs the same way, so no wheel was ever built
+# until the config-repo validation workflow needed one.
 packages = ["nerve"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"nerve/templates" = "nerve/templates"

--- a/tests/test_config_repo.py
+++ b/tests/test_config_repo.py
@@ -14,6 +14,7 @@ from click.testing import CliRunner
 
 import nerve
 from nerve import config_repo
+from nerve.config_pr import _ALLOWED_ROOT_FILES
 from nerve.config_repo import _SCAFFOLD, _template_dir, scaffold_config_repo
 
 _WORKFLOW = ".github/workflows/validate-config.yml"
@@ -35,8 +36,13 @@ def _validate_step(ws: Path) -> dict:
 
 
 def _install_step(ws: Path) -> dict:
-    """The step that installs the nerve the validator comes from."""
-    return next(s for s in _steps(ws) if "pip install" in str(s.get("run", "")))
+    """The step that installs the nerve the validator comes from.
+
+    Matched on the package spec rather than the installer, so swapping how it
+    is installed does not silently match no step and skip the assertions that
+    depend on this.
+    """
+    return next(s for s in _steps(ws) if "nerve @ git+" in str(s.get("run", "")))
 
 
 def _run_ci_validation(ws: Path) -> subprocess.CompletedProcess:
@@ -126,6 +132,37 @@ class TestScaffold:
         assert not ignored("config/config.yaml"), "tracked config must stay committable"
         assert not ignored("config/settings.yaml")
 
+    def test_agent_runtime_state_is_ignored_but_instructions_are_tracked(self, tmp_path):
+        """`nerve init` writes MEMORY.md into every workspace, and the agent
+        rewrites it and TASK.md as it works, so the runbook's `git add -A` would
+        commit a scratchpad the instance then fights the repo over on each pull.
+
+        The same line nerve draws for the agent's own proposals, where these are
+        refused as runtime state while the instruction files are reviewable —
+        so this pins both halves, not just the exclusion. Asked of git for the
+        anchoring reason above: unanchored, `MEMORY.md` would also swallow a
+        skill's own MEMORY.md inside the tracked subtree.
+        """
+        import shutil
+        import subprocess
+
+        if not shutil.which("git"):
+            pytest.skip("git not available")
+        scaffold_config_repo(tmp_path)
+        subprocess.run(["git", "init", "-q"], cwd=str(tmp_path), check=True,
+                       capture_output=True)
+
+        def ignored(rel: str) -> bool:
+            return subprocess.run(
+                ["git", "check-ignore", "-q", rel], cwd=str(tmp_path),
+            ).returncode == 0
+
+        for rel in ("MEMORY.md", "TASK.md", "memory/entity.md"):
+            assert ignored(rel), f"{rel} is runtime state and must not be staged"
+        for rel in _ALLOWED_ROOT_FILES:
+            assert not ignored(rel), f"{rel} is reviewed instruction and must stay committable"
+        assert not ignored("skills/x/MEMORY.md"), "the exclusion must be root-anchored"
+
     def test_gitignore_covers_backup_secret_members(self, tmp_path):
         # If the workspace doubles as the state dir, `git add -A` (which the
         # runbook tells operators to run) must not sweep up nerve's credentials.
@@ -207,6 +244,17 @@ class TestScaffoldedWorkflow:
         run = _install_step(tmp_path)["run"]
         assert "git+https://github.com/ClickHouse/nerve" in run
         assert "install nerve\n" not in run and not run.endswith("install nerve")
+
+    def test_the_validator_is_not_installed_into_the_system_interpreter(self, tmp_path):
+        """`--system` is refused on the runner: its Python is externally managed.
+
+        This failed every scaffolded repo on its first push, at the step after
+        the secret scan, with "The interpreter at /usr is externally managed"
+        (PEP 668). Only the CLI is needed, so it goes in its own environment.
+        """
+        scaffold_config_repo(tmp_path)
+        run = _install_step(tmp_path)["run"]
+        assert "--system" not in run, run
 
     def test_the_validate_step_runs_the_installed_cli(self, tmp_path):
         scaffold_config_repo(tmp_path)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1077,6 +1077,32 @@ class TestMigrateCron:
         # stopped running: the workspace copy wins and the legacy dir is dropped.
         assert any("still holds cron jobs" in w for w in report.warnings)
 
+    def test_keeps_a_cron_path_outside_the_migrated_directory(self, tmp_path):
+        """Only the paths this migration invalidates are dropped.
+
+        A cron file somewhere else entirely is a deliberate choice about a
+        location migration never touches, so it still resolves afterwards and
+        must survive. Dropping it too would silently move that instance's jobs
+        to a directory it never chose.
+        """
+        legacy_cron = paths.cron_dir()
+        legacy_cron.mkdir(parents=True, exist_ok=True)
+        (legacy_cron / "jobs.yaml").write_text("jobs: []\n", encoding="utf-8")
+        elsewhere = tmp_path / "elsewhere" / "jobs.yaml"
+        elsewhere.parent.mkdir(parents=True)
+        elsewhere.write_text(
+            "jobs:\n  - id: kept\n    schedule: 1h\n    prompt: hi\n", encoding="utf-8"
+        )
+        config_dir, workspace = _legacy_install(
+            tmp_path, f"cron:\n  jobs_file: {elsewhere}\n"
+        )
+
+        migrate(config_dir, workspace=workspace)
+
+        config = load_config(config_dir)
+        assert config.cron.jobs_file == elsewhere
+        assert [j.id for j in load_jobs(config.cron.jobs_file)] == ["kept"]
+
     def test_gates_and_prompts_migrate_past_the_files_nerve_init_wrote(self, tmp_path):
         """``nerve init`` writes ``system.yaml`` and an empty ``gates/`` into the
         workspace and copies only ``jobs.yaml`` across. A directory-level "the
@@ -1230,5 +1256,48 @@ class TestStartAfterMigration:
 
         assert result.exit_code == 0, result.output
         config = served["config"]
+        assert config.cron.jobs_file == workspace / "config" / "cron" / "jobs.yaml"
+        assert [j.id for j in load_jobs(config.cron.jobs_file)] == ["mine"]
+
+    def test_cron_paths_naming_the_legacy_dir_do_not_outlive_it(self, tmp_path):
+        """The same silence, for a config that spelled its cron paths out.
+
+        The test above covers a config that never named them, where resolution
+        follows the workspace on its own. A monolith that *did* name them
+        carries absolute ``~/.nerve/cron`` paths into the migrated settings,
+        where they keep pointing at files migration has moved and renamed to
+        ``*.migrated``. Reloading is not enough to recover: the pointers are in
+        the config now, so every subsequent start schedules nothing too.
+
+        Nothing raises, here or in production — an absent cron file is a normal
+        state for an install with no jobs — so the only trace is one INFO line
+        per file and a daemon that quietly never runs anything again.
+        """
+        legacy_cron = paths.cron_dir()
+        legacy_cron.mkdir(parents=True, exist_ok=True)
+        (legacy_cron / "jobs.yaml").write_text(
+            "jobs:\n  - id: mine\n    schedule: 1h\n    prompt: hi\n", encoding="utf-8"
+        )
+        config_dir, workspace = _legacy_install(
+            tmp_path,
+            "timezone: UTC\n"
+            "cron:\n"
+            f"  jobs_file: {legacy_cron / 'jobs.yaml'}\n"
+            f"  system_file: {legacy_cron / 'system.yaml'}\n",
+        )
+
+        migrate(config_dir, workspace=workspace)
+
+        # Nothing machine-local reached the file the docs say to commit, so the
+        # next box to sync this repo does not inherit one box's ~/.nerve either.
+        settings = yaml.safe_load(
+            workspace_settings_file(workspace).read_text(encoding="utf-8")
+        )
+        assert "cron" not in (settings or {}), (
+            "paths naming the files migration just moved were published to the "
+            f"tracked settings: {(settings or {}).get('cron')!r}"
+        )
+
+        config = load_config(config_dir)
         assert config.cron.jobs_file == workspace / "config" / "cron" / "jobs.yaml"
         assert [j.id for j in load_jobs(config.cron.jobs_file)] == ["mine"]


### PR DESCRIPTION
Some fixes around config repo, including a pre-existing wheel build issue.

### 1. Migration silently unschedules every job when using absolute paths

A legacy monolith that spelled its cron paths out —

```yaml
cron:
  system_file: ~/.nerve/cron/system.yaml
  jobs_file: ~/.nerve/cron/jobs.yaml
```

— names the files `_migrate_cron` moves into the workspace, leaving `*.migrated` breadcrumbs behind. Those pointers were carried into the new `settings.yaml` unchanged, so the daemon looked where the files no longer are. Real log from the box this was found on, seven seconds apart:

```
nerve.migrate: Migrated config ... cron ~/.nerve/cron/* → <ws>/config/cron/ (2 file(s), originals kept as *.migrated)
nerve.cron.jobs: No cron jobs file at /home/…/.nerve/cron/system.yaml
nerve.cron.jobs: No cron jobs file at /home/…/.nerve/cron/jobs.yaml
nerve.cron.service: Cron service started with 0 jobs + 1 sources
```

Worth noting for reviewers: **`nerve config validate --portable-only` cannot detect this.** `--portable-only` forces the workspace cron dir and cheerfully reports the jobs it finds there; only plain `nerve config validate`, with the machine layers applied, shows the miss. CI would have stayed green.

The fix drops those keys when they point *into the directory being migrated*, restoring the default that resolves to the workspace. A path anywhere else is a deliberate choice about a location migration never touches, and survives — pinned by its own test.

Rewriting them to the new absolute location would also have "worked", and would have been worse: a machine-local path baked into the very file the docs say to commit, wrong on the next box to sync the repo.

### 2. The wheel could not be built

```
ValueError: A second file is being added to the wheel archive at the same path:
  `nerve/templates/config/settings.yaml`
```

`force-include` added `nerve/templates` a second time on top of `packages = ["nerve"]`. Present since the initial commit and invisible the whole time, because every documented install is `pip install -e .` from a clone and CI installs the same way — nothing had ever built a wheel until the config-repo validation workflow needed one. `pip install` from git was impossible.

Verified after removing it: the wheel builds, and all 18 tracked template files are present (asserted against `git ls-files`, none missing).

### 3. CI could not install the validator

`uv pip install --system` is refused on `ubuntu-latest` — PEP 668, externally-managed interpreter — so `validate-config` failed on a scaffolded repo's very first push, at the step right after the secret scan. Only the `nerve` CLI is needed here, never an importable library, so `uv tool install`.

### 4. The runbook instructions published the agent's scratchpad

`nerve init` writes `MEMORY.md` into every workspace from the template manifest, and the agent rewrites it and `TASK.md` as it works — so step 2's `git add -A` committed them, and every subsequent pull fought the instance over its own state.

They are ignored now. This is the same line nerve already draws for the agent's own proposals, where `_ALLOWED_ROOT_FILES` in `config_pr.py` refuses them as runtime state while the instruction files stay reviewable; the two just were never reconciled with what git tracks. The new test asserts **both halves against `_ALLOWED_ROOT_FILES` itself**, so they cannot drift apart again, and asks `git check-ignore` rather than reading the file's text — the exclusions are root-anchored so a skill's own `MEMORY.md` stays committable.