### PR TITLE
[4/7] Add a Kanban board view for tasks

### DIFF
--- a/nerve/gateway/routes/tasks.py
+++ b/nerve/gateway/routes/tasks.py
@@ -130,6 +130,7 @@ async def search_tasks(q: str, status: str = "", user: dict = Depends(require_au
 async def task_board(
     limit: int = _BOARD_LANE_LIMIT,
     tag: str = "",
+    q: str = "",
     user: dict = Depends(require_auth),
 ):
     """Every lane in one round trip: statuses + their ordered tasks.
@@ -139,15 +140,25 @@ async def task_board(
     keeps the lanes consistent with each other (a task that moves mid-load
     can't appear in two lanes or neither) and keeps the client from having
     to know the status list before it can start fetching.
+
+    ``q`` searches server-side, per lane. It has to happen here rather than
+    as a client-side filter over the loaded cards: a lane is paginated, so
+    filtering what the client holds would silently miss matches deeper in
+    the lane and report "no results" for tasks that exist. Hits keep their
+    lane order rather than FTS relevance order — the board is spatial, and
+    reordering cards under a search would move them away from where the
+    person looking already knows they are.
     """
     deps = get_deps()
     limit = max(1, min(limit, 200))
     tag_filter = tag.strip().lower() or None
 
+    query = q.strip()
+
     statuses = await deps.db.list_task_statuses()
-    # One GROUP BY covers every lane's total; only a tag filter (which the
-    # grouped count can't express) needs the per-lane fallback.
-    counts = {} if tag_filter else await deps.db.count_tasks_by_status()
+    # One GROUP BY covers every lane's total; a tag filter (which the grouped
+    # count can't express) or a search needs the per-lane path instead.
+    counts = {} if (tag_filter or query) else await deps.db.count_tasks_by_status()
 
     lanes = []
     for status_def in statuses:
@@ -155,14 +166,24 @@ async def task_board(
         lane_limit = (
             min(limit, _BOARD_DONE_LANE_LIMIT) if name == TERMINAL_STATUS else limit
         )
-        tasks = await deps.db.list_tasks(
-            status=name, tag=tag_filter, sort="position", limit=lane_limit,
-        )
-        total = (
-            await deps.db.count_tasks(status=name, tag=tag_filter)
-            if tag_filter
-            else counts.get(name, 0)
-        )
+        if query:
+            tasks = await deps.db.search_tasks(
+                query=query, status=name, tag=tag_filter, limit=lane_limit,
+            )
+            # search_tasks ranks by relevance; the board wants lane order.
+            tasks.sort(key=lambda t: (t.get("position") or 0.0, t["id"]))
+            # No count query for a search: the lane holds every hit unless it
+            # hit the cap, in which case "+N more" would be a guess anyway.
+            total = len(tasks)
+        else:
+            tasks = await deps.db.list_tasks(
+                status=name, tag=tag_filter, sort="position", limit=lane_limit,
+            )
+            total = (
+                await deps.db.count_tasks(status=name, tag=tag_filter)
+                if tag_filter
+                else counts.get(name, 0)
+            )
         lanes.append({"status": name, "total": total, "tasks": tasks})
 
     return {"statuses": statuses, "lanes": lanes}

--- a/tests/test_task_board_api.py
+++ b/tests/test_task_board_api.py
@@ -132,6 +132,85 @@ class TestTaskBoardRoutes:
         tags = setup.client.get("/api/tasks/tags").json()
         assert "tags" in tags, "GET /api/tasks/tags resolved to the detail route"
 
+    # ── Board search ─────────────────────────────────────────────────────
+
+    async def test_board_search_filters_every_lane(self, setup):
+        await self._create(setup, "Fix the widget encoder")
+        await self._create(setup, "Unrelated chore")
+
+        body = setup.client.get("/api/tasks/board?q=encoder").json()
+        titles = [t["title"] for lane in body["lanes"] for t in lane["tasks"]]
+
+        assert titles == ["Fix the widget encoder"]
+
+    async def test_board_search_reports_matching_totals(self, setup):
+        await self._create(setup, "Fix the widget encoder")
+        await self._create(setup, "Unrelated chore")
+
+        body = setup.client.get("/api/tasks/board?q=encoder").json()
+        pending = next(l for l in body["lanes"] if l["status"] == "pending")
+
+        # A stale total would offer "+N more" for tasks the search excluded.
+        assert pending["total"] == 1
+
+    async def test_board_search_spans_lanes(self, setup):
+        keep = await self._create(setup, "Encoder work in progress")
+        setup.client.patch(f"/api/tasks/{keep}", json={"status": "in_progress"})
+        await self._create(setup, "Encoder work pending")
+
+        body = setup.client.get("/api/tasks/board?q=encoder").json()
+        by_lane = {l["status"]: len(l["tasks"]) for l in body["lanes"]}
+
+        # Search narrows lanes; it does not collapse them into one list.
+        assert by_lane["pending"] == 1
+        assert by_lane["in_progress"] == 1
+
+    async def test_board_search_keeps_lane_order_not_relevance_order(self, setup):
+        first = await self._create(setup, "Encoder alpha")
+        second = await self._create(setup, "Encoder beta")
+        # Put them in an order relevance ranking would not produce.
+        setup.client.post(f"/api/tasks/{second}/move", json={"before_id": first})
+
+        body = setup.client.get("/api/tasks/board?q=encoder").json()
+        pending = next(l for l in body["lanes"] if l["status"] == "pending")
+
+        assert [t["id"] for t in pending["tasks"]] == [first, second]
+
+    async def test_board_search_finds_a_task_beyond_the_lane_page(self, setup):
+        """Why this is server-side rather than a client-side filter.
+
+        The board holds one page per lane, so filtering what the client
+        already has would silently miss anything deeper and report no
+        results for a task that exists.
+        """
+        for i in range(4):
+            await self._create(setup, f"Filler task {i}")
+        await self._create(setup, "Buried encoder task")
+
+        body = setup.client.get("/api/tasks/board?limit=2&q=encoder").json()
+        titles = [t["title"] for lane in body["lanes"] for t in lane["tasks"]]
+
+        assert titles == ["Buried encoder task"]
+
+    async def test_board_search_with_no_matches_returns_empty_lanes(self, setup):
+        await self._create(setup, "Something else entirely")
+
+        body = setup.client.get("/api/tasks/board?q=nonexistentterm").json()
+
+        # Lanes still present, just empty — the client needs the columns to
+        # render its "no matches" state in the right shape.
+        assert body["lanes"]
+        assert all(len(l["tasks"]) == 0 for l in body["lanes"])
+
+    async def test_board_search_combines_with_a_tag_filter(self, setup):
+        await self._create(setup, "Encoder backend work", tags="backend")
+        await self._create(setup, "Encoder frontend work", tags="frontend")
+
+        body = setup.client.get("/api/tasks/board?q=encoder&tag=backend").json()
+        titles = [t["title"] for lane in body["lanes"] for t in lane["tasks"]]
+
+        assert titles == ["Encoder backend work"]
+
     # ── Tag facets ───────────────────────────────────────────────────────
 
     async def test_tags_endpoint_counts_and_ranks(self, setup):

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@pierre/diffs": "^1.2.7",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.575.0",
@@ -569,6 +572,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -6994,6 +7050,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@pierre/diffs": "^1.2.7",
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.575.0",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -367,9 +367,10 @@ export const api = {
     );
   },
   /** Every board lane in one round trip. */
-  getTaskBoard: (params?: { tag?: string; limit?: number }) => {
+  getTaskBoard: (params?: { tag?: string; limit?: number; q?: string }) => {
     const qs = new URLSearchParams();
     if (params?.tag) qs.set('tag', params.tag);
+    if (params?.q) qs.set('q', params.q);
     if (params?.limit !== undefined) qs.set('limit', String(params.limit));
     const q = qs.toString();
     return request<{

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10,6 +10,21 @@ export interface TaskStatusDef {
   created_at?: string;
 }
 
+export interface Task {
+  id: string;
+  title: string;
+  status: string;
+  deadline: string | null;
+  source: string;
+  source_url: string | null;
+  tags: string;
+  /** Board rank within its lane, ascending. Server-assigned. */
+  position: number;
+  created_at: string;
+  updated_at: string;
+  content?: string;
+}
+
 export interface UltracodeUsage {
   input_tokens?: number;
   cached_input_tokens?: number;
@@ -332,9 +347,10 @@ export const api = {
     }),
 
   // Tasks
-  listTasks: (params?: { status?: string; sort?: string; limit?: number; offset?: number }) => {
+  listTasks: (params?: { status?: string; tag?: string; sort?: string; limit?: number; offset?: number }) => {
     const qs = new URLSearchParams();
     if (params?.status) qs.set('status', params.status);
+    if (params?.tag) qs.set('tag', params.tag);
     if (params?.sort) qs.set('sort', params.sort);
     if (params?.limit !== undefined) qs.set('limit', String(params.limit));
     if (params?.offset !== undefined) qs.set('offset', String(params.offset));
@@ -350,11 +366,48 @@ export const api = {
       `/tasks/search?${qs}`,
     );
   },
+  /** Every board lane in one round trip. */
+  getTaskBoard: (params?: { tag?: string; limit?: number }) => {
+    const qs = new URLSearchParams();
+    if (params?.tag) qs.set('tag', params.tag);
+    if (params?.limit !== undefined) qs.set('limit', String(params.limit));
+    const q = qs.toString();
+    return request<{
+      statuses: TaskStatusDef[];
+      lanes: { status: string; total: number; tasks: Task[] }[];
+    }>(`/tasks/board${q ? '?' + q : ''}`);
+  },
+  listTaskTags: (includeDone = false) =>
+    request<{ tags: { name: string; count: number }[] }>(
+      `/tasks/tags${includeDone ? '?include_done=true' : ''}`,
+    ),
+  /**
+   * Move a task within or between lanes. Sends the neighbours it should
+   * land between rather than a rank — the server computes the ordering,
+   * so a board a few seconds stale can't write a conflicting position.
+   */
+  moveTask: (id: string, data: { status?: string; before_id?: string | null; after_id?: string | null }) =>
+    request<{ task: Task }>(`/tasks/${id}/move`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   getTask: (id: string) => request<any>(`/tasks/${id}`),
-  createTask: (data: { title: string; content?: string; deadline?: string }) =>
-    request<any>('/tasks', { method: 'POST', body: JSON.stringify(data) }),
-  updateTask: (id: string, data: { status?: string; note?: string; content?: string }) =>
-    request<any>(`/tasks/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  createTask: (data: {
+    title: string; content?: string; deadline?: string;
+    tags?: string; status?: string; confirm_duplicate?: boolean;
+  }) => request<{ task: Task; message: string }>('/tasks', {
+    method: 'POST', body: JSON.stringify(data),
+  }),
+  /**
+   * Partial update. Server reads `deadline` and `tags` by *presence*: omit
+   * the key to leave the field alone, pass '' to clear it.
+   */
+  updateTask: (id: string, data: {
+    status?: string; note?: string; content?: string; title?: string;
+    deadline?: string; tags?: string;
+  }) => request<{ task: Task; task_id: string; updated: boolean }>(`/tasks/${id}`, {
+    method: 'PATCH', body: JSON.stringify(data),
+  }),
 
   // Task statuses (configurable)
   listTaskStatuses: () =>

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -1,5 +1,5 @@
 import { getToken } from './client';
-import type { ReviewLoop, WorkflowRun } from './client';
+import type { ReviewLoop, Task, WorkflowRun } from './client';
 import type { WorkflowSnapshot } from '../types/chat';
 
 export type WSMessage =
@@ -35,6 +35,10 @@ export type WSMessage =
   | { type: 'workflow_progress'; session_id: string; tool_use_id: string; workflow: WorkflowSnapshot }
   | { type: 'workflow_run_update'; session_id: string | null; run: WorkflowRun }
   | { type: 'review_loop_update'; session_id: string | null; loop: ReviewLoop; message?: { role: string; content: string; channel?: string; created_at?: string } }
+  // Global (session_id is always null): a task row changed anywhere — the
+  // API, another tab, or the agent in an unrelated session. Deliberately
+  // NOT view-scoped; the board reflects all of them.
+  | { type: 'task_updated'; session_id: null; event: 'created' | 'updated' | 'moved' | 'done'; task: Task }
   | { type: 'wakeup'; session_id: string }
   | { type: 'auto_turn'; session_id: string }
   | { type: 'model_changed'; session_id: string; from_model: string; to_model: string; downgrade: boolean }

--- a/web/src/components/Tasks/Board/BoardCard.tsx
+++ b/web/src/components/Tasks/Board/BoardCard.tsx
@@ -1,0 +1,147 @@
+import { memo } from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Calendar, Clock, ExternalLink } from 'lucide-react';
+import type { Task } from '../../../api/client';
+import { formatTimeAgo } from '../../../utils/dateGroups';
+
+/**
+ * Deadline urgency, as a token class rather than a raw colour so it tracks
+ * the theme. Overdue and due-today are the two states worth interrupting
+ * someone for; anything further out is informational.
+ */
+function deadlineTone(deadline: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(`${deadline}T00:00:00`);
+  if (Number.isNaN(due.getTime())) return 'text-text-dim';
+  const days = Math.round((due.getTime() - today.getTime()) / 86_400_000);
+  if (days < 0) return 'text-hue-red';
+  if (days === 0) return 'text-hue-orange';
+  if (days <= 3) return 'text-hue-yellow';
+  return 'text-text-dim';
+}
+
+function parseTags(tags: string | null | undefined): string[] {
+  return (tags || '').split(',').map((t) => t.trim()).filter(Boolean);
+}
+
+export interface BoardCardProps {
+  task: Task;
+  onOpen: (task: Task) => void;
+}
+
+/**
+ * A single draggable card.
+ *
+ * Deliberately lighter than the list view's `TaskCard`: at ~280px there is
+ * no room for the inline status `<select>`, and a card whose whole surface
+ * is a drag handle shouldn't also contain a control that swallows pointer
+ * events. Changing status here is the drag itself.
+ */
+function BoardCardInner({ task, onOpen }: BoardCardProps) {
+  const {
+    attributes, listeners, setNodeRef, transform, transition, isDragging,
+  } = useSortable({ id: task.id, data: { type: 'task', task } });
+
+  const tags = parseTags(task.tags);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      {...attributes}
+      {...listeners}
+      onClick={() => onOpen(task)}
+      // The drag sensor has a 4px activation distance, so a plain click
+      // still reaches this handler and opens the task.
+      className={`group text-left w-full p-3 bg-surface border border-border-subtle rounded-lg
+        hover:border-border cursor-pointer transition-colors
+        ${isDragging ? 'opacity-40' : ''}`}
+    >
+      <h3 className="text-[13px] font-medium text-text leading-snug line-clamp-2 mb-2">
+        {task.title}
+      </h3>
+
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="px-1.5 py-0.5 text-[10px] rounded bg-surface-raised text-text-dim border border-border-subtle"
+            >
+              {tag}
+            </span>
+          ))}
+          {tags.length > 3 && (
+            <span className="px-1 py-0.5 text-[10px] text-text-faint">
+              +{tags.length - 3}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2.5 text-[11px] flex-wrap">
+        {task.deadline && (
+          <span className={`flex items-center gap-1 ${deadlineTone(task.deadline)}`}>
+            <Calendar size={10} /> {task.deadline}
+          </span>
+        )}
+        {task.updated_at && (
+          <span
+            className="flex items-center gap-1 text-text-faint"
+            title={`Updated ${task.updated_at}`}
+          >
+            <Clock size={10} /> {formatTimeAgo(task.updated_at)}
+          </span>
+        )}
+        {task.source && task.source !== 'manual' && (
+          <span className="text-text-faint">{task.source}</span>
+        )}
+        {task.source_url && (
+          <a
+            href={task.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            // Not a drag target: stop the sensor claiming the pointer so
+            // the link is clickable rather than the start of a drag.
+            onPointerDown={(e) => e.stopPropagation()}
+            className="ml-auto text-text-faint hover:text-text-muted opacity-0 group-hover:opacity-100 transition-opacity"
+            aria-label="Open source link"
+          >
+            <ExternalLink size={11} />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Lanes re-render on every drag frame; without memo each card in every
+// lane re-renders with them.
+export const BoardCard = memo(BoardCardInner);
+
+/** The card rendered under the cursor mid-drag (no sortable wiring). */
+export function BoardCardOverlay({ task }: { task: Task }) {
+  const tags = parseTags(task.tags);
+  return (
+    <div className="w-[272px] p-3 bg-surface border border-accent/50 rounded-lg shadow-xl rotate-2">
+      <h3 className="text-[13px] font-medium text-text leading-snug line-clamp-2">
+        {task.title}
+      </h3>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="px-1.5 py-0.5 text-[10px] rounded bg-surface-raised text-text-dim border border-border-subtle"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Tasks/Board/BoardColumn.tsx
+++ b/web/src/components/Tasks/Board/BoardColumn.tsx
@@ -1,0 +1,125 @@
+import { useDroppable } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
+import type { Task, TaskStatusDef } from '../../../api/client';
+import type { Lane } from '../../../stores/taskStore';
+import { BoardCard } from './BoardCard';
+
+export interface BoardColumnProps {
+  lane: Lane;
+  status: TaskStatusDef | undefined;
+  collapsed: boolean;
+  onToggleCollapse: (status: string) => void;
+  onCreate: (status: string) => void;
+  onOpenTask: (task: Task) => void;
+}
+
+export function BoardColumn({
+  lane, status, collapsed, onToggleCollapse, onCreate, onOpenTask,
+}: BoardColumnProps) {
+  // A lane must accept a drop even with no cards in it, and an empty
+  // SortableContext registers no droppable of its own — hence the explicit
+  // one on the column body.
+  const { setNodeRef, isOver } = useDroppable({
+    id: `lane:${lane.status}`,
+    data: { type: 'lane', status: lane.status },
+  });
+
+  const label = status?.label ?? lane.status;
+  const color = status?.color ?? '#6b7280';
+  const hidden = lane.total - lane.tasks.length;
+
+  if (collapsed) {
+    return (
+      <div className="w-11 shrink-0 flex flex-col items-center gap-3 py-3 bg-surface-raised/40 border border-border-subtle rounded-xl">
+        <button
+          onClick={() => onToggleCollapse(lane.status)}
+          className="text-text-faint hover:text-text-muted cursor-pointer"
+          aria-label={`Expand ${label} column`}
+          title={`Expand ${label}`}
+        >
+          <ChevronRight size={15} />
+        </button>
+        <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: color }} />
+        {/* Vertical rail: the label reads bottom-to-top so long status
+            names stay legible instead of being truncated to a glyph. */}
+        <span
+          className="text-[12px] font-medium text-text-secondary whitespace-nowrap"
+          style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+        >
+          {label}
+        </span>
+        <span className="text-[11px] text-text-faint tabular-nums">{lane.total}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-[300px] shrink-0 flex flex-col bg-surface-raised/40 border border-border-subtle rounded-xl max-h-full">
+      <div className="shrink-0 px-3 py-2.5 border-b border-border-subtle">
+        <div className="flex items-center gap-2">
+          <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
+          <h2 className="text-[13px] font-semibold text-text-secondary truncate">{label}</h2>
+          <span className="text-[11px] text-text-faint tabular-nums">{lane.total}</span>
+          <div className="ml-auto flex items-center gap-0.5">
+            <button
+              onClick={() => onCreate(lane.status)}
+              className="p-1 text-text-faint hover:text-text-muted cursor-pointer rounded"
+              aria-label={`New task in ${label}`}
+              title={`New task in ${label}`}
+            >
+              <Plus size={14} />
+            </button>
+            <button
+              onClick={() => onToggleCollapse(lane.status)}
+              className="p-1 text-text-faint hover:text-text-muted cursor-pointer rounded"
+              aria-label={`Collapse ${label} column`}
+              title="Collapse"
+            >
+              <ChevronLeft size={14} />
+            </button>
+          </div>
+        </div>
+        {status?.description && (
+          <p className="mt-1 text-[11px] text-text-faint line-clamp-1" title={status.description}>
+            {status.description}
+          </p>
+        )}
+      </div>
+
+      <div
+        ref={setNodeRef}
+        className={`flex-1 overflow-y-auto min-h-0 p-2 space-y-2 rounded-b-xl transition-colors
+          ${isOver ? 'bg-accent/5' : ''}`}
+      >
+        <SortableContext
+          items={lane.tasks.map((t) => t.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          {lane.tasks.map((task) => (
+            <BoardCard key={task.id} task={task} onOpen={onOpenTask} />
+          ))}
+        </SortableContext>
+
+        {lane.tasks.length === 0 && (
+          <div
+            className={`h-20 flex items-center justify-center text-[12px] rounded-lg border border-dashed
+              ${isOver
+                ? 'border-accent/40 text-accent'
+                : 'border-border-subtle text-text-faint'}`}
+          >
+            {isOver ? 'Drop here' : 'No tasks'}
+          </div>
+        )}
+
+        {hidden > 0 && (
+          // The lane is paginated server-side; say so rather than silently
+          // showing a partial column whose count doesn't match its cards.
+          <p className="pt-1 pb-2 text-center text-[11px] text-text-faint">
+            +{hidden} more — narrow the filters or use List view
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Tasks/Board/BoardFilterBar.tsx
+++ b/web/src/components/Tasks/Board/BoardFilterBar.tsx
@@ -12,12 +12,16 @@ export function BoardFilterBar() {
   if (availableTags.length === 0) return null;
 
   // Ranked by count server-side; an active filter is pinned so it can
-  // always be switched off even if it falls outside the top slice.
+  // always be switched off even if it falls outside the top slice — or has
+  // left the list altogether, which happens as soon as its last open task is
+  // retagged or finished, since the facets exclude done. Synthesising a
+  // zero-count chip keeps the "Clear" affordance reachable; the alternative
+  // is a filter the user can see the effect of but not turn off.
   const shown = availableTags.slice(0, MAX_FACETS);
-  const activeIsHidden = tagFilter && !shown.some((t) => t.name === tagFilter);
-  const facets = activeIsHidden
-    ? [...shown, availableTags.find((t) => t.name === tagFilter)!]
-    : shown;
+  const facets =
+    tagFilter && !shown.some((t) => t.name === tagFilter)
+      ? [...shown, availableTags.find((t) => t.name === tagFilter) ?? { name: tagFilter, count: 0 }]
+      : shown;
 
   return (
     <div className="flex items-center gap-1.5 px-4 py-2 border-b border-border-subtle overflow-x-auto shrink-0">

--- a/web/src/components/Tasks/Board/BoardFilterBar.tsx
+++ b/web/src/components/Tasks/Board/BoardFilterBar.tsx
@@ -1,0 +1,52 @@
+import { Tag, X } from 'lucide-react';
+import { useTaskStore } from '../../../stores/taskStore';
+
+/** How many tag facets to offer before it stops being a filter bar. */
+const MAX_FACETS = 12;
+
+export function BoardFilterBar() {
+  const availableTags = useTaskStore((s) => s.availableTags);
+  const tagFilter = useTaskStore((s) => s.tagFilter);
+  const setTagFilter = useTaskStore((s) => s.setTagFilter);
+
+  if (availableTags.length === 0) return null;
+
+  // Ranked by count server-side; an active filter is pinned so it can
+  // always be switched off even if it falls outside the top slice.
+  const shown = availableTags.slice(0, MAX_FACETS);
+  const activeIsHidden = tagFilter && !shown.some((t) => t.name === tagFilter);
+  const facets = activeIsHidden
+    ? [...shown, availableTags.find((t) => t.name === tagFilter)!]
+    : shown;
+
+  return (
+    <div className="flex items-center gap-1.5 px-4 py-2 border-b border-border-subtle overflow-x-auto shrink-0">
+      <Tag size={12} className="text-text-faint shrink-0" />
+      {facets.map((tag) => {
+        const active = tag.name === tagFilter;
+        return (
+          <button
+            key={tag.name}
+            onClick={() => setTagFilter(active ? '' : tag.name)}
+            aria-pressed={active}
+            className={`shrink-0 px-2 py-0.5 text-[11px] rounded-full border cursor-pointer transition-colors
+              ${active
+                ? 'bg-accent/15 border-accent/40 text-accent'
+                : 'bg-surface-raised border-border-subtle text-text-dim hover:text-text-secondary hover:border-border'}`}
+          >
+            {tag.name}
+            <span className="ml-1 tabular-nums opacity-60">{tag.count}</span>
+          </button>
+        );
+      })}
+      {tagFilter && (
+        <button
+          onClick={() => setTagFilter('')}
+          className="shrink-0 flex items-center gap-1 px-2 py-0.5 text-[11px] text-text-faint hover:text-text-muted cursor-pointer"
+        >
+          <X size={11} /> Clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Tasks/Board/TaskBoard.tsx
+++ b/web/src/components/Tasks/Board/TaskBoard.tsx
@@ -14,6 +14,7 @@ import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import type { Task } from '../../../api/client';
 import { useTaskStatusStore } from '../../../stores/taskStatusStore';
 import { useTaskStore } from '../../../stores/taskStore';
+import { boardAnnouncements } from './announcements';
 import { BoardCardOverlay } from './BoardCard';
 import { isNoOpMove, resolveDropIntent } from './dropIntent';
 import { BoardColumn } from './BoardColumn';
@@ -60,6 +61,11 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
   const statusByName = useMemo(
     () => new Map(statuses.map((s) => [s.name, s])),
     [statuses],
+  );
+
+  const announcements = useMemo(
+    () => boardAnnouncements((name) => statusByName.get(name)?.label ?? name),
+    [statusByName],
   );
 
   const handleToggleCollapse = useCallback((status: string) => {
@@ -126,16 +132,7 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragCancel={() => setActiveTask(null)}
-        accessibility={{
-          announcements: {
-            onDragStart: ({ active }) => `Picked up task ${active.id}.`,
-            onDragOver: ({ over }) =>
-              over ? `Task is over ${String(over.id).replace('lane:', 'the ')} lane.` : '',
-            onDragEnd: ({ over }) =>
-              over ? `Task dropped on ${over.id}.` : 'Task dropped, position unchanged.',
-            onDragCancel: () => 'Move cancelled.',
-          },
-        }}
+        accessibility={{ announcements }}
       >
         <div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden px-4 pb-4">
           <div className="flex gap-3 h-full items-start min-w-min">

--- a/web/src/components/Tasks/Board/TaskBoard.tsx
+++ b/web/src/components/Tasks/Board/TaskBoard.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import type { Task } from '../../../api/client';
+import { useTaskStatusStore } from '../../../stores/taskStatusStore';
+import { useTaskStore } from '../../../stores/taskStore';
+import { BoardCardOverlay } from './BoardCard';
+import { isNoOpMove, resolveDropIntent } from './dropIntent';
+import { BoardColumn } from './BoardColumn';
+
+const COLLAPSED_KEY = 'nerve_board_collapsed';
+
+function readCollapsed(): string[] {
+  try {
+    const raw = localStorage.getItem(COLLAPSED_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeCollapsed(next: string[]): void {
+  try {
+    localStorage.setItem(COLLAPSED_KEY, JSON.stringify(next));
+  } catch {
+    /* not fatal */
+  }
+}
+
+export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) {
+  const lanes = useTaskStore((s) => s.lanes);
+  const boardLoading = useTaskStore((s) => s.boardLoading);
+  const boardError = useTaskStore((s) => s.boardError);
+  const moveTask = useTaskStore((s) => s.moveTask);
+  const setShowCreateDialog = useTaskStore((s) => s.setShowCreateDialog);
+  const statuses = useTaskStatusStore((s) => s.statuses);
+
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const [collapsed, setCollapsed] = useState<string[]>(readCollapsed);
+
+  const sensors = useSensors(
+    // 4px of travel before a drag begins, so a plain click still reaches
+    // the card's onClick and opens the task instead of starting a drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const statusByName = useMemo(
+    () => new Map(statuses.map((s) => [s.name, s])),
+    [statuses],
+  );
+
+  const handleToggleCollapse = useCallback((status: string) => {
+    setCollapsed((prev) => {
+      const next = prev.includes(status)
+        ? prev.filter((s) => s !== status)
+        : [...prev, status];
+      writeCollapsed(next);
+      return next;
+    });
+  }, []);
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    const task = event.active.data.current?.task as Task | undefined;
+    setActiveTask(task ?? null);
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    setActiveTask(null);
+    const { active, over } = event;
+    if (!over) return;
+
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    if (activeId === overId) return;
+
+    const intent = resolveDropIntent(lanes, activeId, overId);
+    if (!intent) return;
+    // Skip the round trip when the card was dropped back where it started.
+    if (isNoOpMove(lanes, activeId, intent)) return;
+
+    void moveTask(activeId, intent);
+  }, [lanes, moveTask]);
+
+  if (boardLoading) {
+    return <div className="text-text-faint text-center py-10">Loading board...</div>;
+  }
+
+  if (lanes.length === 0) {
+    return <div className="text-text-faint text-center py-10">No statuses configured.</div>;
+  }
+
+  return (
+    <>
+      {boardError && (
+        <div className="mx-4 mb-2 px-3 py-2 text-[12px] text-hue-red bg-red-400/10 border border-red-400/20 rounded-lg">
+          {boardError}
+        </div>
+      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCorners}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveTask(null)}
+        accessibility={{
+          announcements: {
+            onDragStart: ({ active }) => `Picked up task ${active.id}.`,
+            onDragOver: ({ over }) =>
+              over ? `Task is over ${String(over.id).replace('lane:', 'the ')} lane.` : '',
+            onDragEnd: ({ over }) =>
+              over ? `Task dropped on ${over.id}.` : 'Task dropped, position unchanged.',
+            onDragCancel: () => 'Move cancelled.',
+          },
+        }}
+      >
+        <div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden px-4 pb-4">
+          <div className="flex gap-3 h-full items-start min-w-min">
+            {lanes.map((lane) => (
+              <BoardColumn
+                key={lane.status}
+                lane={lane}
+                status={statusByName.get(lane.status)}
+                collapsed={collapsed.includes(lane.status)}
+                onToggleCollapse={handleToggleCollapse}
+                onCreate={(status) => setShowCreateDialog(true, status)}
+                onOpenTask={onOpenTask}
+              />
+            ))}
+          </div>
+        </div>
+
+        <DragOverlay dropAnimation={null}>
+          {activeTask && <BoardCardOverlay task={activeTask} />}
+        </DragOverlay>
+      </DndContext>
+    </>
+  );
+}

--- a/web/src/components/Tasks/Board/TaskBoard.tsx
+++ b/web/src/components/Tasks/Board/TaskBoard.tsx
@@ -44,6 +44,7 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
   const boardError = useTaskStore((s) => s.boardError);
   const moveTask = useTaskStore((s) => s.moveTask);
   const setShowCreateDialog = useTaskStore((s) => s.setShowCreateDialog);
+  const searchQuery = useTaskStore((s) => s.searchQuery);
   const statuses = useTaskStatusStore((s) => s.statuses);
 
   const [activeTask, setActiveTask] = useState<Task | null>(null);
@@ -99,6 +100,17 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
 
   if (lanes.length === 0) {
     return <div className="text-text-faint text-center py-10">No statuses configured.</div>;
+  }
+
+  // Every lane empty under an active search means no matches — say that
+  // once, rather than repeating "No tasks" in each column as if the board
+  // itself were empty.
+  if (searchQuery.trim() && lanes.every((lane) => lane.tasks.length === 0)) {
+    return (
+      <div className="text-text-faint text-center py-10 text-[13px]">
+        No tasks matching &ldquo;{searchQuery.trim()}&rdquo;
+      </div>
+    );
   }
 
   return (

--- a/web/src/components/Tasks/Board/announcements.test.ts
+++ b/web/src/components/Tasks/Board/announcements.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { Active, Over } from '@dnd-kit/core';
+import { boardAnnouncements } from './announcements';
+
+/**
+ * These strings are the whole of the board for a screen-reader user, and
+ * nothing on screen shows them, so a regression here is silent. The ids
+ * involved are slugs and namespaced keys, which is exactly what must never
+ * reach the announcement.
+ */
+
+const labelFor = (name: string) =>
+  ({ pending: 'Pending', in_progress: 'In Progress' })[name] ?? name;
+
+const a = boardAnnouncements(labelFor);
+
+/** dnd-kit hands these over as refs, hence the `current` indirection. */
+const card = (id: string, title: string) =>
+  ({ id, data: { current: { type: 'task', task: { id, title } } } }) as unknown as Active;
+
+/** A card is both draggable and droppable — the two shapes differ. */
+const overCard = (id: string, title: string) =>
+  card(id, title) as unknown as Over;
+
+const lane = (status: string) =>
+  ({ id: `lane:${status}`, data: { current: { type: 'lane', status } } }) as unknown as Over;
+
+describe('boardAnnouncements', () => {
+  const dragged = card('2026-08-05-fix-the-encoder', 'Fix the encoder');
+
+  it('names the task instead of reading out its slug', () => {
+    expect(a.onDragStart({ active: dragged })).toBe('Picked up task Fix the encoder.');
+  });
+
+  it('uses the configured label for a lane, not the status name', () => {
+    expect(a.onDragOver({ active: dragged, over: lane('in_progress') })).toBe(
+      'Task Fix the encoder is over the In Progress lane.',
+    );
+  });
+
+  it('says it is over a task when the target is a card, not a lane', () => {
+    // The regression: every target was described as a lane, so hovering a
+    // card announced "... is over <slug> lane."
+    expect(a.onDragOver({ active: dragged, over: overCard('b', 'Something else') })).toBe(
+      'Task Fix the encoder is over task Something else.',
+    );
+  });
+
+  it('does not leak the lane: prefix on drop', () => {
+    expect(a.onDragEnd({ active: dragged, over: lane('pending') })).toBe(
+      'Task Fix the encoder dropped on the Pending lane.',
+    );
+  });
+
+  it('reports a drop outside any target as unchanged', () => {
+    expect(a.onDragEnd({ active: dragged, over: null })).toBe(
+      'Task Fix the encoder dropped, position unchanged.',
+    );
+  });
+
+  it('says nothing while over no target', () => {
+    expect(a.onDragOver({ active: dragged, over: null })).toBe('');
+  });
+
+  it('names what was cancelled', () => {
+    expect(a.onDragCancel({ active: dragged, over: null })).toBe(
+      'Move of task Fix the encoder cancelled.',
+    );
+  });
+
+  it('falls back to the id rather than throwing on an untyped payload', () => {
+    const bare = { id: 'mystery', data: { current: undefined } } as unknown as Active;
+    expect(a.onDragStart({ active: bare })).toBe('Picked up mystery.');
+  });
+
+  it('falls back to the status name when it has no configured label', () => {
+    expect(a.onDragEnd({ active: dragged, over: lane('triage') })).toBe(
+      'Task Fix the encoder dropped on the triage lane.',
+    );
+  });
+});

--- a/web/src/components/Tasks/Board/announcements.ts
+++ b/web/src/components/Tasks/Board/announcements.ts
@@ -1,0 +1,40 @@
+/**
+ * Screen-reader wording for the board's drag gestures.
+ *
+ * Kept out of the component and pure for the same reason as `dropIntent`:
+ * this is the only account of the drag a screen-reader user gets, and it is
+ * invisible to everyone else, so it needs tests rather than a look.
+ *
+ * The identifiers involved are a task slug ("2026-08-05-fix-the-encoder")
+ * and namespaced droppable keys ("lane:pending"), so announcing ids reads
+ * out the data model instead of the board. Every draggable and droppable
+ * already carries a typed payload; these messages name the thing from that.
+ */
+import type { Announcements, Active, Over } from '@dnd-kit/core';
+import type { Task } from '../../../api/client';
+
+/** `labelFor` resolves a status name to its configured display label. */
+export function boardAnnouncements(labelFor: (status: string) => string): Announcements {
+  const describe = (node: Active | Over | null): string => {
+    const data = node?.data.current;
+    if (data?.type === 'task') return `task ${(data.task as Task).title}`;
+    if (data?.type === 'lane') return `the ${labelFor(String(data.status))} lane`;
+    // Every draggable and droppable on the board sets `data`, so this is
+    // unreachable — but an announcement is the wrong place to throw, and a
+    // bare id still says more than an empty string.
+    return node ? String(node.id) : 'nothing';
+  };
+
+  const sentence = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+  return {
+    onDragStart: ({ active }) => `Picked up ${describe(active)}.`,
+    onDragOver: ({ active, over }) =>
+      over ? `${sentence(describe(active))} is over ${describe(over)}.` : '',
+    onDragEnd: ({ active, over }) =>
+      over
+        ? `${sentence(describe(active))} dropped on ${describe(over)}.`
+        : `${sentence(describe(active))} dropped, position unchanged.`,
+    onDragCancel: ({ active }) => `Move of ${describe(active)} cancelled.`,
+  };
+}

--- a/web/src/components/Tasks/Board/dropIntent.test.tsx
+++ b/web/src/components/Tasks/Board/dropIntent.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from '../../../api/client';
+import type { Lane } from '../../../stores/taskStore';
+import { isNoOpMove, resolveDropIntent } from './dropIntent';
+
+/**
+ * Drop resolution: "card X landed on target Y" → the neighbour pair the
+ * move API expects.
+ *
+ * This is where drag-and-drop bugs actually live. The classic one is
+ * dragging a card *downward* within its own lane: if the moved card isn't
+ * excluded from the lane before computing anchors, it anchors against its
+ * own current position and lands one slot short of where it was dropped.
+ * Every direction is pinned below for that reason.
+ */
+
+function task(id: string, status = 'pending', position = 0): Task {
+  return {
+    id, title: id, status, position,
+    deadline: null, source: 'manual', source_url: null, tags: '',
+    created_at: '2026-08-05T00:00:00Z', updated_at: '2026-08-05T00:00:00Z',
+  };
+}
+
+function lanes(): Lane[] {
+  return [
+    {
+      status: 'pending',
+      total: 3,
+      tasks: [task('a', 'pending', 1024), task('b', 'pending', 2048), task('c', 'pending', 3072)],
+    },
+    { status: 'in_progress', total: 1, tasks: [task('x', 'in_progress', 1024)] },
+    { status: 'done', total: 0, tasks: [] },
+  ];
+}
+
+describe('resolveDropIntent — within a lane', () => {
+  it('dropping on the card above puts the card in that slot', () => {
+    // c dropped onto a → c takes a's place, a is pushed down.
+    expect(resolveDropIntent(lanes(), 'c', 'a')).toEqual({
+      status: 'pending', beforeId: null, afterId: 'a',
+    });
+  });
+
+  it('dropping on a middle card anchors between its neighbours', () => {
+    expect(resolveDropIntent(lanes(), 'c', 'b')).toEqual({
+      status: 'pending', beforeId: 'a', afterId: 'b',
+    });
+  });
+
+  it('dragging downward excludes the moved card from its own anchors', () => {
+    // a dropped onto c. With `a` still in the list, index(c) === 2 and the
+    // preceding card would be `b` — correct only by accident. Excluding `a`
+    // first gives index 1, preceded by `b`, followed by `c`. The bug shows
+    // up as the card landing above `c` instead of taking its slot.
+    expect(resolveDropIntent(lanes(), 'a', 'c')).toEqual({
+      status: 'pending', beforeId: 'b', afterId: 'c',
+    });
+  });
+
+  it('dragging the top card to the middle', () => {
+    expect(resolveDropIntent(lanes(), 'a', 'b')).toEqual({
+      status: 'pending', beforeId: null, afterId: 'b',
+    });
+  });
+
+  it('dropping on the lane background appends to the end', () => {
+    expect(resolveDropIntent(lanes(), 'a', 'lane:pending')).toEqual({
+      status: 'pending', beforeId: 'c', afterId: null,
+    });
+  });
+});
+
+describe('resolveDropIntent — across lanes', () => {
+  it('dropping onto a card in another lane takes its slot', () => {
+    expect(resolveDropIntent(lanes(), 'a', 'x')).toEqual({
+      status: 'in_progress', beforeId: null, afterId: 'x',
+    });
+  });
+
+  it('dropping on another lane background appends there', () => {
+    expect(resolveDropIntent(lanes(), 'a', 'lane:in_progress')).toEqual({
+      status: 'in_progress', beforeId: 'x', afterId: null,
+    });
+  });
+
+  it('dropping into an empty lane yields no anchors', () => {
+    expect(resolveDropIntent(lanes(), 'a', 'lane:done')).toEqual({
+      status: 'done', beforeId: null, afterId: null,
+    });
+  });
+
+  it('returns null for an unrecognised drop target', () => {
+    expect(resolveDropIntent(lanes(), 'a', 'lane:nonexistent')).toBeNull();
+    expect(resolveDropIntent(lanes(), 'a', 'ghost-task')).toBeNull();
+  });
+});
+
+describe('isNoOpMove', () => {
+  it('detects a drop onto the immediate next card as a no-op', () => {
+    // The reachable no-op: `a` dropped onto `b`, which already sits
+    // directly below it, resolves to the slot `a` is already in. Without
+    // this check every such drag costs a round trip and bumps updated_at
+    // for nothing.
+    const intent = resolveDropIntent(lanes(), 'a', 'b');
+    expect(intent).toEqual({ status: 'pending', beforeId: null, afterId: 'b' });
+    expect(isNoOpMove(lanes(), 'a', intent!)).toBe(true);
+  });
+
+  it('detects a card dropped on its own origin slot', () => {
+    expect(isNoOpMove(lanes(), 'b', { status: 'pending', beforeId: 'a', afterId: 'c' }))
+      .toBe(true);
+  });
+
+  it('treats a real reorder as a change', () => {
+    expect(isNoOpMove(lanes(), 'c', { status: 'pending', beforeId: null, afterId: 'a' }))
+      .toBe(false);
+  });
+
+  it('treats a lane change as a change even at the same index', () => {
+    expect(isNoOpMove(lanes(), 'a', { status: 'in_progress', beforeId: null, afterId: 'x' }))
+      .toBe(false);
+  });
+
+  it('recognises the tail slot as a no-op for the last card', () => {
+    expect(isNoOpMove(lanes(), 'c', { status: 'pending', beforeId: 'b', afterId: null }))
+      .toBe(true);
+  });
+});

--- a/web/src/components/Tasks/Board/dropIntent.ts
+++ b/web/src/components/Tasks/Board/dropIntent.ts
@@ -1,0 +1,67 @@
+import type { Lane, MoveIntent } from '../../../stores/taskStore';
+
+/**
+ * Drag-drop geometry, kept out of the component file so it can be tested
+ * directly (and so the component module stays exports-components-only for
+ * fast refresh).
+ */
+
+/**
+ * Translate "card X was dropped on target Y" into the neighbour pair the
+ * move API expects.
+ *
+ * The drop target is either another card or a lane's background. For a
+ * card, the moved item takes that card's slot and pushes it down — so the
+ * dropped-on card becomes `afterId`, and whatever preceded it becomes
+ * `beforeId`.
+ *
+ * The moved card is excluded from the lane before anchors are read. Skip
+ * that and a downward drag within one lane anchors against the card's own
+ * current position, landing it one slot short of where it was dropped.
+ */
+export function resolveDropIntent(
+  lanes: Lane[],
+  activeId: string,
+  overId: string,
+): MoveIntent | null {
+  const laneFromOver = overId.startsWith('lane:')
+    ? lanes.find((l) => l.status === overId.slice('lane:'.length))
+    : lanes.find((l) => l.tasks.some((t) => t.id === overId));
+  if (!laneFromOver) return null;
+
+  const others = laneFromOver.tasks.filter((t) => t.id !== activeId);
+  const appendToTail = (): MoveIntent => ({
+    status: laneFromOver.status,
+    beforeId: others[others.length - 1]?.id ?? null,
+    afterId: null,
+  });
+
+  // Dropped on empty space in the column.
+  if (overId.startsWith('lane:')) return appendToTail();
+
+  const at = others.findIndex((t) => t.id === overId);
+  // The anchor card is gone from this lane (it moved while the drag was in
+  // flight, or it *is* the dragged card — which the caller short-circuits).
+  if (at === -1) return appendToTail();
+
+  return {
+    status: laneFromOver.status,
+    beforeId: others[at - 1]?.id ?? null,
+    afterId: others[at].id,
+  };
+}
+
+/** True when the intent would leave the board exactly as it is. */
+export function isNoOpMove(
+  lanes: Lane[],
+  activeId: string,
+  intent: MoveIntent,
+): boolean {
+  const lane = lanes.find((l) => l.status === intent.status);
+  if (!lane) return false;
+  const at = lane.tasks.findIndex((t) => t.id === activeId);
+  if (at === -1) return false; // changing lanes is never a no-op
+  const currentBefore = lane.tasks[at - 1]?.id ?? null;
+  const currentAfter = lane.tasks[at + 1]?.id ?? null;
+  return intent.beforeId === currentBefore && intent.afterId === currentAfter;
+}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { ChevronLeft, ChevronRight, Plus, Search, SlidersHorizontal, X } from 'lucide-react';
-import { useTaskStore, TASKS_PAGE_SIZE, type TaskSort } from '../stores/taskStore';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { ChevronLeft, ChevronRight, Columns3, List, Plus, Search, SlidersHorizontal, X } from 'lucide-react';
+import { useTaskStore, TASKS_PAGE_SIZE, type TaskSort, type TaskViewMode } from '../stores/taskStore';
 import { useTaskStatusStore } from '../stores/taskStatusStore';
 import { TaskFilters } from '../components/Tasks/TaskFilters';
 import { TaskCard } from '../components/Tasks/TaskCard';
 import { TaskCreateDialog } from '../components/Tasks/TaskCreateDialog';
 import { TaskStatusManager } from '../components/Tasks/TaskStatusManager';
+import { TaskBoard } from '../components/Tasks/Board/TaskBoard';
+import { BoardFilterBar } from '../components/Tasks/Board/BoardFilterBar';
 
 const SORT_OPTIONS: { value: TaskSort; label: string }[] = [
   { value: 'deadline', label: 'Deadline' },
@@ -13,20 +16,36 @@ const SORT_OPTIONS: { value: TaskSort; label: string }[] = [
   { value: 'created_at', label: 'Created' },
 ];
 
+const VIEW_OPTIONS: { value: TaskViewMode; label: string; Icon: typeof List }[] = [
+  { value: 'board', label: 'Board', Icon: Columns3 },
+  { value: 'list', label: 'List', Icon: List },
+];
+
 export function TasksPage() {
   const {
     tasks, filter, searchQuery, sort, page, total, loading, showCreateDialog,
-    loadTasks, setFilter, setSearch, setSort, setPage,
+    viewMode, loadTasks, loadBoard, loadTags, setViewMode,
+    setFilter, setSearch, setSort, setPage,
     updateStatus, createTask, setShowCreateDialog,
   } = useTaskStore();
 
   const loadStatuses = useTaskStatusStore((s) => s.load);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [localQuery, setLocalQuery] = useState(searchQuery);
   const [showStatusManager, setShowStatusManager] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => { loadTasks(); loadStatuses(); }, []);
+  const isBoard = viewMode === 'board';
+
+  useEffect(() => {
+    loadStatuses();
+    loadTags();
+    if (isBoard) loadBoard();
+    else loadTasks();
+    // Mount-only: view switches load through setViewMode.
+  }, []);
 
   const isSearching = searchQuery.trim().length > 0;
   const pageStart = total === 0 ? 0 : (page - 1) * TASKS_PAGE_SIZE + 1;
@@ -50,14 +69,40 @@ export function TasksPage() {
   // Cleanup debounce on unmount
   useEffect(() => () => clearTimeout(debounceRef.current), []);
 
-  return (
-    <div className="h-full flex flex-col">
-      <div className="border-b border-border-subtle px-6 py-3 flex items-center justify-between bg-bg shrink-0">
-        <div className="flex items-center gap-4">
-          <h1 className="text-lg font-semibold">Tasks</h1>
-          <TaskFilters active={filter} onChange={setFilter} />
+  // Open a task over the board: /tasks/:id renders as a modal when it's
+  // reached from here, and as the full page on a cold load or refresh.
+  const openTask = useCallback((task: { id: string }) => {
+    navigate(`/tasks/${task.id}`, { state: { background: location } });
+  }, [navigate, location]);
 
-          <div className="relative ml-2">
+  return (
+    <div className="h-full flex flex-col min-w-0">
+      <div className="border-b border-border-subtle px-4 py-3 flex items-center justify-between gap-4 bg-bg shrink-0">
+        <div className="flex items-center gap-3 min-w-0">
+          <h1 className="text-lg font-semibold shrink-0">Tasks</h1>
+
+          <div className="flex items-center bg-surface-raised border border-border-subtle rounded-lg p-0.5 shrink-0">
+            {VIEW_OPTIONS.map(({ value, label, Icon }) => (
+              <button
+                key={value}
+                onClick={() => setViewMode(value)}
+                aria-pressed={viewMode === value}
+                title={`${label} view`}
+                className={`flex items-center gap-1.5 px-2.5 py-1 text-[12px] rounded-md cursor-pointer transition-colors
+                  ${viewMode === value
+                    ? 'bg-surface text-text shadow-sm'
+                    : 'text-text-faint hover:text-text-secondary'}`}
+              >
+                <Icon size={13} /> {label}
+              </button>
+            ))}
+          </div>
+
+          {/* Status pills are the list's filter; on the board every status
+              is already a lane, so they'd only hide columns. */}
+          {!isBoard && <TaskFilters active={filter} onChange={setFilter} />}
+
+          <div className="relative ml-2 shrink-0">
             <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-faint" />
             <input
               type="text"
@@ -78,8 +123,8 @@ export function TasksPage() {
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          {!isSearching && (
+        <div className="flex items-center gap-2 shrink-0">
+          {!isSearching && !isBoard && (
             <label className="flex items-center gap-1.5 text-[12px] text-text-faint">
               Sort by
               <select
@@ -109,6 +154,14 @@ export function TasksPage() {
         </div>
       </div>
 
+      {isBoard && <BoardFilterBar />}
+
+      {isBoard ? (
+        // The board owns its own scrolling: columns scroll vertically,
+        // the rail of columns scrolls horizontally. No page-level scroll,
+        // and no max-width — filling the viewport is the whole point.
+        <TaskBoard onOpenTask={openTask} />
+      ) : (
       <div className="flex-1 overflow-y-auto p-6">
         {loading ? (
           <div className="text-text-faint text-center py-10">Loading...</div>
@@ -155,6 +208,7 @@ export function TasksPage() {
           </div>
         )}
       </div>
+      )}
 
       {showCreateDialog && (
         <TaskCreateDialog

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -912,6 +912,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // Review loops — global event (session_running pattern): chip state on
       // the observer session row + live milestone append for the open view.
       case 'review_loop_update': return handleReviewLoopUpdate(msg, get, set);
+      // Tasks — global event (session_id is always null), so the board
+      // reflects a change made by the agent in any session, by another
+      // tab, or over the API. Must stay out of VIEW_SCOPED_EVENTS.
+      case 'task_updated':
+        void import('./taskStore').then(({ useTaskStore }) =>
+          useTaskStore.getState().handleTaskEvent(msg.task)
+        );
+        return;
       // Auxiliary
       case 'interaction':              return handleInteraction(msg, get, set);
       case 'interaction_resolved':     return handleInteractionResolved(msg, get, set);

--- a/web/src/stores/taskStore.test.ts
+++ b/web/src/stores/taskStore.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task } from '../api/client';
+
+vi.mock('../api/client', () => ({
+  api: {
+    moveTask: vi.fn(),
+    getTaskBoard: vi.fn(),
+    listTaskTags: vi.fn(),
+    listTasks: vi.fn(),
+    searchTasks: vi.fn(),
+  },
+}));
+
+const { api } = await import('../api/client');
+const { useTaskStore } = await import('./taskStore');
+
+function task(id: string, status = 'pending', position = 0): Task {
+  return {
+    id, title: id, status, position,
+    deadline: null, source: 'manual', source_url: null, tags: '',
+    created_at: '2026-08-05T00:00:00Z', updated_at: '2026-08-05T00:00:00Z',
+  };
+}
+
+const laneOrder = (status: string) =>
+  useTaskStore.getState().lanes.find((l) => l.status === status)!.tasks.map((t) => t.id);
+
+const laneTotal = (status: string) =>
+  useTaskStore.getState().lanes.find((l) => l.status === status)!.total;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useTaskStore.setState({
+    lanes: [
+      {
+        status: 'pending',
+        total: 3,
+        tasks: [task('a', 'pending', 1024), task('b', 'pending', 2048), task('c', 'pending', 3072)],
+      },
+      { status: 'in_progress', total: 1, tasks: [task('x', 'in_progress', 1024)] },
+      { status: 'done', total: 0, tasks: [] },
+    ],
+    selectedTask: null,
+    boardError: null,
+  });
+});
+
+describe('applyLocalMove', () => {
+  it('reorders within a lane', () => {
+    useTaskStore.getState().applyLocalMove('c', {
+      status: 'pending', beforeId: null, afterId: 'a',
+    });
+    expect(laneOrder('pending')).toEqual(['c', 'a', 'b']);
+  });
+
+  it('appends when there are no anchors', () => {
+    useTaskStore.getState().applyLocalMove('a', {
+      status: 'pending', beforeId: null, afterId: null,
+    });
+    expect(laneOrder('pending')).toEqual(['b', 'c', 'a']);
+  });
+
+  it('moves across lanes and fixes both totals', () => {
+    useTaskStore.getState().applyLocalMove('a', {
+      status: 'in_progress', beforeId: null, afterId: 'x',
+    });
+    expect(laneOrder('pending')).toEqual(['b', 'c']);
+    expect(laneOrder('in_progress')).toEqual(['a', 'x']);
+    // Counts drive the lane headers and the "+N more" affordance; a move
+    // that shifts a card without shifting the totals shows a lane claiming
+    // more cards than it can ever display.
+    expect(laneTotal('pending')).toBe(2);
+    expect(laneTotal('in_progress')).toBe(2);
+  });
+});
+
+describe('moveTask', () => {
+  it('applies optimistically before the request resolves', async () => {
+    let resolveRequest: (v: { task: Task }) => void = () => {};
+    vi.mocked(api.moveTask).mockReturnValue(
+      new Promise((res) => { resolveRequest = res; }) as ReturnType<typeof api.moveTask>,
+    );
+
+    const pending = useTaskStore.getState().moveTask('c', {
+      status: 'pending', beforeId: null, afterId: 'a',
+    });
+
+    // The card has already moved — that's the point of optimistic UI.
+    expect(laneOrder('pending')).toEqual(['c', 'a', 'b']);
+    resolveRequest({ task: task('c', 'pending', 512) });
+    await pending;
+    expect(laneOrder('pending')).toEqual(['c', 'a', 'b']);
+  });
+
+  it('reconciles the server row into the moved card', async () => {
+    vi.mocked(api.moveTask).mockResolvedValue({
+      task: { ...task('c', 'pending', 512), updated_at: '2026-08-05T09:00:00Z' },
+    });
+
+    await useTaskStore.getState().moveTask('c', {
+      status: 'pending', beforeId: null, afterId: 'a',
+    });
+
+    const moved = useTaskStore.getState().lanes[0].tasks[0];
+    // The server owns the rank; without adopting it the next drag computes
+    // anchors from a position that never existed.
+    expect(moved.position).toBe(512);
+    expect(moved.updated_at).toBe('2026-08-05T09:00:00Z');
+  });
+
+  it('rolls back to the exact prior order when the request fails', async () => {
+    vi.mocked(api.moveTask).mockRejectedValue(new Error('409: conflict'));
+    // Resync in flight but unresolved — this asserts the *immediate*
+    // rollback, which is what the user sees while the refetch travels.
+    vi.mocked(api.getTaskBoard).mockReturnValue(
+      new Promise(() => {}) as ReturnType<typeof api.getTaskBoard>,
+    );
+
+    await useTaskStore.getState().moveTask('a', {
+      status: 'in_progress', beforeId: null, afterId: 'x',
+    });
+
+    // Restored from the snapshot, not recomputed — totals included.
+    expect(laneOrder('pending')).toEqual(['a', 'b', 'c']);
+    expect(laneTotal('pending')).toBe(3);
+    expect(laneOrder('in_progress')).toEqual(['x']);
+    expect(useTaskStore.getState().boardError).toBeTruthy();
+  });
+
+  it('resyncs from the server after a failed move', async () => {
+    vi.mocked(api.moveTask).mockRejectedValue(new Error('409: conflict'));
+    // A rejected move means the board was already out of date, so the
+    // snapshot is a stopgap: the server's state wins once it arrives.
+    vi.mocked(api.getTaskBoard).mockResolvedValue({
+      statuses: [],
+      lanes: [
+        { status: 'pending', total: 1, tasks: [task('b', 'pending', 2048)] },
+        { status: 'in_progress', total: 1, tasks: [task('a', 'in_progress', 1024)] },
+      ],
+    });
+
+    await useTaskStore.getState().moveTask('a', {
+      status: 'in_progress', beforeId: null, afterId: 'x',
+    });
+    // Let the un-awaited resync settle.
+    await vi.waitFor(() => expect(api.getTaskBoard).toHaveBeenCalled());
+    await Promise.resolve();
+
+    expect(laneOrder('pending')).toEqual(['b']);
+    expect(laneOrder('in_progress')).toEqual(['a']);
+  });
+});
+
+describe('handleTaskEvent', () => {
+  it('updates a card in place when the lane is unchanged', () => {
+    useTaskStore.getState().handleTaskEvent(
+      { ...task('b', 'pending', 2048), title: 'renamed' },
+    );
+    expect(laneOrder('pending')).toEqual(['a', 'b', 'c']);
+    expect(useTaskStore.getState().lanes[0].tasks[1].title).toBe('renamed');
+    // An in-place edit must not inflate the count.
+    expect(laneTotal('pending')).toBe(3);
+  });
+
+  it('re-slots a card that changed status elsewhere', () => {
+    useTaskStore.getState().handleTaskEvent(task('a', 'in_progress', 2048));
+
+    expect(laneOrder('pending')).toEqual(['b', 'c']);
+    // Inserted by rank, not appended: position 2048 sorts after x's 1024.
+    expect(laneOrder('in_progress')).toEqual(['x', 'a']);
+    expect(laneTotal('pending')).toBe(2);
+    expect(laneTotal('in_progress')).toBe(2);
+  });
+
+  it('inserts a task the board has never seen', () => {
+    useTaskStore.getState().handleTaskEvent(task('new', 'pending', 0));
+
+    // Rank 0 sorts above everything — where a newly created task belongs.
+    expect(laneOrder('pending')).toEqual(['new', 'a', 'b', 'c']);
+    expect(laneTotal('pending')).toBe(4);
+  });
+
+  it('reloads when the status has no lane on this board', () => {
+    vi.mocked(api.getTaskBoard).mockResolvedValue({ statuses: [], lanes: [] });
+
+    useTaskStore.getState().handleTaskEvent(task('a', 'in_review', 1024));
+
+    // Someone added a status; only a refetch can produce its column.
+    expect(api.getTaskBoard).toHaveBeenCalled();
+  });
+
+  it('is a no-op on an empty board', () => {
+    useTaskStore.setState({ lanes: [] });
+    expect(() =>
+      useTaskStore.getState().handleTaskEvent(task('a')),
+    ).not.toThrow();
+  });
+
+  it('refreshes the open detail task without dropping its loaded content', () => {
+    useTaskStore.setState({
+      selectedTask: { ...task('a'), content: '# loaded markdown' },
+    });
+
+    useTaskStore.getState().handleTaskEvent(
+      { ...task('a', 'in_progress', 1024), title: 'renamed' },
+    );
+
+    const sel = useTaskStore.getState().selectedTask!;
+    expect(sel.title).toBe('renamed');
+    expect(sel.status).toBe('in_progress');
+    // The broadcast carries the row, not the file — merging must not blank
+    // the markdown the detail view already fetched.
+    expect(sel.content).toBe('# loaded markdown');
+  });
+});

--- a/web/src/stores/taskStore.test.ts
+++ b/web/src/stores/taskStore.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
     boardError: null,
     viewMode: 'board',
     searchQuery: '',
+    tagFilter: '',
   });
 });
 
@@ -182,6 +183,52 @@ describe('handleTaskEvent', () => {
     expect(laneTotal('pending')).toBe(4);
   });
 
+  it('reloads instead of inserting into a lane it has not fully loaded', () => {
+    // The lane holds 40 tasks and shows 3. An update for one of the other
+    // 37 looks identical to a brand-new task from here, and inserting it
+    // would count it twice — once in the page, once in the total that
+    // drives "+N more".
+    useTaskStore.setState({
+      lanes: [
+        { status: 'pending', total: 40, tasks: [task('a', 'pending', 1024)] },
+        { status: 'in_progress', total: 1, tasks: [task('x', 'in_progress', 1024)] },
+      ],
+    });
+    vi.mocked(api.getTaskBoard).mockResolvedValue({ statuses: [], lanes: [] });
+
+    useTaskStore.getState().handleTaskEvent(task('deep', 'pending', 9999));
+
+    expect(api.getTaskBoard).toHaveBeenCalled();
+    expect(laneOrder('pending')).toEqual(['a']);
+    expect(laneTotal('pending')).toBe(40);
+  });
+
+  it('reloads instead of showing a card the tag filter excludes', () => {
+    // The lanes on screen are the filtered set, so a task that is missing
+    // from them may simply not match. Inserting it puts a card on the board
+    // that contradicts the filter the user set.
+    useTaskStore.setState({ tagFilter: 'urgent' });
+    vi.mocked(api.getTaskBoard).mockResolvedValue({ statuses: [], lanes: [] });
+
+    useTaskStore.getState().handleTaskEvent(task('chore', 'pending', 0));
+
+    expect(api.getTaskBoard).toHaveBeenCalled();
+    expect(laneOrder('pending')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('reloads instead of showing a card the search excludes', () => {
+    // Same reasoning as the tag filter, and it needs its own check: under a
+    // search the server sets total to the match count, so the lane never
+    // looks truncated.
+    useTaskStore.setState({ searchQuery: 'encoder' });
+    vi.mocked(api.getTaskBoard).mockResolvedValue({ statuses: [], lanes: [] });
+
+    useTaskStore.getState().handleTaskEvent(task('unrelated', 'pending', 0));
+
+    expect(api.getTaskBoard).toHaveBeenCalled();
+    expect(laneOrder('pending')).toEqual(['a', 'b', 'c']);
+  });
+
   it('reloads when the status has no lane on this board', () => {
     vi.mocked(api.getTaskBoard).mockResolvedValue({ statuses: [], lanes: [] });
 
@@ -275,5 +322,25 @@ describe('setSearch', () => {
 
     await vi.waitFor(() => expect(api.searchTasks).toHaveBeenCalled());
     expect(api.getTaskBoard).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadTasks', () => {
+  it('does not apply the board tag filter to the list', async () => {
+    // tagFilter belongs to the board: only the facet bar sets it and only
+    // the board renders it. Leaking it into the list silently hides rows in
+    // a view with nothing to show for the filter and no way to clear it —
+    // and only while the search box is empty, since /tasks/search takes no
+    // tag, so the result set would change on typing for no visible reason.
+    useTaskStore.setState({ viewMode: 'list', tagFilter: 'urgent' });
+    vi.mocked(api.listTasks).mockResolvedValue({
+      tasks: [], total: 0, limit: 0, offset: 0,
+    });
+
+    await useTaskStore.getState().loadTasks();
+
+    expect(api.listTasks).toHaveBeenCalledWith(
+      expect.not.objectContaining({ tag: expect.anything() }),
+    );
   });
 });

--- a/web/src/stores/taskStore.test.ts
+++ b/web/src/stores/taskStore.test.ts
@@ -42,6 +42,8 @@ beforeEach(() => {
     ],
     selectedTask: null,
     boardError: null,
+    viewMode: 'board',
+    searchQuery: '',
   });
 });
 
@@ -211,5 +213,67 @@ describe('handleTaskEvent', () => {
     // The broadcast carries the row, not the file — merging must not blank
     // the markdown the detail view already fetched.
     expect(sel.content).toBe('# loaded markdown');
+  });
+});
+
+describe('setSearch', () => {
+  it('refreshes the board when the board is on screen', async () => {
+    // The bug this pins: setSearch called loadTasks(), which only fills
+    // tasks[] — the list's state. The board renders from lanes[], so
+    // typing in the search box filtered an array nothing was reading.
+    useTaskStore.setState({ viewMode: 'board' });
+    vi.mocked(api.getTaskBoard).mockResolvedValue({
+      statuses: [], lanes: [],
+    });
+
+    useTaskStore.getState().setSearch('encoder');
+
+    await vi.waitFor(() => expect(api.getTaskBoard).toHaveBeenCalled());
+    expect(api.listTasks).not.toHaveBeenCalled();
+  });
+
+  it('sends the query to the board endpoint', async () => {
+    useTaskStore.setState({ viewMode: 'board' });
+    vi.mocked(api.getTaskBoard).mockResolvedValue({
+      statuses: [], lanes: [],
+    });
+
+    useTaskStore.getState().setSearch('  encoder  ');
+
+    await vi.waitFor(() =>
+      expect(api.getTaskBoard).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'encoder' }),
+      ),
+    );
+  });
+
+  it('omits the query entirely once search is cleared', async () => {
+    useTaskStore.setState({ viewMode: 'board', searchQuery: 'encoder' });
+    vi.mocked(api.getTaskBoard).mockResolvedValue({
+      statuses: [], lanes: [],
+    });
+
+    useTaskStore.getState().setSearch('');
+
+    // undefined, not '' — an empty q would make the server run a search
+    // that matches nothing instead of listing the lane.
+    await vi.waitFor(() =>
+      expect(api.getTaskBoard).toHaveBeenCalledWith(
+        expect.objectContaining({ q: undefined }),
+      ),
+    );
+  });
+
+  it('still refreshes the list in list view', async () => {
+    useTaskStore.setState({ viewMode: 'list' });
+    // A non-empty query routes through searchTasks, not listTasks.
+    vi.mocked(api.searchTasks).mockResolvedValue({
+      tasks: [], total: 0, limit: 0, offset: 0,
+    });
+
+    useTaskStore.getState().setSearch('encoder');
+
+    await vi.waitFor(() => expect(api.searchTasks).toHaveBeenCalled());
+    expect(api.getTaskBoard).not.toHaveBeenCalled();
   });
 });

--- a/web/src/stores/taskStore.ts
+++ b/web/src/stores/taskStore.ts
@@ -162,12 +162,16 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   loadTasks: async () => {
     set({ loading: true });
     try {
-      const { filter, searchQuery, sort, page, tagFilter } = get();
+      // `tagFilter` is deliberately not read here. It is board state: the
+      // facet bar is the only thing that sets it and only the board renders
+      // it. Applying it to the list would filter a view with no chip to
+      // show for it and no control to clear it — and only while the search
+      // box is empty, since /tasks/search takes no tag.
+      const { filter, searchQuery, sort, page } = get();
       const result = searchQuery
         ? await api.searchTasks(searchQuery, filter || undefined)
         : await api.listTasks({
             status: filter || undefined,
-            tag: tagFilter || undefined,
             sort,
             limit: TASKS_PAGE_SIZE,
             offset: (page - 1) * TASKS_PAGE_SIZE,
@@ -301,6 +305,21 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     if (!target) {
       // A status this board doesn't know about yet (someone just created
       // one). A full reload is the only way to get its lane.
+      void get().loadBoard({ quiet: true });
+      return;
+    }
+
+    // The card is nowhere on the board. That means it is new, or it is
+    // already in this lane below the loaded page, or the active filters
+    // exclude it — and the three are indistinguishable from here. Inserting
+    // regardless would double-count a card the lane already has, or show one
+    // the filter was asked to hide. Only trust the insert when the lane is
+    // whole and unfiltered; otherwise ask the server, which knows.
+    const { tagFilter, searchQuery } = get();
+    if (
+      !currentLane &&
+      (tagFilter || searchQuery.trim() || target.tasks.length < target.total)
+    ) {
       void get().loadBoard({ quiet: true });
       return;
     }

--- a/web/src/stores/taskStore.ts
+++ b/web/src/stores/taskStore.ts
@@ -1,23 +1,66 @@
 import { create } from 'zustand';
-import { api } from '../api/client';
+import { api, type Task } from '../api/client';
 
-export interface Task {
-  id: string;
-  title: string;
-  status: string;
-  deadline: string | null;
-  source: string;
-  source_url: string | null;
-  created_at: string;
-  updated_at: string;
-  content?: string;
-}
+export type { Task };
 
 export type TaskSort = 'deadline' | 'updated_at' | 'created_at';
+export type TaskViewMode = 'board' | 'list';
 
 export const TASKS_PAGE_SIZE = 50;
 
+/** One board column: a page of its tasks plus the lane's true total. */
+export interface Lane {
+  status: string;
+  total: number;
+  tasks: Task[];
+}
+
+/**
+ * Where a dragged card should land, expressed as its new neighbours.
+ *
+ * The server resolves this into a rank. Sending intent rather than a
+ * computed position means a board that's a few seconds stale still
+ * produces a sane result instead of overwriting someone else's ordering
+ * with numbers derived from a lane it no longer matches.
+ */
+export interface MoveIntent {
+  status: string;
+  beforeId: string | null;
+  afterId: string | null;
+}
+
+const VIEW_KEY = 'nerve_tasks_view';
+
+/** localStorage is unavailable in private modes; never let it break a render. */
+function readStoredView(): TaskViewMode | null {
+  try {
+    const raw = localStorage.getItem(VIEW_KEY);
+    return raw === 'board' || raw === 'list' ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredView(mode: TaskViewMode): void {
+  try {
+    localStorage.setItem(VIEW_KEY, mode);
+  } catch {
+    /* not fatal — the choice just won't survive a reload */
+  }
+}
+
+/** Board below this width is unusable; the list is the better default. */
+const BOARD_MIN_WIDTH = 1280;
+
+function defaultViewMode(): TaskViewMode {
+  const stored = readStoredView();
+  if (stored) return stored;
+  if (typeof window === 'undefined') return 'list';
+  return window.innerWidth >= BOARD_MIN_WIDTH ? 'board' : 'list';
+}
+
 interface TaskState {
+  // List view
   tasks: Task[];
   filter: string;
   searchQuery: string;
@@ -27,23 +70,71 @@ interface TaskState {
   loading: boolean;
   showCreateDialog: boolean;
 
+  // Board view
+  viewMode: TaskViewMode;
+  lanes: Lane[];
+  boardLoading: boolean;
+  boardError: string | null;
+  tagFilter: string;
+  availableTags: { name: string; count: number }[];
+  /** Lane to pre-select when the create dialog is opened from a column. */
+  createInStatus: string | null;
+
   // Detail view
   selectedTask: Task | null;
   detailLoading: boolean;
   saving: boolean;
 
   loadTasks: () => Promise<void>;
+  loadBoard: (opts?: { quiet?: boolean }) => Promise<void>;
+  loadTags: () => Promise<void>;
+  setViewMode: (mode: TaskViewMode) => void;
+  setTagFilter: (tag: string) => void;
+  moveTask: (taskId: string, intent: MoveIntent) => Promise<void>;
+  applyLocalMove: (taskId: string, intent: MoveIntent) => void;
+  handleTaskEvent: (task: Task) => void;
   setFilter: (f: string) => void;
   setSearch: (q: string) => void;
   setSort: (s: TaskSort) => void;
   setPage: (p: number) => void;
   updateStatus: (id: string, status: string) => Promise<void>;
   createTask: (title: string, content: string, deadline: string) => Promise<void>;
-  setShowCreateDialog: (show: boolean) => void;
+  setShowCreateDialog: (show: boolean, status?: string | null) => void;
 
   loadTask: (id: string) => Promise<void>;
   saveTaskContent: (id: string, content: string) => Promise<void>;
   clearSelectedTask: () => void;
+}
+
+/** Remove a task from every lane, returning the pruned lanes. */
+function withoutTask(lanes: Lane[], taskId: string): Lane[] {
+  return lanes.map((lane) => {
+    const kept = lane.tasks.filter((t) => t.id !== taskId);
+    return kept.length === lane.tasks.length
+      ? lane
+      : { ...lane, tasks: kept, total: Math.max(0, lane.total - 1) };
+  });
+}
+
+/** Insert a task into `status` at the slot described by the intent. */
+function withTaskAt(lanes: Lane[], task: Task, intent: MoveIntent): Lane[] {
+  return lanes.map((lane) => {
+    if (lane.status !== intent.status) return lane;
+    const tasks = [...lane.tasks];
+    let index = tasks.length;
+    if (intent.afterId) {
+      const at = tasks.findIndex((t) => t.id === intent.afterId);
+      if (at !== -1) index = at;
+    } else if (intent.beforeId) {
+      const at = tasks.findIndex((t) => t.id === intent.beforeId);
+      if (at !== -1) index = at + 1;
+    } else {
+      // No anchors: an empty lane, or a drop on the column background.
+      index = tasks.length;
+    }
+    tasks.splice(index, 0, { ...task, status: intent.status });
+    return { ...lane, tasks, total: lane.total + 1 };
+  });
 }
 
 export const useTaskStore = create<TaskState>((set, get) => ({
@@ -56,6 +147,14 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   loading: true,
   showCreateDialog: false,
 
+  viewMode: defaultViewMode(),
+  lanes: [],
+  boardLoading: true,
+  boardError: null,
+  tagFilter: '',
+  availableTags: [],
+  createInStatus: null,
+
   selectedTask: null,
   detailLoading: false,
   saving: false,
@@ -63,11 +162,12 @@ export const useTaskStore = create<TaskState>((set, get) => ({
   loadTasks: async () => {
     set({ loading: true });
     try {
-      const { filter, searchQuery, sort, page } = get();
+      const { filter, searchQuery, sort, page, tagFilter } = get();
       const result = searchQuery
         ? await api.searchTasks(searchQuery, filter || undefined)
         : await api.listTasks({
             status: filter || undefined,
+            tag: tagFilter || undefined,
             sort,
             limit: TASKS_PAGE_SIZE,
             offset: (page - 1) * TASKS_PAGE_SIZE,
@@ -77,6 +177,145 @@ export const useTaskStore = create<TaskState>((set, get) => ({
       console.error('Failed to load tasks:', e);
       set({ loading: false });
     }
+  },
+
+  /**
+   * `quiet` refetches without flipping the spinner — used to resync after a
+   * failed drag, where the board is already on screen and blanking it would
+   * be a worse experience than a brief inconsistency.
+   */
+  loadBoard: async ({ quiet = false } = {}) => {
+    // Only an explicit load clears the error. A quiet resync is usually
+    // triggered *by* a failure, so clearing here would wipe the message
+    // explaining what just went wrong before it could be read.
+    if (!quiet) set({ boardLoading: true, boardError: null });
+    try {
+      const { tagFilter } = get();
+      const { lanes } = await api.getTaskBoard({ tag: tagFilter || undefined });
+      set({ lanes, boardLoading: false });
+    } catch (e) {
+      console.error('Failed to load board:', e);
+      set({ boardLoading: false, boardError: 'Could not load the board.' });
+    }
+  },
+
+  loadTags: async () => {
+    try {
+      const { tags } = await api.listTaskTags();
+      set({ availableTags: tags });
+    } catch (e) {
+      console.error('Failed to load tags:', e);
+    }
+  },
+
+  setViewMode: (mode) => {
+    writeStoredView(mode);
+    set({ viewMode: mode });
+    if (mode === 'board') void get().loadBoard();
+    else void get().loadTasks();
+  },
+
+  setTagFilter: (tag) => {
+    set({ tagFilter: tag, page: 1 });
+    if (get().viewMode === 'board') void get().loadBoard();
+    else void get().loadTasks();
+  },
+
+  /** Reorder lanes in place, without touching the server. */
+  applyLocalMove: (taskId, intent) => {
+    const { lanes } = get();
+    const task = lanes.flatMap((l) => l.tasks).find((t) => t.id === taskId);
+    if (!task) return;
+    set({ lanes: withTaskAt(withoutTask(lanes, taskId), task, intent) });
+  },
+
+  moveTask: async (taskId, intent) => {
+    // Snapshot before the optimistic write so a failure can restore the
+    // exact prior order rather than approximating it.
+    const snapshot = get().lanes;
+    get().applyLocalMove(taskId, intent);
+
+    try {
+      const { task } = await api.moveTask(taskId, {
+        status: intent.status,
+        before_id: intent.beforeId,
+        after_id: intent.afterId,
+      });
+      // Reconcile against the server's authoritative row — mainly to pick
+      // up the real `position` and `updated_at`, and any file move that
+      // came with a status change.
+      set({
+        lanes: get().lanes.map((lane) => ({
+          ...lane,
+          tasks: lane.tasks.map((t) => (t.id === task.id ? { ...t, ...task } : t)),
+        })),
+        // A move that lands clears any stale failure banner.
+        boardError: null,
+      });
+    } catch (e) {
+      console.error('Move failed:', e);
+      set({ lanes: snapshot, boardError: 'Move failed — the board has been restored.' });
+      // Something rejected the move (a status that vanished, a task deleted
+      // from under us); resync rather than trusting the snapshot for long.
+      void get().loadBoard({ quiet: true });
+    }
+  },
+
+  /**
+   * Apply a `task_updated` broadcast.
+   *
+   * Fires for changes this client didn't make — the agent working in
+   * another session, a second tab, the HTTP API. It's also echoed back for
+   * changes this client *did* make, so it has to be idempotent: replacing
+   * in place when the lane is unchanged, and only re-slotting on an actual
+   * status change.
+   */
+  handleTaskEvent: (task) => {
+    const { lanes, selectedTask } = get();
+
+    if (selectedTask?.id === task.id) {
+      // Keep any locally-loaded markdown; the broadcast carries the row only.
+      set({ selectedTask: { ...selectedTask, ...task } });
+    }
+
+    if (lanes.length === 0) return;
+
+    const currentLane = lanes.find((l) => l.tasks.some((t) => t.id === task.id));
+
+    if (currentLane?.status === task.status) {
+      set({
+        lanes: lanes.map((lane) =>
+          lane.status !== task.status
+            ? lane
+            : { ...lane, tasks: lane.tasks.map((t) => (t.id === task.id ? { ...t, ...task } : t)) },
+        ),
+      });
+      return;
+    }
+
+    const pruned = currentLane ? withoutTask(lanes, task.id) : lanes;
+    const target = pruned.find((l) => l.status === task.status);
+    if (!target) {
+      // A status this board doesn't know about yet (someone just created
+      // one). A full reload is the only way to get its lane.
+      void get().loadBoard({ quiet: true });
+      return;
+    }
+
+    // Insert by rank so a card from elsewhere lands where the server would
+    // have put it, rather than at whichever end is convenient.
+    set({
+      lanes: pruned.map((lane) => {
+        if (lane.status !== task.status) return lane;
+        const tasks = [...lane.tasks];
+        const at = tasks.findIndex((t) => t.position > task.position);
+        tasks.splice(at === -1 ? tasks.length : at, 0, task);
+        // withoutTask already decremented the source lane, so this is a
+        // plain +1 whether the card came from another lane or from nowhere
+        // (a task created directly into this status).
+        return { ...lane, tasks, total: lane.total + 1 };
+      }),
+    });
   },
 
   setFilter: (f: string) => {
@@ -101,21 +340,29 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   updateStatus: async (id: string, status: string) => {
     await api.updateTask(id, { status });
-    // Update selected task inline if viewing it
     const sel = get().selectedTask;
     if (sel && sel.id === id) {
       set({ selectedTask: { ...sel, status } });
     }
-    get().loadTasks();
+    // The WS broadcast updates the board; only the list needs a refetch.
+    if (get().viewMode === 'list') get().loadTasks();
   },
 
   createTask: async (title: string, content: string, deadline: string) => {
-    await api.createTask({ title, content, deadline });
-    set({ showCreateDialog: false, page: 1 });
-    get().loadTasks();
+    const { createInStatus } = get();
+    await api.createTask({
+      title,
+      content,
+      deadline,
+      ...(createInStatus ? { status: createInStatus } : {}),
+    });
+    set({ showCreateDialog: false, createInStatus: null, page: 1 });
+    if (get().viewMode === 'board') void get().loadBoard({ quiet: true });
+    else get().loadTasks();
   },
 
-  setShowCreateDialog: (show: boolean) => set({ showCreateDialog: show }),
+  setShowCreateDialog: (show: boolean, status: string | null = null) =>
+    set({ showCreateDialog: show, createInStatus: show ? status : null }),
 
   loadTask: async (id: string) => {
     set({ detailLoading: true, selectedTask: null });
@@ -132,7 +379,6 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     set({ saving: true });
     try {
       await api.updateTask(id, { content });
-      // Update local state
       const sel = get().selectedTask;
       if (sel && sel.id === id) {
         set({ selectedTask: { ...sel, content } });

--- a/web/src/stores/taskStore.ts
+++ b/web/src/stores/taskStore.ts
@@ -190,8 +190,11 @@ export const useTaskStore = create<TaskState>((set, get) => ({
     // explaining what just went wrong before it could be read.
     if (!quiet) set({ boardLoading: true, boardError: null });
     try {
-      const { tagFilter } = get();
-      const { lanes } = await api.getTaskBoard({ tag: tagFilter || undefined });
+      const { tagFilter, searchQuery } = get();
+      const { lanes } = await api.getTaskBoard({
+        tag: tagFilter || undefined,
+        q: searchQuery.trim() || undefined,
+      });
       set({ lanes, boardLoading: false });
     } catch (e) {
       console.error('Failed to load board:', e);
@@ -325,7 +328,13 @@ export const useTaskStore = create<TaskState>((set, get) => ({
 
   setSearch: (q: string) => {
     set({ searchQuery: q, page: 1 });
-    get().loadTasks();
+    // Board and list read different state, so a search has to refresh
+    // whichever is on screen — the list's tasks[] and the board's lanes[]
+    // are populated by different calls. Quiet on the board: the input is
+    // debounced, and blanking the lanes on each keystroke reads as a
+    // flicker rather than as progress.
+    if (get().viewMode === 'board') void get().loadBoard({ quiet: true });
+    else get().loadTasks();
   },
 
   setSort: (s: TaskSort) => {


### PR DESCRIPTION
> **Stacked on #274** → #273 → #272 → `main`. Needs #272's API at runtime.

`/tasks` was a single column capped at `max-w-3xl` and centred — on a 2560px screen roughly two thirds of the viewport was empty. This adds a Board view alongside it: one lane per configured status, drag to reorder or change status, live updates as tasks change anywhere.

Board is the default at ≥1280px, List below it, and the choice is remembered. **List view is untouched** — same component, same behaviour. A linear, searchable, paginated view is still the better tool once there are more tasks than fit on a screen; this is a second lens, not a replacement.

What it looks like:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/5fcc07ff-6b03-4dc0-9db6-662c1edf4561" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/b3a07005-2056-4796-bc6b-7bab7a4270e6" />



## Ordering is server-authoritative

A drop resolves to *"put this between A and B"* and the server computes the rank (#272). A board a few seconds stale therefore can't overwrite someone else's ordering with numbers derived from a lane it no longer matches.

`dropIntent.ts` holds that translation as pure functions — mostly so the awkward case is testable. Dragging **downward** within a lane has to exclude the moved card before reading its anchors; skip that and it anchors against its own current position and lands one slot short of where you dropped it. Every direction is pinned in `dropIntent.test.tsx`.

## Moves are optimistic, with a real rollback

The card moves immediately. On failure the **exact prior order** is restored from a snapshot — totals included, since those drive the lane headers and the "+N more" affordance — then refetched, because a rejected move means the board was already out of date and the snapshot is only a stopgap.

## Live updates

`task_updated` moves cards when the agent changes a task in an unrelated session, or when a second tab does. Handling is idempotent, since the event is also echoed back to the client that caused it. On this instance that's most of the appeal: the agent works tasks constantly.

## Two smaller decisions

- **4px drag activation distance** — so a plain click still opens the task instead of starting a drag.
- **The board card drops the list card's inline status `<select>`.** At ~280px there's no room, and a card whose entire surface is a drag handle shouldn't also contain a control that swallows pointer events. Changing status here *is* the drag.

## Testing

- [x] `npm test` — 46 passed (27 new: 14 drop-geometry, 13 store)
- [x] `npx tsc -b` — clean
- [x] `npm run build` — clean
- [x] `npx eslint .` — 150 problems vs **152 on the base**; net −2 (typed the new API responses with the new `Task` interface rather than matching the file's existing `any`)

The store specs caught a real bug while being written: `loadBoard` cleared `boardError` synchronously, and since a failed move fires a quiet resync immediately afterward, **the "move failed" banner was wiped before it could ever render**. Error ownership is now explicit — only an explicit load clears it.

**Not verified yet: the actual drag, in a browser.** The drop *geometry* is tested as pure functions and the store reducers are tested directly, but dnd-kit's sensor wiring, the auto-scroll, the DragOverlay, and keyboard dragging are not — and they can't be until #272's API is deployed, since `GET /api/tasks/board` 404s on the current build. That needs a `nerve restart` on this instance, which restarts the agent, so I'm asking before doing it. Live pass to follow; I'll report back here.

## Follow-ups, deliberately not here

- **Task detail modal + background-location routing** — clicking a card currently navigates to the existing full `TaskDetailPage`, which works fine. The modal is the next PR.
- **No status-transition history exists anywhere in Nerve** (filed separately). Dragging is a cheap, frequent status change and `/move` routes through the note-less path, so every drag is currently an untracked mutation. A board is also what makes people ask "how long has this been in progress?" — unanswerable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)