### PR TITLE
[7/7] Reorder board columns by dragging

### DIFF
--- a/nerve/db/task_statuses.py
+++ b/nerve/db/task_statuses.py
@@ -68,6 +68,34 @@ class TaskStatusStore:
         ) as cursor:
             return [dict(row) async for row in cursor]
 
+    async def reorder_task_statuses(self, names: list[str]) -> list[dict]:
+        """Rewrite ``sort_order`` to match the given sequence of names.
+
+        Takes the whole desired order rather than one status's new index:
+        board columns are reordered by dragging, which shifts several
+        statuses at once, and sending the full sequence makes the write
+        idempotent and free of the intermediate states a per-row PATCH
+        storm would leave behind if one of them failed.
+
+        Names not present in the list keep their relative order after the
+        ones that are, so an unknown or omitted status can't be silently
+        dropped from the board.
+        """
+        async with self._atomic():
+            async with self.db.execute(
+                "SELECT name FROM task_statuses ORDER BY sort_order ASC, name ASC"
+            ) as cursor:
+                existing = [row[0] async for row in cursor]
+
+            wanted = [n for n in names if n in existing]
+            ordered = wanted + [n for n in existing if n not in wanted]
+            await self.db.executemany(
+                "UPDATE task_statuses SET sort_order = ? WHERE name = ?",
+                [(i, name) for i, name in enumerate(ordered)],
+            )
+
+        return await self.list_task_statuses()
+
     async def get_task_status_def(self, name: str) -> dict | None:
         async with self.db.execute(
             "SELECT * FROM task_statuses WHERE name = ?", (name,)

--- a/nerve/gateway/routes/tasks.py
+++ b/nerve/gateway/routes/tasks.py
@@ -434,6 +434,24 @@ async def create_task_status(
     return created
 
 
+class TaskStatusReorderRequest(BaseModel):
+    """The full desired column order, outermost first."""
+
+    names: list[str]
+
+
+@router.post("/api/task-statuses/reorder")
+async def reorder_task_statuses(
+    req: TaskStatusReorderRequest, user: dict = Depends(require_auth),
+):
+    """Set board column order in one write.
+
+    Declared above /{name} so "reorder" isn't captured as a status name.
+    """
+    deps = get_deps()
+    return {"statuses": await deps.db.reorder_task_statuses(req.names)}
+
+
 @router.patch("/api/task-statuses/{name}")
 async def update_task_status(
     name: str, req: TaskStatusUpdateRequest, user: dict = Depends(require_auth),

--- a/tests/test_task_board_api.py
+++ b/tests/test_task_board_api.py
@@ -490,6 +490,37 @@ class TestTaskBoardRoutes:
         resp = setup.client.patch("/api/tasks/nope", json={"status": "pending"})
         assert resp.status_code == 404
 
+    # ── Column order ─────────────────────────────────────────────────────
+
+    async def test_reorder_sets_board_column_order(self, setup):
+        before = [l["status"] for l in setup.client.get("/api/tasks/board").json()["lanes"]]
+        target = list(reversed(before))
+
+        resp = setup.client.post("/api/task-statuses/reorder", json={"names": target})
+
+        assert resp.status_code == 200
+        assert [s["name"] for s in resp.json()["statuses"]] == target
+        # The board is what actually has to change.
+        after = [l["status"] for l in setup.client.get("/api/tasks/board").json()["lanes"]]
+        assert after == target
+
+    async def test_reorder_route_is_not_captured_as_a_status_name(self, setup):
+        """/reorder must stay declared above /task-statuses/{name}."""
+        resp = setup.client.post("/api/task-statuses/reorder", json={"names": []})
+        assert resp.status_code == 200
+        assert "statuses" in resp.json()
+
+    async def test_reorder_keeps_omitted_statuses(self, setup):
+        before = [l["status"] for l in setup.client.get("/api/tasks/board").json()["lanes"]]
+
+        resp = setup.client.post(
+            "/api/task-statuses/reorder", json={"names": [before[-1]]},
+        )
+
+        names = [s["name"] for s in resp.json()["statuses"]]
+        assert names[0] == before[-1]
+        assert set(names) == set(before), "a status left out of the request vanished"
+
     # ── List ─────────────────────────────────────────────────────────────
 
     async def test_list_accepts_a_tag_filter(self, setup):

--- a/tests/test_task_statuses.py
+++ b/tests/test_task_statuses.py
@@ -246,3 +246,53 @@ class TestStatusToolHandlers:
         ctx = self._ctx(db, tmp_path)
         text = _text(await task_status_list_handler(ctx, {}))
         assert "pending" in text and "[protected]" in text
+
+
+@pytest.mark.asyncio
+class TestReorderTaskStatuses:
+    """Board column order, rewritten as a whole sequence.
+
+    Reordering by drag shifts several statuses at once, so the API takes the
+    full desired order rather than one status's new index — that makes the
+    write idempotent and avoids the half-applied states a per-row PATCH
+    storm would leave if one of them failed.
+    """
+
+    async def test_reorder_sets_the_given_sequence(self, db):
+        await db.create_task_status(name="review", label="Review", color="#111111")
+        original = [s["name"] for s in await db.list_task_statuses()]
+        reversed_order = list(reversed(original))
+
+        returned = await db.reorder_task_statuses(reversed_order)
+
+        assert [s["name"] for s in returned] == reversed_order
+        # And it persisted, rather than only shaping the return value.
+        assert [s["name"] for s in await db.list_task_statuses()] == reversed_order
+
+    async def test_reorder_is_idempotent(self, db):
+        order = [s["name"] for s in await db.list_task_statuses()]
+        await db.reorder_task_statuses(order)
+        await db.reorder_task_statuses(order)
+        assert [s["name"] for s in await db.list_task_statuses()] == order
+
+    async def test_omitted_statuses_are_kept_after_the_named_ones(self, db):
+        order = [s["name"] for s in await db.list_task_statuses()]
+        assert len(order) > 2
+
+        returned = await db.reorder_task_statuses([order[-1]])
+
+        # A status left out of the request must not vanish from the board.
+        assert [s["name"] for s in returned][0] == order[-1]
+        assert set(s["name"] for s in returned) == set(order)
+
+    async def test_unknown_names_are_ignored(self, db):
+        order = [s["name"] for s in await db.list_task_statuses()]
+
+        returned = await db.reorder_task_statuses(["not_a_status", *order])
+
+        assert [s["name"] for s in returned] == order
+
+    async def test_sort_order_is_contiguous_from_zero(self, db):
+        order = [s["name"] for s in await db.list_task_statuses()]
+        returned = await db.reorder_task_statuses(list(reversed(order)))
+        assert [s["sort_order"] for s in returned] == list(range(len(order)))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -432,6 +432,10 @@ export const api = {
     request<TaskStatusDef>('/task-statuses', { method: 'POST', body: JSON.stringify(data) }),
   updateTaskStatus: (name: string, data: { label?: string; color?: string; description?: string; sort_order?: number }) =>
     request<TaskStatusDef>(`/task-statuses/${encodeURIComponent(name)}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  reorderTaskStatuses: (names: string[]) =>
+    request<{ statuses: TaskStatusDef[] }>('/task-statuses/reorder', {
+      method: 'POST', body: JSON.stringify({ names }),
+    }),
   deleteTaskStatus: (name: string) =>
     request<{ name: string; deleted: boolean }>(`/task-statuses/${encodeURIComponent(name)}`, { method: 'DELETE' }),
 

--- a/web/src/components/Tasks/Board/BoardColumn.tsx
+++ b/web/src/components/Tasks/Board/BoardColumn.tsx
@@ -1,6 +1,8 @@
 import { useDroppable } from '@dnd-kit/core';
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { ChevronLeft, ChevronRight, Plus } from 'lucide-react';
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ChevronLeft, ChevronRight, GripVertical, Plus } from 'lucide-react';
+import { columnDragId } from './dropIntent';
 import type { Task, TaskStatusDef } from '../../../api/client';
 import type { Lane } from '../../../stores/taskStore';
 import { BoardCard } from './BoardCard';
@@ -26,13 +28,50 @@ export function BoardColumn({
     data: { type: 'lane', status: lane.status },
   });
 
+  // The column is itself sortable, but only by its header: the body has to
+  // stay a drop target for cards, and putting drag listeners on the whole
+  // column would make every card drag also pick up its column.
+  const {
+    setNodeRef: setColumnRef,
+    attributes: columnAttributes,
+    listeners: columnListeners,
+    transform: columnTransform,
+    transition: columnTransition,
+    isDragging: isColumnDragging,
+  } = useSortable({
+    id: columnDragId(lane.status),
+    data: { type: 'column', status: lane.status },
+  });
+
+  const columnStyle = {
+    transform: CSS.Translate.toString(columnTransform),
+    transition: columnTransition,
+  };
+  const dragHandle = (
+    <span
+      {...columnAttributes}
+      {...columnListeners}
+      title="Drag to reorder column"
+      aria-label={`Reorder ${status?.label ?? lane.status} column`}
+      className="text-text-faint hover:text-text-muted cursor-grab active:cursor-grabbing shrink-0"
+    >
+      <GripVertical size={13} />
+    </span>
+  );
+
   const label = status?.label ?? lane.status;
   const color = status?.color ?? '#6b7280';
   const hidden = lane.total - lane.tasks.length;
 
   if (collapsed) {
     return (
-      <div className="w-11 shrink-0 flex flex-col items-center gap-3 py-3 bg-surface-raised/40 border border-border-subtle rounded-xl">
+      <div
+        ref={setColumnRef}
+        style={columnStyle}
+        className={`w-11 shrink-0 flex flex-col items-center gap-3 py-3 bg-surface-raised/40 border border-border-subtle rounded-xl
+          ${isColumnDragging ? 'opacity-40' : ''}`}
+      >
+        {dragHandle}
         <button
           onClick={() => onToggleCollapse(lane.status)}
           className="text-text-faint hover:text-text-muted cursor-pointer"
@@ -56,9 +95,15 @@ export function BoardColumn({
   }
 
   return (
-    <div className="w-[300px] shrink-0 flex flex-col bg-surface-raised/40 border border-border-subtle rounded-xl max-h-full">
+    <div
+      ref={setColumnRef}
+      style={columnStyle}
+      className={`w-[300px] shrink-0 flex flex-col bg-surface-raised/40 border border-border-subtle rounded-xl max-h-full
+        ${isColumnDragging ? 'opacity-40' : ''}`}
+    >
       <div className="shrink-0 px-3 py-2.5 border-b border-border-subtle">
         <div className="flex items-center gap-2">
+          {dragHandle}
           <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
           <h2 className="text-[13px] font-semibold text-text-secondary truncate">{label}</h2>
           <span className="text-[11px] text-text-faint tabular-nums">{lane.total}</span>

--- a/web/src/components/Tasks/Board/TaskBoard.tsx
+++ b/web/src/components/Tasks/Board/TaskBoard.tsx
@@ -10,13 +10,23 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core';
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
 import type { Task } from '../../../api/client';
 import { useTaskStatusStore } from '../../../stores/taskStatusStore';
 import { useTaskStore } from '../../../stores/taskStore';
 import { boardAnnouncements } from './announcements';
 import { BoardCardOverlay } from './BoardCard';
-import { isNoOpMove, resolveDropIntent } from './dropIntent';
+import {
+  columnDragId,
+  isNoOpMove,
+  reorderStatuses,
+  resolveDropIntent,
+  statusFromDropTarget,
+} from './dropIntent';
 import { BoardColumn } from './BoardColumn';
 
 const COLLAPSED_KEY = 'nerve_board_collapsed';
@@ -48,8 +58,10 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
   const setShowCreateDialog = useTaskStore((s) => s.setShowCreateDialog);
   const searchQuery = useTaskStore((s) => s.searchQuery);
   const statuses = useTaskStatusStore((s) => s.statuses);
+  const reorderColumns = useTaskStatusStore((s) => s.reorder);
 
   const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const [activeColumn, setActiveColumn] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState<string[]>(readCollapsed);
 
   const sensors = useSensors(
@@ -80,12 +92,17 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
   }, []);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
-    const task = event.active.data.current?.task as Task | undefined;
-    setActiveTask(task ?? null);
+    const data = event.active.data.current;
+    if (data?.type === 'column') {
+      setActiveColumn(String(data.status));
+      return;
+    }
+    setActiveTask((data?.task as Task | undefined) ?? null);
   }, []);
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     setActiveTask(null);
+    setActiveColumn(null);
     const { active, over } = event;
     if (!over) return;
 
@@ -93,13 +110,24 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
     const overId = String(over.id);
     if (activeId === overId) return;
 
+    // Columns and cards share one DndContext, so branch on what was picked
+    // up rather than on what it landed on.
+    if (active.data.current?.type === 'column') {
+      const moved = String(active.data.current.status);
+      const target = statusFromDropTarget(lanes, overId);
+      if (!target) return;
+      const next = reorderStatuses(lanes.map((l) => l.status), moved, target);
+      if (next) void reorderColumns(next);
+      return;
+    }
+
     const intent = resolveDropIntent(lanes, activeId, overId);
     if (!intent) return;
     // Skip the round trip when the card was dropped back where it started.
     if (isNoOpMove(lanes, activeId, intent)) return;
 
     void moveTask(activeId, intent);
-  }, [lanes, moveTask]);
+  }, [lanes, moveTask, reorderColumns]);
 
   if (boardLoading) {
     return <div className="text-text-faint text-center py-10">Loading board...</div>;
@@ -132,11 +160,15 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
         collisionDetection={closestCorners}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
-        onDragCancel={() => setActiveTask(null)}
+        onDragCancel={() => { setActiveTask(null); setActiveColumn(null); }}
         accessibility={{ announcements }}
       >
         <div className="flex-1 min-h-0 overflow-x-auto overflow-y-hidden px-4 pb-4">
           <div className="flex gap-3 h-full items-start min-w-min">
+            <SortableContext
+              items={lanes.map((l) => columnDragId(l.status))}
+              strategy={horizontalListSortingStrategy}
+            >
             {lanes.map((lane) => (
               <BoardColumn
                 key={lane.status}
@@ -149,11 +181,17 @@ export function TaskBoard({ onOpenTask }: { onOpenTask: (task: Task) => void }) 
                 onOpenTask={onOpenTask}
               />
             ))}
+            </SortableContext>
           </div>
         </div>
 
         <DragOverlay dropAnimation={null}>
           {activeTask && <BoardCardOverlay task={activeTask} />}
+          {activeColumn && (
+            <div className="w-[300px] px-3 py-2.5 bg-surface-raised border border-accent/50 rounded-xl shadow-xl text-[13px] font-semibold text-text-secondary">
+              {statusByName.get(activeColumn)?.label ?? activeColumn}
+            </div>
+          )}
         </DragOverlay>
       </DndContext>
     </>

--- a/web/src/components/Tasks/Board/announcements.test.ts
+++ b/web/src/components/Tasks/Board/announcements.test.ts
@@ -25,6 +25,9 @@ const overCard = (id: string, title: string) =>
 const lane = (status: string) =>
   ({ id: `lane:${status}`, data: { current: { type: 'lane', status } } }) as unknown as Over;
 
+const column = (status: string) =>
+  ({ id: `col:${status}`, data: { current: { type: 'column', status } } }) as unknown as Active;
+
 describe('boardAnnouncements', () => {
   const dragged = card('2026-08-05-fix-the-encoder', 'Fix the encoder');
 
@@ -76,6 +79,30 @@ describe('boardAnnouncements', () => {
   it('falls back to the status name when it has no configured label', () => {
     expect(a.onDragEnd({ active: dragged, over: lane('triage') })).toBe(
       'Task Fix the encoder dropped on the triage lane.',
+    );
+  });
+});
+
+describe('boardAnnouncements for a column drag', () => {
+  // Columns and cards share one DndContext, so `active` is not always a
+  // task. Assuming it was announced "Picked up task col:pending."
+  const dragged = column('pending');
+
+  it('says a column was picked up, not a task called col:something', () => {
+    expect(a.onDragStart({ active: dragged })).toBe('Picked up the Pending column.');
+  });
+
+  it('describes both ends of a column-over-column drag', () => {
+    expect(a.onDragOver({ active: dragged, over: column('in_progress') as unknown as Over })).toBe(
+      'The Pending column is over the In Progress column.',
+    );
+  });
+
+  it('describes a column dropped onto a card it landed over', () => {
+    // Collision detection returns the nearest droppable of any kind, so a
+    // column drag routinely finishes with the cursor over a card.
+    expect(a.onDragEnd({ active: dragged, over: overCard('t9', 'Some card') })).toBe(
+      'The Pending column dropped on task Some card.',
     );
   });
 });

--- a/web/src/components/Tasks/Board/announcements.ts
+++ b/web/src/components/Tasks/Board/announcements.ts
@@ -6,9 +6,13 @@
  * invisible to everyone else, so it needs tests rather than a look.
  *
  * The identifiers involved are a task slug ("2026-08-05-fix-the-encoder")
- * and namespaced droppable keys ("lane:pending"), so announcing ids reads
- * out the data model instead of the board. Every draggable and droppable
- * already carries a typed payload; these messages name the thing from that.
+ * and namespaced keys ("lane:pending", "col:pending"), so announcing ids
+ * reads out the data model instead of the board. Every draggable and
+ * droppable already carries a typed payload; these messages name the thing
+ * from that.
+ *
+ * Cards and columns share one DndContext, so `active` is not always a task
+ * and the wording has to come from the payload rather than be assumed.
  */
 import type { Announcements, Active, Over } from '@dnd-kit/core';
 import type { Task } from '../../../api/client';
@@ -19,6 +23,7 @@ export function boardAnnouncements(labelFor: (status: string) => string): Announ
     const data = node?.data.current;
     if (data?.type === 'task') return `task ${(data.task as Task).title}`;
     if (data?.type === 'lane') return `the ${labelFor(String(data.status))} lane`;
+    if (data?.type === 'column') return `the ${labelFor(String(data.status))} column`;
     // Every draggable and droppable on the board sets `data`, so this is
     // unreachable — but an announcement is the wrong place to throw, and a
     // bare id still says more than an empty string.

--- a/web/src/components/Tasks/Board/dropIntent.test.tsx
+++ b/web/src/components/Tasks/Board/dropIntent.test.tsx
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { Task } from '../../../api/client';
 import type { Lane } from '../../../stores/taskStore';
-import { isNoOpMove, resolveDropIntent } from './dropIntent';
+import {
+  columnDragId,
+  isNoOpMove,
+  reorderStatuses,
+  resolveDropIntent,
+  statusFromDropTarget,
+} from './dropIntent';
 
 /**
  * Drop resolution: "card X landed on target Y" → the neighbour pair the
@@ -125,5 +131,68 @@ describe('isNoOpMove', () => {
   it('recognises the tail slot as a no-op for the last card', () => {
     expect(isNoOpMove(lanes(), 'c', { status: 'pending', beforeId: 'b', afterId: null }))
       .toBe(true);
+  });
+});
+
+describe('statusFromDropTarget', () => {
+  it('resolves a column drop target', () => {
+    expect(statusFromDropTarget(lanes(), columnDragId('done'))).toBe('done');
+  });
+
+  it('resolves a lane body drop target', () => {
+    expect(statusFromDropTarget(lanes(), 'lane:in_progress')).toBe('in_progress');
+  });
+
+  it('resolves a card drop target to its lane', () => {
+    // A column drag often finishes with the cursor over a card, since
+    // collision detection returns the nearest droppable of any kind.
+    // Treating that as "no target" would make the gesture feel broken.
+    expect(statusFromDropTarget(lanes(), 'b')).toBe('pending');
+  });
+
+  it('returns null for an unknown target', () => {
+    expect(statusFromDropTarget(lanes(), 'ghost')).toBeNull();
+  });
+
+  it('namespaces column ids away from task ids', () => {
+    // A status could legitimately be named the same as nothing here, but
+    // the prefix is what guarantees a task id can never be mistaken for a
+    // column in the shared DndContext.
+    expect(columnDragId('pending')).not.toBe('pending');
+    expect(statusFromDropTarget(lanes(), columnDragId('pending'))).toBe('pending');
+  });
+});
+
+describe('reorderStatuses', () => {
+  const order = ['pending', 'in_progress', 'done'];
+
+  it('moves a column later', () => {
+    expect(reorderStatuses(order, 'pending', 'done'))
+      .toEqual(['in_progress', 'done', 'pending']);
+  });
+
+  it('moves a column earlier', () => {
+    expect(reorderStatuses(order, 'done', 'pending'))
+      .toEqual(['done', 'pending', 'in_progress']);
+  });
+
+  it('moves into the middle', () => {
+    expect(reorderStatuses(order, 'done', 'in_progress'))
+      .toEqual(['pending', 'done', 'in_progress']);
+  });
+
+  it('returns null when the column lands on itself', () => {
+    // Skips the request entirely rather than writing the order it already had.
+    expect(reorderStatuses(order, 'pending', 'pending')).toBeNull();
+  });
+
+  it('returns null when either end is unknown', () => {
+    expect(reorderStatuses(order, 'pending', 'nope')).toBeNull();
+    expect(reorderStatuses(order, 'nope', 'pending')).toBeNull();
+  });
+
+  it('preserves every column', () => {
+    const next = reorderStatuses(order, 'in_progress', 'done')!;
+    expect([...next].sort()).toEqual([...order].sort());
   });
 });

--- a/web/src/components/Tasks/Board/dropIntent.ts
+++ b/web/src/components/Tasks/Board/dropIntent.ts
@@ -65,3 +65,52 @@ export function isNoOpMove(
   const currentAfter = lane.tasks[at + 1]?.id ?? null;
   return intent.beforeId === currentBefore && intent.afterId === currentAfter;
 }
+
+// ── Column ordering ──────────────────────────────────────────────────────
+
+const COLUMN_PREFIX = 'col:';
+
+/** Drag id for a column, namespaced so it can't collide with a task id. */
+export function columnDragId(status: string): string {
+  return `${COLUMN_PREFIX}${status}`;
+}
+
+export function isColumnDragId(id: string): boolean {
+  return id.startsWith(COLUMN_PREFIX);
+}
+
+/**
+ * The status a drop target belongs to, whichever kind of target it is.
+ *
+ * A column drag can finish over another column, over a lane body, or over
+ * a card — collision detection returns the nearest droppable of any kind,
+ * and all three mean "put it here". Resolving them all keeps the gesture
+ * forgiving instead of silently doing nothing when the cursor happens to
+ * be over a card.
+ */
+export function statusFromDropTarget(lanes: Lane[], overId: string): string | null {
+  if (isColumnDragId(overId)) return overId.slice(COLUMN_PREFIX.length);
+  if (overId.startsWith('lane:')) return overId.slice('lane:'.length);
+  const owning = lanes.find((l) => l.tasks.some((t) => t.id === overId));
+  return owning?.status ?? null;
+}
+
+/**
+ * Reorder `statuses` by moving `moved` to where `target` currently sits.
+ * Returns null when the move is a no-op or either end is unknown, so the
+ * caller can skip the request entirely.
+ */
+export function reorderStatuses(
+  statuses: string[],
+  moved: string,
+  target: string,
+): string[] | null {
+  if (moved === target) return null;
+  const from = statuses.indexOf(moved);
+  const to = statuses.indexOf(target);
+  if (from === -1 || to === -1) return null;
+  const next = [...statuses];
+  next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}

--- a/web/src/stores/taskStatusStore.ts
+++ b/web/src/stores/taskStatusStore.ts
@@ -13,6 +13,7 @@ interface TaskStatusState {
   create: (data: { name: string; label?: string; color?: string; description?: string }) => Promise<void>;
   update: (name: string, data: { label?: string; color?: string; description?: string; sort_order?: number }) => Promise<void>;
   remove: (name: string) => Promise<void>;
+  reorder: (names: string[]) => Promise<void>;
   byName: (name: string) => TaskStatusDef | undefined;
 }
 
@@ -42,6 +43,28 @@ export const useTaskStatusStore = create<TaskStatusState>((set, get) => ({
   update: async (name, data) => {
     await api.updateTaskStatus(name, data);
     await get().load(true);
+  },
+
+  /**
+   * Set column order. Applied locally first so the dragged column doesn't
+   * snap back while the request is in flight; the server's echo is
+   * authoritative, and a failure reloads rather than guessing.
+   */
+  reorder: async (names) => {
+    const snapshot = get().statuses;
+    const byName = new Map(snapshot.map((s) => [s.name, s]));
+    const optimistic = names
+      .map((n) => byName.get(n))
+      .filter((s): s is TaskStatusDef => Boolean(s));
+    if (optimistic.length === snapshot.length) set({ statuses: optimistic });
+    try {
+      const { statuses } = await api.reorderTaskStatuses(names);
+      set({ statuses });
+    } catch (e) {
+      console.error('Failed to reorder statuses:', e);
+      set({ statuses: snapshot });
+      await get().load(true);
+    }
   },
 
   // Throws on failure (e.g. 409 in-use, 400 protected) so callers can surface


### PR DESCRIPTION
> **Stacked on #277** → #276 → #275 → #274 → #273 → #272 → `main`.

From live testing feedback. Column order was fixed at whatever `sort_order` the statuses happened to have, with no way to change it from the UI — and lane order is the part of a board people arrange to match how they actually work.

## Two details make the drag work

Columns are sortable **in the same `DndContext` as the cards**, branching on what was picked up rather than on what it landed on.

1. **Drag listeners live on the header only**, not the whole column. The body has to stay a drop target for cards; listeners on the wrapper would make every card drag also pick up its column.
2. **Column ids are namespaced** (`col:<status>`) so they can't be confused with a task id inside the shared context — and a drop resolves through *any* kind of target: another column, a lane body, or a card. Collision detection returns the nearest droppable of any kind, so a column drag routinely finishes with the cursor over a card. Treating that as "no target" would make the gesture feel broken for no reason.

## The API takes a whole sequence, not an index

`POST /api/task-statuses/reorder {names: [...]}`.

A drag shifts several statuses at once, so a full-sequence write is idempotent and avoids the half-applied states a per-row `PATCH` storm would leave behind if one of them failed. Statuses omitted from the request keep their relative order *after* the named ones, so an incomplete call can't drop a column off the board.

Applied optimistically in the store so the dragged column doesn't snap back mid-request; the server's echo is authoritative and a failure reloads rather than guessing.

## Testing

- [x] `pytest tests/ -q` — **3113 passed**
- [x] `npm test` — **84 passed** (11 for the column geometry, 3 for the column announcements)
- [x] `tsc -b` + `npm run build` clean · `eslint` 146

The reorder route test includes a declaration-order guard — `/reorder` has to stay above `/task-statuses/{name}` or it gets captured as a status name.

**Not verified: the drag gesture itself in a browser.** Geometry and the reorder reducer are tested as pure functions, but dnd-kit's sensor behaviour with two nested `SortableContext`s (horizontal columns, vertical cards) isn't. Needs a `nerve restart` on the instance to deploy the endpoint before I can check it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
