### PR TITLE
Derive task_write's deadline column from the content it wrote

### DIFF
--- a/nerve/agent/tools/handlers/tasks.py
+++ b/nerve/agent/tools/handlers/tasks.py
@@ -429,7 +429,9 @@ async def task_write_handler(ctx: ToolContext, args: dict) -> ToolResult:
     )
     new_title = parse_task_title(new_content) or task["title"]
     frontmatter = parse_task_frontmatter(new_content)
-    new_deadline = frontmatter.get("deadline", task.get("deadline", ""))
+    # The deadline column is a pure projection of the file's Deadline line, so it
+    # comes from the content we just wrote, never from the pre-write snapshot.
+    new_deadline = frontmatter.get("deadline", "")
     new_tags = tags_to_string(parse_tags_string(frontmatter.get("tags", task.get("tags", ""))))
 
     await ctx.db.upsert_task(

--- a/tests/test_task_write_deadline.py
+++ b/tests/test_task_write_deadline.py
@@ -1,0 +1,180 @@
+"""``task_write`` must derive the ``deadline`` column from the content it wrote.
+
+``task_write`` overwrites a task's markdown file and then re-syncs the DB row.
+The ``deadline`` column is a pure projection of the file's ``**Deadline:**``
+line: it has exactly one SQL writer (the ``upsert_task`` INSERT) and no
+row-only setter, unlike ``status`` and ``tags`` which each have a dedicated
+``update_task_*`` method. So there is no row state to preserve for it -- only a
+file to agree with.
+
+The handler used to fall back to a snapshot taken *before* the file was
+replaced, which made the row assert a deadline the file it had just written
+denied: a concurrent writer's value was dropped, and a deliberately cleared
+deadline was resurrected. ``escalation.py`` reads that column, so a stale row
+escalates on a date nothing asks for.
+
+The rival writer here commits strictly *inside* the handler's snapshot ->
+upsert window, via a one-shot wrapper on ``db.get_task``. Each test asserts the
+hook fired and the rival's write was committed before asserting anything about
+the outcome -- a rival that lands before the snapshot is read cannot expose the
+bug at all, so without those assertions the tests would pass vacuously.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nerve.agent.tools.handlers import tasks as task_handlers
+from nerve.agent.tools.registry import ToolContext
+from nerve.db import Database
+from nerve.tasks.manager import TaskManager
+from nerve.tasks.models import parse_task_frontmatter
+
+TASK_ID = "t1"
+REL_PATH = f"memory/tasks/active/{TASK_ID}.md"
+
+WITH_DEADLINE = "# T1\n\n**Tags:** urgent\n**Deadline:** 2030-01-01\n\nbody\n"
+NO_DEADLINE_LINE = "# T1\n\n**Tags:** urgent\n\nbody edited\n"
+STATES_DEADLINE = "# T1\n\n**Tags:** urgent\n**Deadline:** 2030-01-01\n\nbody edited\n"
+
+RIVAL_DEADLINE = "2030-06-30"
+RIVAL_CONTENT = WITH_DEADLINE.replace("2030-01-01", RIVAL_DEADLINE)
+CLEARED_CONTENT = WITH_DEADLINE.replace("**Deadline:** 2030-01-01\n", "")
+
+
+async def _seed(tmp_path, db, monkeypatch):
+    """Workspace + row holding ``2030-01-01``, ready for ``task_write``."""
+    workspace = tmp_path / "ws"
+    (workspace / "memory" / "tasks" / "active").mkdir(parents=True)
+    (workspace / "memory" / "tasks" / "done").mkdir(parents=True)
+    (workspace / REL_PATH).write_text(WITH_DEADLINE, encoding="utf-8")
+    await db.upsert_task(
+        task_id=TASK_ID, file_path=REL_PATH, title="T1", status="in_progress",
+        deadline="2030-01-01", tags="urgent", content=WITH_DEADLINE,
+    )
+    monkeypatch.setattr(task_handlers, "_tasks_read", {TASK_ID})
+    return workspace, ToolContext(session_id="test", db=db, workspace=workspace)
+
+
+def _arm_rival(db, workspace, *, clear: bool):
+    """Fire one rival write right after the handler reads its snapshot.
+
+    Returns a dict the caller must check: ``fired`` proves the hook ran (so the
+    rival really is inside the window) and ``committed`` proves the rival's
+    write reached the DB.
+    """
+    state: dict[str, object] = {"fired": False, "committed": "<never>"}
+    original_get_task = db.get_task
+
+    async def hooked(task_id):
+        row = await original_get_task(task_id)
+        if not state["fired"]:
+            state["fired"] = True
+            content = CLEARED_CONTENT if clear else RIVAL_CONTENT
+            (workspace / REL_PATH).write_text(content, encoding="utf-8")
+            await db.upsert_task(
+                task_id=TASK_ID, file_path=REL_PATH, title="T1",
+                status="in_progress", tags="urgent",
+                deadline=None if clear else RIVAL_DEADLINE, content=content,
+            )
+            state["committed"] = (await original_get_task(TASK_ID))["deadline"]
+        return row
+
+    db.get_task = hooked
+    return state
+
+
+def _assert_rival_landed(state, *, clear: bool):
+    assert state["fired"], "harness: the get_task hook never fired"
+    expected = None if clear else RIVAL_DEADLINE
+    assert state["committed"] == expected, (
+        f"harness: rival did not commit ({state['committed']!r} != {expected!r})"
+    )
+
+
+async def _reindex_oracle(tmp_path, db_path_name, workspace):
+    """What the indexer derives from the file, i.e. the authoritative answer."""
+    oracle_db = Database(tmp_path / db_path_name, workspace=workspace)
+    await oracle_db.connect()
+    try:
+        await TaskManager(workspace, oracle_db).reindex()
+        row = await oracle_db.get_task(TASK_ID)
+        return row["deadline"] if row else None
+    finally:
+        await oracle_db.close()
+
+
+@pytest.mark.asyncio
+async def test_rival_moves_the_deadline_and_content_omits_the_line(tmp_path, db, monkeypatch):
+    """Content is silent about the deadline, so the row must be silent too."""
+    workspace, ctx = await _seed(tmp_path, db, monkeypatch)
+    state = _arm_rival(db, workspace, clear=False)
+
+    await task_handlers.task_write_handler(
+        ctx, {"task_id": TASK_ID, "content": NO_DEADLINE_LINE},
+    )
+    _assert_rival_landed(state, clear=False)
+
+    written = (workspace / REL_PATH).read_text(encoding="utf-8")
+    assert written == NO_DEADLINE_LINE
+    assert parse_task_frontmatter(written).get("deadline") is None
+    row = await db.get_task(TASK_ID)
+    # The stale snapshot value must not survive as the row's answer.
+    assert row["deadline"] is None
+    assert row["deadline"] == await _reindex_oracle(tmp_path, "oracle1.db", workspace)
+
+
+@pytest.mark.asyncio
+async def test_rival_clears_the_deadline_and_content_omits_the_line(tmp_path, db, monkeypatch):
+    """A deliberately cleared deadline must not be resurrected."""
+    workspace, ctx = await _seed(tmp_path, db, monkeypatch)
+    state = _arm_rival(db, workspace, clear=True)
+
+    await task_handlers.task_write_handler(
+        ctx, {"task_id": TASK_ID, "content": NO_DEADLINE_LINE},
+    )
+    _assert_rival_landed(state, clear=True)
+
+    row = await db.get_task(TASK_ID)
+    assert row["deadline"] is None
+    assert row["deadline"] == await _reindex_oracle(tmp_path, "oracle2.db", workspace)
+
+
+@pytest.mark.asyncio
+async def test_content_that_states_a_deadline_still_wins(tmp_path, db, monkeypatch):
+    """Unchanged behaviour: a stated deadline is written even against a rival.
+
+    This case already passed before the fix -- it pins that the change did not
+    turn the content-derived path into a clear.
+    """
+    workspace, ctx = await _seed(tmp_path, db, monkeypatch)
+    state = _arm_rival(db, workspace, clear=False)
+
+    await task_handlers.task_write_handler(
+        ctx, {"task_id": TASK_ID, "content": STATES_DEADLINE},
+    )
+    _assert_rival_landed(state, clear=False)
+
+    row = await db.get_task(TASK_ID)
+    assert row["deadline"] == "2030-01-01"
+    assert row["deadline"] == await _reindex_oracle(tmp_path, "oracle3.db", workspace)
+
+
+@pytest.mark.asyncio
+async def test_dropping_the_deadline_line_clears_the_column(tmp_path, db, monkeypatch):
+    """Single-threaded observable change: no line in the content -> no deadline.
+
+    Previously the column kept its old value even though the file no longer
+    stated one, leaving the row disagreeing with the file. The value is not
+    lost destructively: the file is authoritative and a reindex reproduces
+    whatever the file says, which is what the oracle below asserts.
+    """
+    workspace, ctx = await _seed(tmp_path, db, monkeypatch)
+
+    await task_handlers.task_write_handler(
+        ctx, {"task_id": TASK_ID, "content": NO_DEADLINE_LINE},
+    )
+
+    row = await db.get_task(TASK_ID)
+    assert row["deadline"] is None
+    assert row["deadline"] == await _reindex_oracle(tmp_path, "oracle4.db", workspace)


### PR DESCRIPTION
### Description

`task_write` overwrites a task's markdown file and then re-syncs the DB row, but it took
the `deadline` from a snapshot read *before* the file was replaced. Content carrying no
`**Deadline:**` line kept the snapshot value, so the row asserted a deadline the file it
had just written denied.

**Root cause.** That column is a pure projection of the `**Deadline:**` line. It has
exactly one SQL writer (the `upsert_task` INSERT) and no row-only setter, unlike `status`
and `tags`, which each have a dedicated `update_task_*` method. So no row state exists to
preserve for it, only a file to agree with.

**Effects**, with a concurrent writer committing inside the handler's snapshot-to-upsert
window: a deadline it set was dropped, and one it deliberately *cleared* was resurrected.
`escalation.py` reads this column, so a stale row escalates on a date nothing asks for.

**The change** takes the value from the content, removing the only stale read. No new
sentinel, signature, SQL or schema change: the existing `deadline=new_deadline or None`
already writes NULL when the file states nothing.

**Observable change:** a `task_write` whose content omits `**Deadline:**` now clears the
column, so `escalation.py` stops reminding on that task until a `**Deadline:**` line comes
back. Nothing is lost destructively: the file is authoritative, and `TaskManager.reindex`
derives the same value from it. (That indexer has no production caller today; it is cited
as the file-to-row definition, not a live path.) No test pinned the old behaviour.

**Validation.** Base arm (source reverted, tests kept) fails the three intended
assertions; fixed arm passes 4. Full suite 7 failed / 2937 passed, failure name set
identical to the 7 pre-existing failures at this base. `ruff` clean.

**Not closed here:** the PATCH route in `routes/tasks.py` carries the same snapshot echo
on the same argument, and the file/DB pair is still not atomic.

<details>
<summary>Test design and mutation matrix</summary>

The regression test drives the real handler with a one-shot wrapper on `db.get_task` that
fires the rival writer inside the window, and asserts both that the hook fired and that
the rival's write committed before asserting any outcome. A rival landing before the
snapshot is read cannot expose the bug, so without those guards the two concurrency cases
degenerate into duplicates of the single-threaded case and pass vacuously, verified by
neutering the rival with both guards removed, which turns the suite green.

Mutation matrix, unmutated control at both ends of every run, each mutant asserting it
applied before the suite runs:

| mutant | verdict |
|---|---|
| revert the line to the snapshot fallback | KILLED (exactly the 3 intended tests) |
| drop the `""` default | SURVIVED, a proven no-op: one consumer, and `or None` maps `""` and `None` identically in every content shape (no line / set / empty / whitespace / no frontmatter) |
| delete the hook-fired assertion | survives on the fixed tree (it is a vacuity guard, not a discriminator); killed against the base tree, and the paired "rival committed" assertion still catches a neutered rival |

Four cases: rival moves the deadline, rival clears it, content states a deadline
(unchanged behaviour, passes before the fix), and the single-threaded observable change.
Each asserts the row against a real `TaskManager.reindex()` oracle rather than a
hand-computed expectation.

</details>
