### PR TITLE
Flag task_update refusals with is_error so callers can detect them

### DIFF
--- a/nerve/agent/tools/handlers/tasks.py
+++ b/nerve/agent/tools/handlers/tasks.py
@@ -284,7 +284,7 @@ async def task_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
     if status:
         err = await _validate_status(ctx, status)
         if err:
-            return ToolResult.text(err)
+            return ToolResult.text(err, is_error=True)
 
     # Route done transitions through task_done to ensure file move + FTS sync
     if status == TERMINAL_STATUS:
@@ -293,7 +293,7 @@ async def task_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
     if ctx.db:
         task = await ctx.db.get_task(task_id)
         if not task:
-            return ToolResult.text(f"Task not found: {task_id}")
+            return ToolResult.text(f"Task not found: {task_id}", is_error=True)
 
         new_tags_str = ""
         if raw_tags:
@@ -454,7 +454,7 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
     if ctx.db:
         task = await ctx.db.get_task(task_id)
         if not task:
-            return ToolResult.text(f"Task not found: {task_id}")
+            return ToolResult.text(f"Task not found: {task_id}", is_error=True)
 
         # Done is a write like any other — it copies the file into done/ and
         # unlinks the source, so a stored ``file_path`` inside the tracked config

--- a/tests/test_task_statuses.py
+++ b/tests/test_task_statuses.py
@@ -133,9 +133,41 @@ class TestStatusToolHandlers:
         await task_create_handler(ctx, {"title": "Some task", "content": "x"})
         task_id = (await db.list_tasks(status="all"))[0]["id"]
         result = await task_update_handler(ctx, {"task_id": task_id, "status": "nope"})
+        # Text is the model-facing reminder and must not move.
         assert "Invalid task status: 'nope'" in _text(result)
+        # is_error is the only field a programmatic caller can test.
+        assert result.is_error is True
         # Status unchanged.
         assert (await db.get_task(task_id))["status"] == "pending"
+
+    async def test_update_missing_task_is_flagged(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        result = await task_update_handler(
+            ctx, {"task_id": "no-such-task", "status": "in_progress", "note": "n"},
+        )
+        assert "Task not found: no-such-task" in _text(result)
+        assert result.is_error is True
+
+    async def test_update_missing_task_done_routed_is_flagged(
+        self, db: Database, tmp_path,
+    ):
+        # status == "done" delegates to task_done_handler, a separate return site.
+        ctx = self._ctx(db, tmp_path)
+        result = await task_update_handler(
+            ctx, {"task_id": "no-such-task", "status": "done", "note": "n"},
+        )
+        assert "Task not found: no-such-task" in _text(result)
+        assert result.is_error is True
+
+    async def test_update_success_is_not_flagged(self, db: Database, tmp_path):
+        ctx = self._ctx(db, tmp_path)
+        await task_create_handler(ctx, {"title": "Happy path", "content": "x"})
+        task_id = (await db.list_tasks(status="all"))[0]["id"]
+        result = await task_update_handler(
+            ctx, {"task_id": task_id, "status": "in_progress"},
+        )
+        assert result.is_error is False
+        assert (await db.get_task(task_id))["status"] == "in_progress"
 
     async def test_update_accepts_valid_status(self, db: Database, tmp_path):
         ctx = self._ctx(db, tmp_path)


### PR DESCRIPTION
## Symptom

`task_update_handler` reports two refusals by **returning** a `ToolResult` rather than raising: an unconfigured status (via `_validate_status`) and a task row that does not exist. Both used `ToolResult.text(...)`, whose `is_error` defaults to `False` (`registry.py:77`), and `ToolRegistry.invoke` does not wrap handlers. So a refusal was indistinguishable from a success on the only machine-readable field a caller has; only string-matching prose could tell them apart. Six call sites discard the result entirely. Both early returns also precede the file write, so the note is lost too.

Reachability is narrow but real: `in_progress` is seeded `is_system=0` and so is deletable, and the missing-task branch needs no config change at all.

## Root cause

`ToolResult` is the model-facing return type. On the agent-loop path a refusal must come back as readable text so the model can self-correct, and `_validate_status` returns a reminder listing the valid statuses. The handler was written for that path only, and `is_error`, the one field carrying "this did not happen" across the boundary, was left at its default.

## Fix

Set `is_error=True` on the three refusal returns in `nerve/agent/tools/handlers/tasks.py`: the unconfigured-status and missing-task returns in `task_update_handler`, and the missing-task return in `task_done_handler`, which `task_update` reaches by delegation when `status == "done"`. Without that third site the flag would be absent for exactly one status. `+3/-3`, one production file.

Raising would have been wrong, since neither refusal is a programmer error. `is_error=True` on a refusal is already the convention here (32 sites across five sibling handler modules). The flag is orthogonal to the text on all three surfaces (`to_dict`, the MCP server's `isError=`, the SDK adapter), so the agent loop keeps reading the reminder verbatim.

**No programmatic caller acts on the flag yet**, so the refused mutation itself is unchanged. The flag does reach the agent loop, where a refusal now records `success=0` in its MCP-usage row (`engine.py:1645`) and renders as an error in the chat UI -- both of which it should. The `PATCH /api/tasks` ordering and the plan-approval boundary are tracked separately and are not addressed here.

## Tests

The existing unconfigured-status test gains an `is_error` assertion and **keeps** its text assertion, which pins the agent-loop contract and would catch a "fix" that flagged by replacing the reminder. Three tests are added: missing task, done-routed missing task, and a success control that must stay unflagged.

Each refusal test fails when its own single token is reverted, and in the `task_done_handler` revert arm the other two still pass, so each test isolates the carrier it names. Full suite compared by sorted FAILED-name sets: identical to `main` (7 pre-existing failures, in two files neither touched here), `+3` passed. `ruff` clean.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*
