### PR TITLE
tests: pin the pre-recall prompt-cache freeze

### DIFF
--- a/tests/test_engine_backend_selection.py
+++ b/tests/test_engine_backend_selection.py
@@ -252,6 +252,104 @@ class TestResumeDroppedEnginePath:
         assert session.get("backend") == "codex"
 
 
+class TestPreRecallFreeze:
+    """The first successful pre-recall is persisted to session metadata and
+    reused verbatim on every later rebuild instead of re-recalled."""
+
+    @pytest.mark.asyncio
+    async def test_first_recall_is_frozen_and_reused_on_rebuild(
+        self, tmp_path, db,
+    ):
+        """Phase A pins the metadata write; phase B pins that a rebuild
+        renders the stored priors, not a fresh recall."""
+        import json
+        from unittest.mock import AsyncMock, MagicMock
+
+        from nerve.agent.backends.base import BackendCapabilities
+
+        first = ["prior-alpha-9f1", "prior-beta-9f2"]
+        second = ["rearmed-gamma-7c1", "rearmed-delta-7c2"]
+
+        engine = _engine(tmp_path, db)
+        await db.create_session("s-freeze", source="web", backend="codex")
+
+        bridge = MagicMock(available=True)
+        bridge.recall = AsyncMock(
+            return_value=[{"summary": m} for m in first],
+        )
+        engine._memory_bridge = bridge
+
+        prompts: list[str] = []
+
+        class StubClient:
+            model = "gpt-5.6-sol"
+
+            def is_alive(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+        class StubBackend:
+            name = "codex"
+            capabilities = BackendCapabilities(
+                cost_is_cumulative=False,
+                supports_idle_stream=False,
+                supports_cache_ttl=False,
+                interactive_builtins=False,
+                reports_context_window=True,
+            )
+
+            def default_model(self, source):
+                return "gpt-5.6-sol"
+
+            def excluded_tools(self):
+                return set()
+
+            def validate_resume_target(self, native_id, cwd):
+                return True
+
+            async def create_client(self, spec):
+                prompts.append(spec.system_prompt)
+                return StubClient()
+
+        engine._backends["codex"] = StubBackend()
+
+        # Phase A: the write under test.
+        await engine._get_or_create_client("s-freeze", "web", None)
+        session = await db.get_session("s-freeze")
+        meta = json.loads(session.get("metadata") or "{}")
+        assert meta.get("recalled_memories") == first, meta
+        assert len(prompts) == 1
+        for m in first:
+            assert f"- {m}" in prompts[0]
+
+        # Phase B: evict the cached client so the rebuild re-enters the
+        # freeze block (a live client returns before metadata is parsed),
+        # and rearm recall so a live re-recall would be visible.
+        engine.sessions.remove_client("s-freeze")
+        bridge.recall.return_value = [{"summary": m} for m in second]
+
+        await engine._get_or_create_client("s-freeze", "web", None)
+
+        # Precondition: the rebuild really happened.
+        assert len(prompts) == 2, prompts
+        # The frozen priors are what the second prompt carries.
+        for m in first:
+            assert f"- {m}" in prompts[1]
+        for m in second:
+            assert m not in prompts[1]
+        # Verbatim means byte-identical: order and multiplicity are prompt
+        # bytes (prompts.py:167), and byte-identity is the cache property.
+        assert prompts[1] == prompts[0]
+        # Corroborating: nothing re-recalled, nothing overwrote the store.
+        assert bridge.recall.await_count == 1
+        after = await db.get_session("s-freeze")
+        assert json.loads(after.get("metadata") or "{}").get(
+            "recalled_memories",
+        ) == first
+
+
 class TestCreateSessionRoute:
     """POST /api/sessions with the new-chat backend selector's param."""
 


### PR DESCRIPTION
## Symptom

`AgentEngine._get_or_create_client` freezes a session's first successful pre-recall
(`engine.py:1149`) so every later rebuild renders a byte-identical system prompt and hits
the prompt cache. **Nothing tested it, in either direction:**

```
git grep -c 'recalled_memories' origin/main -- tests/   # 0 hits, any test file
git grep -c 'meta_updates'      origin/main -- tests/   # 0
git show origin/main:tests/test_prompts.py | grep -c recalled_memories   # 0
```

Delete `engine.py:1149` and the whole suite stays green. Nothing else re-derives the value,
so the regression is silent: every rebuild re-recalls live, a session's priors drift, and
the cache hit the freeze exists to buy is gone with no test failing.

## Root cause of the gap

The freeze's payoff is a cross-rebuild property. Dropping the write leaves an observably
identical first turn; the loss only shows on a *later rebuild of the same session*. No
existing test spanned two rebuilds, so the line entered the tree untested.

## Fix

Test-only, insert-only: one class in the file that already drives `_get_or_create_client`
end to end against the real `db` fixture with a local stub backend. No production line
changes and no new seam - the stub's `create_client` just keeps the `SessionSpec` it is
already handed.

* **Phase A** - first call, recall returns `P1`: metadata holds `recalled_memories == P1`,
  and the rendered system prompt carries each prior of `P1` (`prompts.py:166-168`), which was
  unpinned in `tests/` *and* in `test_prompts.py`.
* **Phase B** - evict the client (`sessions.remove_client`), rearm recall to `P2`, call
  again: assert the rebuild really happened (a live client returns at `engine.py:1077`
  *before* metadata is parsed, so without this precondition the arm is vacuous), the second
  prompt carries `P1` and no `P2`, and `recall.await_count == 1`.

## Tests

Coverage-only, so discrimination is the deliverable: eight mutants, each killed, each arm
asserting the mutation applied and restoring the tree afterwards, with the unmutated control
green at both ends. The metadata check, the first-prompt check and the second-prompt check
each uniquely kill a different mutant, so no assertion is decoration. Byte-identity is
the only check that sees order and multiplicity: reversing or doubling the frozen list
passes every other assertion, and both mutants survive without it.

<details>
<summary>Mutation matrix</summary>

| mutant | result |
|---|---|
| delete `engine.py:1149` | **FAIL** (phase A metadata) |
| `frozen_recall = None` - rebuild re-recalls | **FAIL** (phase B: prompt carried `P2`) |
| freeze the wrong value (`= []`) | **FAIL** (phase A) |
| render call drops the priors (`recalled_memories=None`) | **FAIL** (phase A prompt only) |
| frozen-read branch reads then discards | **FAIL** (phase B prompt only) |
| eviction removed from the test | **FAIL loudly** at the precondition (`1 == 2`), not a silent pass |
| frozen list reversed (order) | **FAIL** (phase B byte-identity only; survives without it) |
| frozen list doubled (multiplicity) | **FAIL** (phase B byte-identity only; survives without it) |

</details>

Target file 20 -> 21 passed. Full suite compared **by failure name**: 7 failed / 2933 passed
-> 7 failed / 2934 passed, the two sorted name sets byte-identical (all 7 pre-existing, none
in a file this touches). New test 20/20 stable.

No related open issue found.
