### PR TITLE
[0/8] Stop a task write from dropping metadata or deleting the file

### DIFF
--- a/nerve/agent/tools/handlers/tasks.py
+++ b/nerve/agent/tools/handlers/tasks.py
@@ -38,6 +38,7 @@ from nerve.db.task_statuses import (
     normalize_color,
     random_status_color,
 )
+from nerve.tasks.files import move_task_file
 
 logger = logging.getLogger(__name__)
 
@@ -346,18 +347,20 @@ async def task_update_handler(ctx: ToolContext, args: dict) -> ToolResult:
 
                 final_title = new_title or task["title"]
                 final_status = status or task["status"]
-                final_deadline = deadline or task.get("deadline")
-                final_tags = new_tags_str if raw_tags else (task.get("tags") or "")
+                # Only the columns this call edits. The rest keep their
+                # stored values, so nothing has to be read back off ``task``.
+                edits: dict = {}
+                if deadline:
+                    edits["deadline"] = deadline
+                if raw_tags:
+                    edits["tags"] = new_tags_str
                 await ctx.db.upsert_task(
                     task_id=task_id,
                     file_path=task["file_path"],
                     title=final_title,
                     status=final_status,
-                    source=task.get("source"),
-                    source_url=task.get("source_url"),
-                    deadline=final_deadline,
-                    tags=final_tags,
                     content=content,
+                    **edits,
                 )
                 return ToolResult.text(f"Task {task_id} updated.")
 
@@ -432,18 +435,20 @@ async def task_write_handler(ctx: ToolContext, args: dict) -> ToolResult:
     # The deadline column is a pure projection of the file's Deadline line, so it
     # comes from the content we just wrote, never from the pre-write snapshot.
     new_deadline = frontmatter.get("deadline", "")
-    new_tags = tags_to_string(parse_tags_string(frontmatter.get("tags", task.get("tags", ""))))
+    # Tags follow the reindex rule: the file wins whenever it carries the
+    # field, and an absent field keeps the stored column.
+    edits: dict = {}
+    if "tags" in frontmatter:
+        edits["tags"] = tags_to_string(parse_tags_string(frontmatter["tags"]))
 
     await ctx.db.upsert_task(
         task_id=task_id,
         file_path=task["file_path"],
         title=new_title,
         status=task["status"],
-        source=task.get("source"),
-        source_url=task.get("source_url"),
         deadline=new_deadline or None,
-        tags=new_tags,
         content=new_content,
+        **edits,
     )
 
     return ToolResult.text(f"Task {task_id} written ({len(new_content)} chars).")
@@ -458,9 +463,9 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
         if not task:
             return ToolResult.text(f"Task not found: {task_id}", is_error=True)
 
-        # Done is a write like any other — it copies the file into done/ and
-        # unlinks the source, so a stored ``file_path`` inside the tracked config
-        # subtree would delete config. Refuse before the status flip, or a
+        # Done is a write like any other — it appends to the file and moves it
+        # into done/, so a stored ``file_path`` inside the tracked config
+        # subtree would rewrite config. Refuse before the status flip, or a
         # refusal leaves a task marked done whose file never moved.
         if ctx.workspace:
             ensure_path_not_tracked_config(ctx.workspace / task["file_path"], "move")
@@ -486,11 +491,7 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
 
                 dst = _done_dir(ctx) / src.name
 
-                def _move_to_done() -> None:
-                    dst.write_text(content, encoding="utf-8")
-                    src.unlink()
-
-                await asyncio.to_thread(_move_to_done)
+                await asyncio.to_thread(move_task_file, src, dst, content)
 
                 rel_path = str(dst.relative_to(ctx.workspace))
                 await ctx.db.upsert_task(
@@ -498,10 +499,6 @@ async def task_done_handler(ctx: ToolContext, args: dict) -> ToolResult:
                     file_path=rel_path,
                     title=task["title"],
                     status="done",
-                    source=task.get("source"),
-                    source_url=task.get("source_url"),
-                    deadline=task.get("deadline"),
-                    tags=task.get("tags") or "",
                     content=content,
                 )
 

--- a/nerve/db/tasks.py
+++ b/nerve/db/tasks.py
@@ -6,6 +6,35 @@ import re
 from datetime import datetime, timezone
 
 
+class _Keep:
+    """Type of the :data:`KEEP` sentinel."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "KEEP"
+
+
+# Default for the preserve-on-omit columns of :meth:`TaskStore.upsert_task`.
+# A separate sentinel is necessary because ``None`` is a real value there: it
+# clears the column.
+KEEP = _Keep()
+
+
+def _resolve_kept(value, stored: dict | None, column: str, default):
+    """Resolve one preserve-on-omit argument against the stored row.
+
+    A stored NULL gives ``default``. A row written before its column existed
+    can hold NULL, and ``tags`` must stay a ``str``.
+    """
+    if value is not KEEP:
+        return value
+    if stored is None:
+        return default
+    kept = stored[column]
+    return default if kept is None else kept
+
+
 class TaskStore:
     """Mixin providing task CRUD, FTS search, and escalation operations."""
 
@@ -15,14 +44,41 @@ class TaskStore:
         file_path: str,
         title: str,
         status: str = "pending",
-        source: str | None = None,
-        source_url: str | None = None,
-        deadline: str | None = None,
-        tags: str = "",
+        source: str | None | _Keep = KEEP,
+        source_url: str | None | _Keep = KEEP,
+        deadline: str | None | _Keep = KEEP,
+        tags: str | _Keep = KEEP,
         content: str = "",
     ) -> None:
+        """Insert or update a task row and its FTS entry.
+
+        ``file_path``, ``title``, ``status`` and ``content`` are a full
+        replace. Every caller rebuilds them from the markdown file.
+
+        ``source``, ``source_url``, ``deadline`` and ``tags`` are
+        preserve-on-omit. An omitted column keeps its stored value. To clear
+        one, pass it: ``None`` for the nullable columns, ``""`` for ``tags``.
+
+        Those four columns need that rule because a markdown file carries
+        them only while it has the frontmatter for them. Under a full
+        replace, every caller has to read the row and pass all four back,
+        and a caller that forgets one deletes user data. That happened
+        twice. ``TaskManager.reindex`` dropped ``tags`` after v018 added the
+        column, and ``task_done`` nulled all four when it moved a file into
+        done/. ``test_task_upsert_preserve.py`` holds the rule itself;
+        ``test_task_reindex.py`` and ``test_task_completion.py`` hold the
+        caller-level regressions.
+        """
         now = datetime.now(timezone.utc).isoformat()
         async with self._atomic():
+            # One read resolves every preserve-on-omit column. The statement
+            # below stays a plain full replace, and the FTS text sees the
+            # tags that actually land in the row.
+            stored = await self._stored_task_columns(task_id)
+            source = _resolve_kept(source, stored, "source", None)
+            source_url = _resolve_kept(source_url, stored, "source_url", None)
+            deadline = _resolve_kept(deadline, stored, "deadline", None)
+            tags = _resolve_kept(tags, stored, "tags", "")
             await self.db.execute(
                 """INSERT INTO tasks (id, file_path, title, status, source, source_url, deadline, tags, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -48,6 +104,15 @@ class TaskStore:
         async with self.db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)) as cursor:
             row = await cursor.fetchone()
             return dict(row) if row else None
+
+    async def _stored_task_columns(self, task_id: str) -> dict | None:
+        """The columns an upsert can preserve, or ``None`` for a new task."""
+        async with self.db.execute(
+            "SELECT source, source_url, deadline, tags FROM tasks WHERE id = ?",
+            (task_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return dict(row) if row else None
 
     # Supported sort keys → ORDER BY clause. Keep deterministic with a
     # secondary key so equal timestamps don't flicker between pages.

--- a/nerve/gateway/routes/tasks.py
+++ b/nerve/gateway/routes/tasks.py
@@ -147,16 +147,20 @@ async def update_task(task_id: str, req: TaskUpdateRequest, user: dict = Depends
             )
             new_title = parse_task_title(req.content)
             fields = parse_task_frontmatter(req.content)
+            # Only the columns the saved markdown carries. The rest keep their
+            # stored values, so nothing is read back off ``task`` here.
+            edits: dict = {}
+            if fields.get("deadline"):
+                edits["deadline"] = fields["deadline"]
+            if fields.get("tags"):
+                edits["tags"] = tags_to_string(parse_tags_string(fields["tags"]))
             await deps.db.upsert_task(
                 task_id=task_id,
                 file_path=task["file_path"],
                 title=new_title,
                 status=req.status or task["status"],
-                source=task.get("source"),
-                source_url=task.get("source_url"),
-                deadline=fields.get("deadline") or task.get("deadline"),
-                tags=tags_to_string(parse_tags_string(fields.get("tags") or task.get("tags", ""))),
                 content=req.content,
+                **edits,
             )
 
     # Update status/note/deadline/title via the unified handler (may

--- a/nerve/tasks/files.py
+++ b/nerve/tasks/files.py
@@ -1,0 +1,26 @@
+"""Filesystem moves for task markdown files.
+
+Shared by the task tool handlers and :class:`~nerve.tasks.manager.TaskManager`,
+which both move a file between ``memory/tasks/active/`` and
+``memory/tasks/done/`` as a task changes status.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def move_task_file(src: Path, dst: Path, content: str) -> None:
+    """Write ``content`` to ``src``, then move it to ``dst``.
+
+    The move is a rename, not a copy followed by an unlink. A copy deletes the
+    file whenever ``src`` and ``dst`` are the same path, and that happens every
+    time a task is completed twice: the first completion stores a ``file_path``
+    under done/, and the second one reads that path back as its source. A
+    rename onto one path is a no-op, so the same sequence now only appends the
+    second note.
+
+    Blocking. Call it through ``asyncio.to_thread``.
+    """
+    src.write_text(content, encoding="utf-8")
+    src.replace(dst)

--- a/nerve/tasks/manager.py
+++ b/nerve/tasks/manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from nerve.config import ensure_path_not_tracked_config
 from nerve.db import Database
+from nerve.tasks.files import move_task_file
 from nerve.tasks.models import (
     Task,
     TaskStatus,
@@ -35,14 +36,16 @@ class TaskManager:
     async def reindex(self) -> int:
         """Scan task files and rebuild the SQLite + FTS index.
 
-        ``upsert_task`` replaces the whole row, so every column this loop does
-        not supply is written back as its signature default. Values that live
-        only in the DB (status) are carried from the stored row. For values the
-        file may carry, the rule is per column, each matching the save path that
-        already writes it: ``tags`` takes the file whenever the field is
-        present, so a present-but-empty field is an explicit clear;
-        ``source_url`` and ``deadline`` take any non-empty file value and
-        otherwise keep the stored row.
+        This loop supplies only the columns a markdown file carries. The rest
+        keep their stored values, because ``upsert_task`` is preserve-on-omit
+        for them. Which file values win is a per-column rule, each matching
+        the save path that already writes the column: ``tags`` takes the file
+        whenever the field is present, so a present-but-empty field is an
+        explicit clear; ``source_url`` and ``deadline`` take any non-empty
+        file value.
+
+        ``status`` is different. It lives only in the DB, so this loop reads
+        it from the stored row and always supplies it.
         """
         await self.db.rebuild_fts()
         count = 0
@@ -72,24 +75,26 @@ class TaskManager:
                         prev = stored.get("status")
                         status = prev if prev and prev != "done" else default_status
 
+                    edits: dict = {}
+                    # **Source:** carries the URL (handlers/tasks.py writes
+                    # source_url there); `source` is a DB-only vocabulary, so
+                    # no file value ever reaches it.
+                    if fields.get("source"):
+                        edits["source_url"] = fields["source"]
+                    if fields.get("deadline"):
+                        edits["deadline"] = fields["deadline"]
+                    # Presence, not truthiness: a present-but-empty field is
+                    # an explicit clear, an absent one is "no information".
+                    if "tags" in fields:
+                        edits["tags"] = tags_to_string(parse_tags_string(fields["tags"]))
+
                     await self.db.upsert_task(
                         task_id=task_id,
                         file_path=rel_path,
                         title=title,
                         status=status,
-                        # **Source:** carries the URL (handlers/tasks.py writes
-                        # source_url there); `source` is a DB-only vocabulary.
-                        source=stored.get("source"),
-                        source_url=fields.get("source") or stored.get("source_url"),
-                        deadline=fields.get("deadline") or stored.get("deadline"),
-                        # Presence, not truthiness: a present-but-empty field is
-                        # an explicit clear, an absent one is "no information".
-                        tags=(
-                            tags_to_string(parse_tags_string(fields["tags"]))
-                            if "tags" in fields
-                            else (stored.get("tags") or "")
-                        ),
                         content=content,
+                        **edits,
                     )
                     count += 1
                 except Exception as e:
@@ -128,9 +133,9 @@ class TaskManager:
             return False
 
         src = self.workspace / row["file_path"]
-        # Done is a write like any other — it copies the file into done/ and
-        # unlinks the source, so a stored ``file_path`` inside the tracked config
-        # subtree would delete config. Refuse before any of it runs, or the
+        # Done is a write like any other — it appends to the file and moves it
+        # into done/, so a stored ``file_path`` inside the tracked config
+        # subtree would rewrite config. Refuse before any of it runs, or the
         # refusal still leaves that config file mirrored into done/.
         ensure_path_not_tracked_config(src, "move")
         if src.exists():
@@ -139,11 +144,7 @@ class TaskManager:
             today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             content += f"\n- {today}: DONE"
 
-            def _move_to_done() -> None:
-                dst.write_text(content, encoding="utf-8")
-                src.unlink()
-
-            await asyncio.to_thread(_move_to_done)
+            await asyncio.to_thread(move_task_file, src, dst, content)
 
             # Update DB
             rel_path = str(dst.relative_to(self.workspace))
@@ -152,10 +153,6 @@ class TaskManager:
                 file_path=rel_path,
                 title=row["title"],
                 status="done",
-                source=row.get("source"),
-                source_url=row.get("source_url"),
-                deadline=row.get("deadline"),
-                tags=row.get("tags") or "",
                 content=content,
             )
 

--- a/tests/test_lockdown.py
+++ b/tests/test_lockdown.py
@@ -1562,9 +1562,10 @@ class TestLockdownTaskHandlersGuardWritesOnly:
         assert "lockdown: true" in (ws / "config" / "settings.yaml").read_text()
 
     @pytest.mark.asyncio
-    async def test_done_is_refused_before_it_unlinks(self, tmp_path, db, monkeypatch):
-        """``task_done`` copies the file into ``done/`` and unlinks the source —
-        a delete of tracked config, and the most destructive of the three."""
+    async def test_done_is_refused_before_it_moves(self, tmp_path, db, monkeypatch):
+        """``task_done`` appends to the file and renames it into ``done/`` —
+        a rewrite and a move of tracked config, the most destructive of the
+        three."""
         from nerve.agent.tools.handlers.tasks import task_done_handler
 
         ws, ctx = await self._locked_task(tmp_path, db, monkeypatch)
@@ -1608,10 +1609,10 @@ class TestLockdownTaskHandlersGuardWritesOnly:
 
 
 class TestLockdownTaskManagerGuardsTheMove:
-    """``TaskManager.mark_done`` has the same read-copy-unlink shape as the
-    ``task_done`` tool — a stored ``file_path`` joined to the workspace, copied
-    into ``done/`` and then unlinked — so it needs the same guard, or it is a
-    second route to deleting tracked config.
+    """``TaskManager.mark_done`` has the same append-and-rename shape as the
+    ``task_done`` tool — a stored ``file_path`` joined to the workspace,
+    appended to and then renamed into ``done/`` — so it needs the same guard,
+    or it is a second route to rewriting and moving tracked config.
 
     Both cases run locked, so the second one is what stops the guard from being
     written as "refuse every move".

--- a/tests/test_task_completion.py
+++ b/tests/test_task_completion.py
@@ -67,3 +67,64 @@ async def test_task_manager_mark_done_preserves_metadata(db: Database, tmp_path)
     assert await manager.mark_done(task_id)
 
     await _assert_metadata_preserved(db, task_id)
+
+
+class TestCompletingATaskTwice:
+    """The second completion reads the ``file_path`` the first one stored, so
+    its source and its destination are one path under done/. While the move
+    was a copy followed by an unlink, that sequence wrote the file and then
+    deleted it: the task kept its row and lost every word of its markdown,
+    including the update history the file had collected.
+
+    Two callers reach it without anything unusual happening. An agent that
+    retries ``task_done`` after a timeout sends the call twice, and the board
+    can move a card out of Done and back in.
+    """
+
+    @pytest.mark.asyncio
+    async def test_task_done_twice_keeps_the_file(self, db: Database, tmp_path):
+        task_id = "2026-07-30-done-twice"
+        await _create_task(db, tmp_path, task_id)
+        ctx = ToolContext(session_id="test", db=db, workspace=tmp_path)
+        done_file = tmp_path / "memory" / "tasks" / "done" / f"{task_id}.md"
+
+        await task_done_handler(ctx, {"task_id": task_id, "note": "first"})
+        await task_done_handler(ctx, {"task_id": task_id, "note": "second"})
+
+        assert done_file.exists()
+        body = done_file.read_text(encoding="utf-8")
+        assert "Investigate source synchronization." in body
+        # Both completions recorded, and neither cost the file its history.
+        assert "DONE — first" in body
+        assert "DONE — second" in body
+        await _assert_metadata_preserved(db, task_id)
+
+    @pytest.mark.asyncio
+    async def test_the_row_still_points_at_the_file(self, db: Database, tmp_path):
+        """A row pointing at a path that no longer exists is the quiet half of
+        the bug: ``task_read`` and the detail page 404 while the task still
+        lists."""
+        task_id = "2026-07-30-done-twice-row"
+        await _create_task(db, tmp_path, task_id)
+        ctx = ToolContext(session_id="test", db=db, workspace=tmp_path)
+
+        await task_done_handler(ctx, {"task_id": task_id})
+        await task_done_handler(ctx, {"task_id": task_id})
+
+        row = await db.get_task(task_id)
+        assert (tmp_path / row["file_path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_mark_done_twice_keeps_the_file(self, db: Database, tmp_path):
+        task_id = "2026-07-30-manager-done-twice"
+        await _create_task(db, tmp_path, task_id)
+        manager = TaskManager(tmp_path, db)
+
+        assert await manager.mark_done(task_id)
+        assert await manager.mark_done(task_id)
+
+        done_file = tmp_path / "memory" / "tasks" / "done" / f"{task_id}.md"
+        assert done_file.exists()
+        assert "Investigate source synchronization." in done_file.read_text(
+            encoding="utf-8",
+        )

--- a/tests/test_task_reindex.py
+++ b/tests/test_task_reindex.py
@@ -1,9 +1,11 @@
 """Regression tests for TaskManager.reindex() column preservation.
 
-``upsert_task`` replaces the whole row (its ``ON CONFLICT(id) DO UPDATE SET``
-assigns every column unconditionally), so any argument ``reindex`` omits or
-mis-keys is written back as that argument's signature default. These tests pin
-one behaviour per affected column so a partial fix cannot pass.
+``reindex`` rebuilds each row from a markdown file, so it must supply the
+columns that file carries and omit the ones it does not. ``upsert_task`` keeps
+a stored value for every column an argument omits (the rule itself lives in
+``test_task_upsert_preserve.py``), but a mis-keyed or wrongly-conditioned
+argument still writes the wrong value. These tests pin one behaviour per
+affected column so a partial fix cannot pass.
 
 Discriminator notes (measured against the unfixed tree, not assumed):
 

--- a/tests/test_task_upsert_preserve.py
+++ b/tests/test_task_upsert_preserve.py
@@ -1,0 +1,156 @@
+"""The preserve-on-omit contract of ``TaskStore.upsert_task``.
+
+Four columns hold state that a markdown file does not always carry:
+``source``, ``source_url``, ``deadline`` and ``tags``. A caller that rewrites
+a row for another reason — a file move, an appended note — omits them, and
+the stored values have to survive. Under the full-replace semantics this
+replaced, every such caller had to read the row and pass all four back, and
+two shipped bugs came from a caller that forgot: ``reindex`` dropped ``tags``
+after v018 added the column, and ``task_done`` nulled all four when it moved
+a file into done/.
+
+The tests here drive ``upsert_task`` directly, because the rule itself is the
+subject. The caller-level regressions live with their callers
+(``test_task_completion.py``, ``test_task_reindex.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nerve.db import Database
+
+
+METADATA = {
+    "source": "github",
+    "source_url": "https://github.com/example/project/issues/7",
+    "deadline": "2026-09-01",
+    "tags": "backend,p1",
+}
+
+CONTENT = "Body text about queue draining."
+
+
+async def _seed(db: Database, task_id: str = "seeded", **overrides) -> str:
+    """A pending row carrying every metadata column."""
+    await db.upsert_task(
+        task_id=task_id,
+        file_path=f"memory/tasks/active/{task_id}.md",
+        title="Seeded",
+        status="pending",
+        content=CONTENT,
+        **{**METADATA, **overrides},
+    )
+    return task_id
+
+
+async def _rewrite(db: Database, task_id: str, **columns) -> None:
+    """The shape every non-metadata caller uses: move the file, keep the rest."""
+    await db.upsert_task(
+        task_id=task_id,
+        file_path=f"memory/tasks/done/{task_id}.md",
+        title="Seeded",
+        status="done",
+        content=CONTENT,
+        **columns,
+    )
+
+
+@pytest.mark.asyncio
+class TestOmit:
+    async def test_omitting_every_column_keeps_all_four(self, db: Database):
+        task_id = await _seed(db)
+
+        await _rewrite(db, task_id)
+
+        row = await db.get_task(task_id)
+        assert {field: row[field] for field in METADATA} == METADATA
+        # The columns the caller did supply still replace.
+        assert row["status"] == "done"
+        assert row["file_path"] == f"memory/tasks/done/{task_id}.md"
+
+    @pytest.mark.parametrize("column", sorted(METADATA))
+    async def test_omitting_one_column_leaves_the_others_alone(
+        self, db: Database, column: str,
+    ):
+        """One supplied column must not turn the rest into a full replace."""
+        task_id = await _seed(db)
+        replacement = "" if column == "tags" else "changed"
+
+        await _rewrite(db, task_id, **{column: replacement})
+
+        row = await db.get_task(task_id)
+        assert row[column] == replacement
+        assert {f: row[f] for f in METADATA if f != column} == {
+            f: v for f, v in METADATA.items() if f != column
+        }
+
+    async def test_a_new_row_falls_back_to_the_column_defaults(self, db: Database):
+        """Nothing is stored yet, so an omitted column has nothing to keep."""
+        await db.upsert_task(
+            task_id="fresh",
+            file_path="memory/tasks/active/fresh.md",
+            title="Fresh",
+            content=CONTENT,
+        )
+
+        row = await db.get_task("fresh")
+        assert row["source"] is None
+        assert row["source_url"] is None
+        assert row["deadline"] is None
+        assert row["tags"] == ""
+
+
+@pytest.mark.asyncio
+class TestExplicitClear:
+    """Clearing has to stay expressible, which is why ``None`` is not the
+    'omitted' marker: the detail modal can drop a deadline or the last tag."""
+
+    @pytest.mark.parametrize("column", ["source", "source_url", "deadline"])
+    async def test_none_clears_a_nullable_column(self, db: Database, column: str):
+        task_id = await _seed(db)
+
+        await _rewrite(db, task_id, **{column: None})
+
+        assert (await db.get_task(task_id))[column] is None
+
+    async def test_an_empty_string_clears_tags(self, db: Database):
+        task_id = await _seed(db)
+
+        await _rewrite(db, task_id, tags="")
+
+        assert (await db.get_task(task_id))["tags"] == ""
+
+
+@pytest.mark.asyncio
+class TestSearchIndex:
+    async def test_preserved_tags_stay_searchable(self, db: Database):
+        """The FTS text is rebuilt from scratch on every upsert, so a
+        preserved column has to reach the index and not just the row."""
+        task_id = await _seed(db)
+
+        await _rewrite(db, task_id)
+
+        matches = await db.search_tasks("queue draining", status="all", tag="p1")
+        assert [match["id"] for match in matches] == [task_id]
+
+    async def test_cleared_tags_leave_the_index(self, db: Database):
+        task_id = await _seed(db)
+
+        await _rewrite(db, task_id, tags="")
+
+        assert await db.search_tasks("queue draining", status="all", tag="p1") == []
+
+
+@pytest.mark.asyncio
+async def test_a_stored_null_tags_column_resolves_to_empty(db: Database):
+    """``tags`` gained a ``DEFAULT ''`` in v018, but a row written before it
+    can hold NULL. Preserving that value must not reach ``str.replace`` in
+    the FTS text build."""
+    task_id = await _seed(db)
+    await db.db.execute("UPDATE tasks SET tags = NULL WHERE id = ?", (task_id,))
+    await db.db.commit()
+
+    await _rewrite(db, task_id)
+
+    assert (await db.get_task(task_id))["tags"] == ""


### PR DESCRIPTION
Base of the task-board stack. Two defects in the task write path, both of which
lose user data. They sit below #272 because both are present on main today and
neither depends on the board work.

## The metadata columns

`upsert_task` replaced every column on every call. A caller that rewrote a row
for some other reason — a file move, an appended note — had to read the row
first and pass `source`, `source_url`, `deadline` and `tags` back, or the write
nulled them.

Two bugs came from a caller that did not:

- `TaskManager.reindex` dropped `tags` after v018 added the column.
- `task_done` nulled all four when it moved a file into done/. #238 fixed that
  one by adding the four lines back.

The nulled `source_url` also broke duplicate detection, because
`_find_duplicate_tasks` matches that column first. A completed task stopped
matching the source item that created it, so the next sync of that item made a
second task.

Those four columns are now preserve-on-omit: an omitted column keeps its stored
value. `None` still clears one, and `""` still clears `tags`. Five call sites
stop restoring what they never change, and `reindex` stops merging file values
against the stored row by hand.

## The second completion

The move wrote the destination and unlinked the source. Both are one path when
a task is completed twice, because the first completion stores a `file_path`
under done/ and the second one reads that path back as its source. The sequence
wrote the file and then deleted it. The task kept its row and lost its whole
markdown file, including the update history it had collected.

Reaching it needs nothing unusual. An agent that retries `task_done` after a
timeout sends the call twice, and with #272 the board can move a card out of
Done and back in. `move_task_file` now appends and renames, and a rename onto
one path is a no-op.

## Tests

- `test_task_upsert_preserve.py` — the preserve-on-omit rule, its explicit
  clears, and the FTS text.
- `test_task_completion.py` — three tests for the second completion. All three
  fail on the old copy-and-unlink shape.

Full suite: 3030 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
