### PR TITLE
memory: do not report a semantic reinforce as successful when the row is gone

### DIFF
--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -1192,8 +1192,11 @@ class MemUBridge:
                 threshold = _SEMANTIC_DEDUP_THRESHOLD
                 if threshold > 0 and embedding is not None and self.items:
                     # Type-filtered top-1 via the persistent matrix index —
-                    # no per-item corpus rebuild.
-                    hits = _vec_index_for(self).search(
+                    # no per-item corpus rebuild. Bind the index once: calling
+                    # _vec_index_for again after popping from self.items would
+                    # see the size drift and force an O(n) rebuild.
+                    idx = _vec_index_for(self)
+                    hits = idx.search(
                         embedding, k=1, memory_type=str(memory_type),
                     )
                     if hits:
@@ -1210,6 +1213,7 @@ class MemUBridge:
                             extra = dict(matched.extra or {})
                             extra["reinforcement_count"] = extra.get("reinforcement_count", 1) + 1
                             extra["last_reinforced_at"] = now.isoformat()
+                            row_written = False
                             with self._sessions.session() as session:
                                 row = session.exec(
                                     _sel(self._memory_item_model).where(
@@ -1221,10 +1225,26 @@ class MemUBridge:
                                     row.updated_at = now
                                     session.add(row)
                                     session.commit()
-                            # Update in-memory cache
-                            matched.extra = extra
-                            matched.updated_at = now
-                            return matched
+                                    row_written = True
+                            if row_written:
+                                # Update in-memory cache
+                                matched.extra = extra
+                                matched.updated_at = now
+                                return matched
+                            # The row is gone (deleted by another process), so
+                            # the cache hit is stale, not authoritative. Evict it
+                            # -- otherwise it stays a dedup magnet that silently
+                            # drops every similar memorize -- and fall through to
+                            # the real create path so this memory is stored.
+                            logger.warning(
+                                "Semantic dedup: cached %s item %s has no DB row "
+                                "(deleted concurrently); evicting the stale entry "
+                                "and creating instead",
+                                memory_type, match_id,
+                            )
+                            self.items.pop(match_id, None)
+                            idx.remove(match_id)
+                            idx.seen_items_len = len(self.items)
 
                 return _original_sqlite_reinforce(
                     self,

--- a/tests/test_memu_bridge.py
+++ b/tests/test_memu_bridge.py
@@ -1134,3 +1134,189 @@ class TestMemorizeFileLockRetry:
             await bridge.memorize_file(str(target))
 
         assert bridge._service.memorize.await_count == 1
+
+
+# --- Semantic-dedup reinforce: a stale cache hit must not report success ------
+
+
+def _semantic_reinforce_store(tmp_path, name, *, _models_cache={}):
+    """Build an isolated SQLiteStore with the real _patch_sqlite_bugs() applied.
+
+    The scoped SQLA models are built once per process and shared: nerve's
+    _patched_get_models clears memu's model cache and rebuilds, and SQLAlchemy
+    refuses to reassign a Column object to a second Table, so a second bare
+    SQLiteStore(dsn=...) in one process raises "Column object 'url' already
+    assigned to Table 'memu_resources'". Each store still gets its own DB file.
+    """
+    import memu.app  # noqa: F401 -- FIRST, breaks a circular import in memu.database
+    import memu.database.sqlite.schema as schema_mod
+    from memu.database.sqlite.sqlite import SQLiteStore
+    from pydantic import BaseModel as _PydBaseModel
+
+    MemUBridge._patch_sqlite_bugs()
+    if "models" not in _models_cache:
+        _models_cache["models"] = schema_mod.get_sqlite_sqlalchemy_models(
+            scope_model=_PydBaseModel,
+        )
+
+    db_path = tmp_path / f"{name}.sqlite"
+    store = SQLiteStore(dsn=f"sqlite:///{db_path}", sqla_models=_models_cache["models"])
+    resource = store.resource_repo.create_resource(
+        url="mem://test", modality="text", local_path=str(tmp_path / "src.txt"),
+        caption=None, embedding=None, user_data={},
+    )
+    return store, resource, str(db_path)
+
+
+def _item_row_count(db_path):
+    db = sqlite3.connect(db_path)
+    try:
+        return db.execute("SELECT COUNT(*) FROM memu_memory_items").fetchone()[0]
+    finally:
+        db.close()
+
+
+def _item_extra_in_db(db_path, item_id):
+    """Read extra straight from the file -- proves persistence, not caching."""
+    db = sqlite3.connect(db_path)
+    try:
+        row = db.execute(
+            "SELECT extra FROM memu_memory_items WHERE id = ?", (item_id,),
+        ).fetchone()
+        return json.loads(row[0]) if row and row[0] else None
+    finally:
+        db.close()
+
+
+def _delete_row_externally(db_path, item_id):
+    """Delete the row over a SECOND connection -- what another process does."""
+    db = sqlite3.connect(db_path)
+    try:
+        db.execute("DELETE FROM memu_memory_items WHERE id = ?", (item_id,))
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestSemanticReinforceStaleCacheHit:
+    """A semantic-dedup cache hit whose DB row was deleted by another process
+    used to be reported as "reinforced" while nothing was persisted.
+
+    ``_semantic_sqlite_reinforce`` decided from the in-memory cache but wrote to
+    the DB, and its ``return matched`` sat OUTSIDE the ``if row:`` write guard.
+    So a cross-connection delete produced an item with
+    ``reinforcement_count == 2`` for a row that no longer existed, and memU's
+    pipeline (``memu/app/memorize.py:614``:
+    ``if reinforce and item.extra.get("reinforcement_count", 1) > 1: continue``)
+    reads that as "already persisted" and skips both creation and category
+    linking -- silently dropping the memory, with no exception and no log.
+
+    Worse, the stale cache entry was not evicted, so it stayed a dedup magnet:
+    every later semantically-similar memorize kept matching it and kept being
+    dropped.
+    """
+
+    # Cosine ~0.999 between the two, i.e. far above _SEMANTIC_DEDUP_THRESHOLD,
+    # so the second write is guaranteed to take the semantic-dedup branch.
+    EMB_SEED = [1.0, 0.0, 0.0, 0.0]
+    EMB_SIMILAR = [0.999, 0.0447, 0.0, 0.0]
+
+    def _seed_then_delete_externally(self, tmp_path, name):
+        """Seed one item, warm the vector index, delete the row externally."""
+        from nerve.memory.memu_bridge import _vec_index_for
+
+        store, resource, db_path = _semantic_reinforce_store(tmp_path, name)
+        repo = store.memory_item_repo
+
+        seeded = repo.create_item_reinforce(
+            resource_id=resource.id, memory_type="knowledge",
+            summary="the alpha fact about widgets",
+            embedding=self.EMB_SEED, user_data={},
+        )
+        assert _item_row_count(db_path) == 1, "seeding did not persist"
+        _vec_index_for(repo)  # make the cached entry searchable
+
+        _delete_row_externally(db_path, seeded.id)
+        assert _item_row_count(db_path) == 0, "external delete did not take"
+        # Precondition of the whole bug: the cache still serves the dead id.
+        assert seeded.id in repo.items
+
+        return repo, resource, db_path, seeded.id
+
+    def _reinforce_similar(self, repo, resource):
+        return repo.create_item_reinforce(
+            resource_id=resource.id, memory_type="knowledge",
+            summary="alpha fact regarding widgets",
+            embedding=self.EMB_SIMILAR, user_data={},
+        )
+
+    def test_a_stale_cache_hit_creates_a_new_persisted_row(self, tmp_path):
+        repo, resource, db_path, dead_id = self._seed_then_delete_externally(
+            tmp_path, "stale-creates",
+        )
+
+        returned = self._reinforce_similar(repo, resource)
+
+        assert returned.id != dead_id, (
+            "returned the deleted id -- the ghost reinforce is back"
+        )
+        assert (returned.extra or {}).get("reinforcement_count", 1) == 1, (
+            "reinforcement_count > 1 makes memu/app/memorize.py:614 skip "
+            "creation and category linking, silently dropping the memory"
+        )
+        assert _item_row_count(db_path) == 1, "the memory was not stored"
+
+    def test_a_stale_cache_hit_evicts_the_cache_and_index_entry(self, tmp_path):
+        from nerve.memory.memu_bridge import _vec_index_for
+
+        repo, resource, db_path, dead_id = self._seed_then_delete_externally(
+            tmp_path, "stale-evicts",
+        )
+
+        self._reinforce_similar(repo, resource)
+
+        assert dead_id not in repo.items, "stale cache entry survived"
+        assert dead_id not in _vec_index_for(repo).id_to_row, (
+            "stale vector-index entry survived -- still a dedup magnet"
+        )
+        assert dead_id not in repo.list_items(), (
+            "list_items() still serves the deleted id"
+        )
+
+    def test_the_returned_item_is_never_a_row_that_does_not_exist(self, tmp_path):
+        """The invariant, stated directly."""
+        repo, resource, db_path, _dead_id = self._seed_then_delete_externally(
+            tmp_path, "stale-invariant",
+        )
+
+        returned = self._reinforce_similar(repo, resource)
+
+        assert _item_extra_in_db(db_path, returned.id) is not None, (
+            f"returned item {returned.id} has no row in the database"
+        )
+
+    def test_reinforce_still_dedups_when_the_row_exists(self, tmp_path):
+        """Control: the row-present path must be completely untouched."""
+        from nerve.memory.memu_bridge import _vec_index_for
+
+        store, resource, db_path = _semantic_reinforce_store(tmp_path, "row-present")
+        repo = store.memory_item_repo
+
+        seeded = repo.create_item_reinforce(
+            resource_id=resource.id, memory_type="knowledge",
+            summary="the alpha fact about widgets",
+            embedding=self.EMB_SEED, user_data={},
+        )
+        _vec_index_for(repo)
+
+        returned = self._reinforce_similar(repo, resource)
+
+        assert returned.id == seeded.id, "semantic dedup stopped deduplicating"
+        assert (returned.extra or {}).get("reinforcement_count") == 2
+        assert _item_row_count(db_path) == 1, "dedup created a duplicate row"
+        # The bump must be PERSISTED, not merely cached.
+        db_extra = _item_extra_in_db(db_path, seeded.id)
+        assert db_extra["reinforcement_count"] == 2, (
+            "the reinforcement bump was not written to the database"
+        )
+        assert "last_reinforced_at" in db_extra

--- a/tests/test_memu_bridge.py
+++ b/tests/test_memu_bridge.py
@@ -1153,8 +1153,8 @@ def _semantic_reinforce_store(tmp_path, name, *, _models_cache={}):
     from memu.database.sqlite.sqlite import SQLiteStore
     from pydantic import BaseModel as _PydBaseModel
 
-    MemUBridge._patch_sqlite_bugs()
     if "models" not in _models_cache:
+        MemUBridge._patch_sqlite_bugs()
         _models_cache["models"] = schema_mod.get_sqlite_sqlalchemy_models(
             scope_model=_PydBaseModel,
         )
@@ -1199,21 +1199,8 @@ def _delete_row_externally(db_path, item_id):
 
 
 class TestSemanticReinforceStaleCacheHit:
-    """A semantic-dedup cache hit whose DB row was deleted by another process
-    used to be reported as "reinforced" while nothing was persisted.
-
-    ``_semantic_sqlite_reinforce`` decided from the in-memory cache but wrote to
-    the DB, and its ``return matched`` sat OUTSIDE the ``if row:`` write guard.
-    So a cross-connection delete produced an item with
-    ``reinforcement_count == 2`` for a row that no longer existed, and memU's
-    pipeline (``memu/app/memorize.py:614``:
-    ``if reinforce and item.extra.get("reinforcement_count", 1) > 1: continue``)
-    reads that as "already persisted" and skips both creation and category
-    linking -- silently dropping the memory, with no exception and no log.
-
-    Worse, the stale cache entry was not evicted, so it stayed a dedup magnet:
-    every later semantically-similar memorize kept matching it and kept being
-    dropped.
+    """A semantic-dedup hit on a row another process deleted must evict the stale
+    cache/index entry and actually persist the memory, not report a ghost.
     """
 
     # Cosine ~0.999 between the two, i.e. far above _SEMANTIC_DEDUP_THRESHOLD,

--- a/tests/test_memu_bridge.py
+++ b/tests/test_memu_bridge.py
@@ -1267,7 +1267,10 @@ class TestSemanticReinforceStaleCacheHit:
         assert _item_row_count(db_path) == 1, "the memory was not stored"
 
     def test_a_stale_cache_hit_evicts_the_cache_and_index_entry(self, tmp_path):
-        from nerve.memory.memu_bridge import _vec_index_for
+        # _vec_index_note, NOT _vec_index_for: the latter REBUILDS whenever it
+        # sees the cache size drift, which silently repairs a missing
+        # idx.remove() and would make this assertion vacuous.
+        from nerve.memory.memu_bridge import _vec_index_note
 
         repo, resource, db_path, dead_id = self._seed_then_delete_externally(
             tmp_path, "stale-evicts",
@@ -1276,12 +1279,42 @@ class TestSemanticReinforceStaleCacheHit:
         self._reinforce_similar(repo, resource)
 
         assert dead_id not in repo.items, "stale cache entry survived"
-        assert dead_id not in _vec_index_for(repo).id_to_row, (
+        index = _vec_index_note(repo)
+        assert index is not None, "the vector index was never built"
+        assert dead_id not in index.id_to_row, (
             "stale vector-index entry survived -- still a dedup magnet"
         )
         assert dead_id not in repo.list_items(), (
             "list_items() still serves the deleted id"
         )
+
+    def test_after_a_stale_hit_the_new_item_is_visible_to_later_dedup(self, tmp_path):
+        """The eviction must leave the index in a REBUILDABLE state.
+
+        ``_vec_index_for`` rebuilds only when ``seen_items_len`` differs from
+        ``len(items)``. Evicting without resyncing ``seen_items_len`` leaves
+        them equal (1 == 1) while the index itself is empty, so no rebuild ever
+        fires and the item created by the fall-through stays invisible to
+        semantic dedup for the rest of the process -- turning one silent drop
+        into permanently duplicated memories.
+        """
+        repo, resource, db_path, _dead_id = self._seed_then_delete_externally(
+            tmp_path, "stale-then-visible",
+        )
+
+        created = self._reinforce_similar(repo, resource)
+
+        # A third, still-similar memorize must dedup ONTO the new item.
+        third = repo.create_item_reinforce(
+            resource_id=resource.id, memory_type="knowledge",
+            summary="alpha facts on widgets now",
+            embedding=[0.998, 0.0632, 0.0, 0.0], user_data={},
+        )
+
+        assert third.id == created.id, (
+            "the item created after a stale hit is invisible to semantic dedup"
+        )
+        assert _item_row_count(db_path) == 1, "dedup created a duplicate row"
 
     def test_the_returned_item_is_never_a_row_that_does_not_exist(self, tmp_path):
         """The invariant, stated directly."""


### PR DESCRIPTION
## Problem

`MemUBridge._patch_sqlite_bugs()`'s `_semantic_sqlite_reinforce` decides from the
in-memory cache but writes to the database, and its `return matched` sat
**outside** the `if row:` write guard. If another process deleted the matched row,
the lookup returned `None`, the write was correctly skipped, and the cached object's
`reinforcement_count` was still bumped and returned.

memU reads that as "already persisted" (`memu/app/memorize.py:614`: `if reinforce
and item.extra.get("reinforcement_count", 1) > 1: continue`) and skips creation and
category linking, so the memory is **silently dropped**, nothing raised or logged,
and the un-evicted stale entry stayed a dedup magnet swallowing every later similar
`memorize`.

Measured at `main` (`94406ea`), reinforcing similar text after deleting the row over
a second connection: returned id **==** the deleted id, count **2**, rows in DB
**0**, dead id still served by `repo.items`, the index and `list_items()`.

## Fix

An absent row is a cache-invalidation signal, not an authoritative match. Track
whether the write committed; on the stale path evict from `self.items` and the vector
index (resyncing `seen_items_len`, the two operations `_indexed_delete_item` performs)
and fall through to the real `create_item_reinforce`, which creates and returns a
persisted row. The success early-return now sits inside the row-present branch, so it
fires only when something was written. The index handle is bound once for `search`
and `remove`, since `_vec_index_for` rebuilds on cache-size drift and re-fetching it
after the pop would force an O(n) rebuild on a write path.

`_semantic_inmemory_reinforce` has the same shape but is unreachable (provider
hardcoded to `sqlite`), so it is unchanged. The dangling `memu_category_items` row is
the external deleter's, out of scope here.

## Tests

`TestSemanticReinforceStaleCacheHit` in `tests/test_memu_bridge.py` (5 cases): a
stale hit creates a new persisted row; cache **and** index entries are evicted; the
returned item is always `SELECT`-able; the new item stays visible to later dedup;
plus a row-present control, byte-identical on both trees.

The 4 stale-path tests **fail** at `main`, **pass** with the fix. Whole repo suite
**7 failed / 2938 passed** vs **7 / 2933** at `main`: failure sets identical by name
(all pre-existing), passes `+5` = exactly the new tests. Six mutants are each killed
by a new test; two initially survived and the tests were strengthened. Both `ruff`
findings here are byte-identical at `main`; `memu_bridge.py` is ruff-clean.

Third commit, test hygiene only. The helper called `_patch_sqlite_bugs()` per test,
and 8 of the 17 attributes it reassigns wrap the value they replace, none guarded, so
the `create_item_reinforce` chain reached **6** deep for the rest of the pytest
process. Moving the call into the existing `_models_cache` memo takes it to **2**,
patch still installed. No production guard is added: `:1028` asserts unconditional
re-wrapping.
