### PR TITLE
Make the composer model picker per-chat instead of global

### DIFF
--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -299,7 +299,12 @@ async def get_messages(session_id: str, limit: int = 500, user: dict = Depends(r
 
 @router.patch("/api/sessions/{session_id}")
 async def update_session(session_id: str, req: dict, user: dict = Depends(require_auth)):
-    """Update session fields (title, starred).
+    """Update session fields (title, starred, model).
+
+    ``model`` re-points THIS session only — the composer's picker is
+    per-chat, not a global preference. The engine re-reads the session
+    row each turn (per-message override -> ``sessions.model`` -> backend
+    default), so the switch takes effect on the session's next message.
 
     When ``sessions.star_project_hook`` is enabled (default off), a ``starred``
     0<->1 transition fires a one-shot internal turn in that same session so the
@@ -314,6 +319,22 @@ async def update_session(session_id: str, req: dict, user: dict = Depends(requir
         fields["title"] = req["title"]
     if "starred" in req:
         fields["starred"] = 1 if req["starred"] else 0
+    if "model" in req:
+        requested_model = str(req["model"] or "").strip()
+        if not requested_model:
+            raise HTTPException(status_code=400, detail="model cannot be empty")
+        # Backend is sticky on the session row — validate the pick against
+        # it (same optional seam as session creation: codex can cheaply
+        # reject; claude accepts any ID since Ollama models ride it).
+        backend_id = session.get("backend") or deps.engine.config.agent.backend
+        selected_backend = deps.engine._backends.get(backend_id)
+        validate_model = getattr(selected_backend, "validate_model", None)
+        if validate_model is not None:
+            try:
+                await validate_model(requested_model)
+            except BackendError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+        fields["model"] = requested_model
     if not fields:
         raise HTTPException(status_code=400, detail="No valid fields to update")
     old_starred = int(session.get("starred") or 0)

--- a/tests/test_session_create_model.py
+++ b/tests/test_session_create_model.py
@@ -1,9 +1,15 @@
-"""HTTP route tests for POST /api/sessions with a model override.
+"""HTTP route tests for the composer model picker's session endpoints.
 
-The composer's model picker sends its choice at session creation so the
+POST /api/sessions: the picker sends its choice at session creation so the
 session row (and the header's model badge) carries the picked model from
 the first render — instead of the backend default until the first turn
-resolves the override. Pattern mirrors test_workflow_routes.py.
+resolves the override.
+
+PATCH /api/sessions/{id}: the picker re-points ONE existing session's
+model (per-chat, not a global preference); the engine reads the row each
+turn, so the switch applies on that session's next message only.
+
+Pattern mirrors test_workflow_routes.py.
 """
 
 from __future__ import annotations
@@ -57,39 +63,40 @@ class FakeSessionManager:
         )
 
 
+@pytest_asyncio.fixture
+async def setup(db: Database, tmp_path):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    import nerve.config as cfg_mod
+    from nerve.config import NerveConfig
+    from nerve.gateway.routes._deps import init_deps
+    from nerve.gateway.routes.sessions import router as sessions_router
+
+    cfg = NerveConfig()
+    cfg.workspace = tmp_path
+    cfg.auth.jwt_secret = ""  # require_auth becomes a no-op
+    cfg_mod._config = cfg
+
+    engine = SimpleNamespace(
+        _backends={
+            "claude": FakeClaudeBackend(),
+            "codex": FakeCodexBackend(),
+        },
+        config=cfg,
+        sessions=FakeSessionManager(db),
+    )
+    init_deps(engine=engine, db=db)  # type: ignore[arg-type]
+
+    app = FastAPI()
+    app.include_router(sessions_router)
+    yield SimpleNamespace(client=TestClient(app), db=db)
+
+    cfg_mod._config = None
+
+
 @pytest.mark.asyncio
 class TestCreateSessionModel:
-    @pytest_asyncio.fixture
-    async def setup(self, db: Database, tmp_path):
-        from fastapi import FastAPI
-        from fastapi.testclient import TestClient
-
-        import nerve.config as cfg_mod
-        from nerve.config import NerveConfig
-        from nerve.gateway.routes._deps import init_deps
-        from nerve.gateway.routes.sessions import router as sessions_router
-
-        cfg = NerveConfig()
-        cfg.workspace = tmp_path
-        cfg.auth.jwt_secret = ""  # require_auth becomes a no-op
-        cfg_mod._config = cfg
-
-        engine = SimpleNamespace(
-            _backends={
-                "claude": FakeClaudeBackend(),
-                "codex": FakeCodexBackend(),
-            },
-            config=cfg,
-            sessions=FakeSessionManager(db),
-        )
-        init_deps(engine=engine, db=db)  # type: ignore[arg-type]
-
-        app = FastAPI()
-        app.include_router(sessions_router)
-        yield SimpleNamespace(client=TestClient(app), db=db)
-
-        cfg_mod._config = None
-
     async def test_model_persisted_at_creation(self, setup):
         resp = setup.client.post(
             "/api/sessions",
@@ -128,3 +135,79 @@ class TestCreateSessionModel:
         )
         assert resp.status_code == 200
         assert resp.json()["model"] == "gpt-5.6-sol"
+
+
+@pytest.mark.asyncio
+class TestPatchSessionModel:
+    """PATCH /api/sessions/{id} with a model — the per-chat picker path."""
+
+    async def _create(self, setup, backend: str = "claude", model: str | None = None) -> dict:
+        payload: dict = {"backend": backend}
+        if model:
+            payload["model"] = model
+        resp = setup.client.post("/api/sessions", json=payload)
+        assert resp.status_code == 200
+        return resp.json()
+
+    async def test_patch_model_repoints_session(self, setup):
+        session = await self._create(setup, model="claude-fable-5")
+        resp = setup.client.patch(
+            f"/api/sessions/{session['id']}", json={"model": "claude-opus-5"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "claude-opus-5"
+        row = await setup.db.get_session(session["id"])
+        assert row["model"] == "claude-opus-5"
+
+    async def test_patch_model_only_touches_target_session(self, setup):
+        """The regression this endpoint exists for: a pick in one chat must
+        never change any other chat's model."""
+        a = await self._create(setup, model="claude-fable-5")
+        b = await self._create(setup, model="claude-fable-5")
+        resp = setup.client.patch(
+            f"/api/sessions/{a['id']}", json={"model": "claude-opus-5"},
+        )
+        assert resp.status_code == 200
+        assert (await setup.db.get_session(a["id"]))["model"] == "claude-opus-5"
+        assert (await setup.db.get_session(b["id"]))["model"] == "claude-fable-5"
+
+    async def test_patch_blank_model_rejected(self, setup):
+        session = await self._create(setup, model="claude-fable-5")
+        resp = setup.client.patch(
+            f"/api/sessions/{session['id']}", json={"model": "   "},
+        )
+        assert resp.status_code == 400
+        assert (await setup.db.get_session(session["id"]))["model"] == "claude-fable-5"
+
+    async def test_patch_model_validated_by_session_backend(self, setup):
+        session = await self._create(setup, backend="codex", model="gpt-5.6-sol")
+        resp = setup.client.patch(
+            f"/api/sessions/{session['id']}", json={"model": "claude-opus-5"},
+        )
+        assert resp.status_code == 400
+        assert "not available" in resp.json()["detail"]
+        assert (await setup.db.get_session(session["id"]))["model"] == "gpt-5.6-sol"
+
+    async def test_patch_model_codex_accepts_known(self, setup):
+        session = await self._create(setup, backend="codex", model="gpt-5.6-sol")
+        resp = setup.client.patch(
+            f"/api/sessions/{session['id']}", json={"model": "gpt-5.6-sol"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["model"] == "gpt-5.6-sol"
+
+    async def test_patch_model_unknown_session_404(self, setup):
+        resp = setup.client.patch(
+            "/api/sessions/nonexist", json={"model": "claude-opus-5"},
+        )
+        assert resp.status_code == 404
+
+    async def test_patch_title_alone_still_works(self, setup):
+        session = await self._create(setup, model="claude-fable-5")
+        resp = setup.client.patch(
+            f"/api/sessions/{session['id']}", json={"title": "renamed"},
+        )
+        assert resp.status_code == 200
+        row = await setup.db.get_session(session["id"])
+        assert row["title"] == "renamed"
+        assert row["model"] == "claude-fable-5"

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -306,7 +306,7 @@ export const api = {
     ),
   deleteSession: (id: string) =>
     request<any>(`/sessions/${id}`, { method: 'DELETE' }),
-  updateSession: (id: string, data: { title?: string; starred?: boolean }) =>
+  updateSession: (id: string, data: { title?: string; starred?: boolean; model?: string }) =>
     request<any>(`/sessions/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   getMessages: (sessionId: string, limit = 100) =>
     request<{ messages: any[]; last_usage?: { input_tokens: number; output_tokens: number; cache_creation_input_tokens: number; cache_read_input_tokens: number; cache_creation?: { ephemeral_5m_input_tokens?: number; ephemeral_1h_input_tokens?: number }; max_context_tokens: number; num_turns?: number } }>(`/sessions/${sessionId}/messages?limit=${limit}`),

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -134,16 +134,14 @@ export class NerveWebSocket {
     return 'dropped';
   }
 
-  sendMessage(content: string, sessionId: string, fileIds?: string[], model?: string): SendStatus {
+  sendMessage(content: string, sessionId: string, fileIds?: string[]): SendStatus {
     const msg: Record<string, unknown> = { type: 'message', content, session_id: sessionId };
     if (fileIds && fileIds.length > 0) {
       msg.file_ids = fileIds;
     }
-    // Per-message model override from the composer's picker (omitted → server
-    // uses the configured default). May be an Anthropic id or an Ollama model.
-    if (model) {
-      msg.model = model;
-    }
+    // No model field: the server resolves the session row's model each
+    // turn (sessions.model, set at creation or via PATCH), so the pick is
+    // per-chat rather than a client-global override.
     return this.send(msg);
   }
 

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -103,15 +103,21 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
     ? (chosenBackend ?? 'claude')
     : (sessions.find(s => s.id === activeSession)?.backend ?? 'claude');
 
-  // ── Model picker ──
+  // ── Model picker (per-chat) ──
+  // A virtual chat's pick lives in newChatModels until the session is
+  // created; a real session's model IS its row (sessions[].model), so the
+  // picker always shows — and only ever changes — the current chat.
   const availableModels = useChatStore(s => s.availableModels);
-  const selectedModels = useChatStore(s => s.selectedModels);
+  const newChatModels = useChatStore(s => s.newChatModels);
   const modelDefaults = useChatStore(s => s.modelDefaults);
-  const setSelectedModel = useChatStore(s => s.setSelectedModel);
+  const setNewChatModel = useChatStore(s => s.setNewChatModel);
+  const setSessionModel = useChatStore(s => s.setSessionModel);
   const loadModels = useChatStore(s => s.loadModels);
   const scopedModels = availableModels.filter(m => m.backend === activeBackend);
-  const selectedModel = selectedModels[activeBackend] ?? null;
   const modelsDefault = modelDefaults[activeBackend] ?? null;
+  const currentModel = isVirtualChat
+    ? (newChatModels[activeBackend] ?? modelsDefault)
+    : (sessions.find(s => s.id === activeSession)?.model ?? modelsDefault);
 
   const [prevQuoteCount, setPrevQuoteCount] = useState(0);
 
@@ -613,16 +619,30 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
           {isVirtualChat && (
             <BackendSelector disabled={disabled || isStreaming || rewriteActive} />
           )}
-          {/* Backend-scoped model picker. A Claude/Ollama selection can never
-              leak into Codex (or vice versa) when the backend changes. */}
+          {/* Backend-scoped, PER-CHAT model picker. A pick here re-points
+              only this chat: virtual chats bind it at creation, real
+              sessions PATCH their own row — never a global preference. */}
           {scopedModels.length > 1 && (
             <select
-              value={selectedModel ?? modelsDefault ?? ''}
-              onChange={(e) => setSelectedModel(activeBackend, e.target.value === modelsDefault ? null : e.target.value)}
+              value={currentModel ?? ''}
+              onChange={(e) => {
+                const picked = e.target.value;
+                if (isVirtualChat) {
+                  setNewChatModel(activeBackend, picked === modelsDefault ? null : picked);
+                } else {
+                  setSessionModel(activeSession, picked);
+                }
+              }}
               disabled={disabled || isStreaming || rewriteActive}
-              title="Model for your next message"
+              title="Model for this chat (other chats keep theirs)"
               className="h-10 max-w-[170px] px-2.5 bg-surface-raised border border-border rounded-xl text-[13px] text-text-secondary outline-none focus:border-accent/50 cursor-pointer shrink-0 disabled:opacity-30 truncate"
             >
+              {/* A session may run on a model the picker no longer offers
+                  (retired id, uninstalled Ollama model) — keep it visible
+                  instead of silently snapping to the first option. */}
+              {currentModel && !scopedModels.some(m => m.id === currentModel) && (
+                <option value={currentModel}>{currentModel}</option>
+              )}
               {scopedModels.some(m => m.provider === 'anthropic') && (
                 <optgroup label="Anthropic">
                   {scopedModels.filter(m => m.provider === 'anthropic').map(m => (

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -181,7 +181,13 @@ interface ChatState {
   // Review-loop config for the CURRENT virtual chat; null = panel closed.
   // Bound at session materialization (like newChatBackend) and reset after.
   newChatReviewLoop: NewChatReviewLoop | null;
-  selectedModels: Record<string, string | null>;
+  // Model picked for the CURRENT virtual (unsent) chat, keyed by backend so
+  // a Claude pick can't leak into Codex when the backend toggle moves
+  // (null/absent = backend default). Bound at session materialization and
+  // reset after. Real sessions don't use this — their model lives on the
+  // session row (sessions[].model) and is changed via setSessionModel, so
+  // a pick in one chat never affects any other chat.
+  newChatModels: Record<string, string | null>;
 
   loadSessions: () => Promise<void>;
   switchSession: (id: string) => Promise<void>;
@@ -209,8 +215,10 @@ interface ChatState {
   setNewChatBackend: (backend: string | null) => void;
   /** Patch (or close with null) the new-chat review-loop panel state. */
   setNewChatReviewLoop: (patch: Partial<NewChatReviewLoop> | null) => void;
-  /** Set the model for the next message (null → server default). */
-  setSelectedModel: (backend: string, model: string | null) => void;
+  /** Set the model for the current virtual chat (null → server default). */
+  setNewChatModel: (backend: string, model: string | null) => void;
+  /** Re-point ONE existing session's model (persisted on its row). */
+  setSessionModel: (sessionId: string, model: string) => Promise<void>;
   stopSession: () => void;
   handleWSMessage: (msg: WSMessage) => void;
   addQuote: (text: string, action: QuoteAction) => void;
@@ -273,11 +281,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   backendDefault: null,
   newChatBackend: null,
   newChatReviewLoop: null,
-  selectedModels: {
-    claude: localStorage.getItem('nerve_selected_model_claude')
-      || localStorage.getItem('nerve_selected_model') || null,
-    codex: localStorage.getItem('nerve_selected_model_codex') || null,
-  },
+  newChatModels: {},
 
   addQuote: (text: string, action: QuoteAction) => {
     const id = `q${++_quoteId}`;
@@ -596,7 +600,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // the session row (and the header badge) carries it from the start,
     // instead of the backend default until the first turn resolves it.
     const effBackend = get().newChatBackend ?? get().backendDefault ?? 'claude';
-    const pickedModel = get().selectedModels[effBackend] ?? undefined;
+    const pickedModel = get().newChatModels[effBackend] ?? undefined;
     const real: Session = await api.createSession(
       undefined, get().newChatBackend, rlCwd, rlPayload, pickedModel,
     );
@@ -616,6 +620,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         ...(state.activeSession === vs.id ? { activeSession: real.id } : {}),
         virtualSession: null,
         newChatBackend: null,  // bound into the created session; reset for the next chat
+        newChatModels: {},     // ditto — the pick now lives on the session row
         newChatReviewLoop: null,  // ditto — the loop (if any) is now running server-side
         drafts,
         // POST /api/sessions returns a partial row (no updated_at); fill the
@@ -632,7 +637,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   discardVirtualSession: () => {
     const vs = get().virtualSession;
     if (!vs) return;
-    set({ newChatBackend: null, newChatReviewLoop: null });
+    set({ newChatBackend: null, newChatModels: {}, newChatReviewLoop: null });
     removeDraft(vs.id);
     set((s) => {
       const drafts = { ...s.drafts };
@@ -749,25 +754,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
   loadModels: async () => {
     try {
       const res = await api.getModels();
+      // The pick used to be a global localStorage preference that leaked
+      // into every chat; it's per-chat state now — drop the legacy keys.
+      localStorage.removeItem('nerve_selected_model');
+      localStorage.removeItem('nerve_selected_model_claude');
+      localStorage.removeItem('nerve_selected_model_codex');
       set((state) => {
-        // Drop a stale pick (e.g. an Ollama model no longer installed) so we
-        // never send a model the server can't route.
-        const selectedModels = { ...state.selectedModels };
-        for (const backend of ['claude', 'codex']) {
+        // Drop a stale new-chat pick (e.g. an Ollama model no longer
+        // installed) so we never create a session on a model the server
+        // can't route.
+        const newChatModels = { ...state.newChatModels };
+        for (const [backend, selected] of Object.entries(newChatModels)) {
           const ids = new Set(res.models.filter(m => m.backend === backend).map(m => m.id));
-          const selected = selectedModels[backend];
-          if (selected && !ids.has(selected)) {
-            selectedModels[backend] = null;
-            localStorage.removeItem(`nerve_selected_model_${backend}`);
-          }
+          if (selected && !ids.has(selected)) newChatModels[backend] = null;
         }
-        localStorage.removeItem('nerve_selected_model');
         return {
           availableModels: res.models,
           modelDefaults: res.defaults ?? { claude: res.default },
           backendOptions: res.backends?.options ?? [],
           backendDefault: res.backends?.default ?? null,
-          selectedModels,
+          newChatModels,
         };
       });
     } catch (e) {
@@ -783,13 +789,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
       : { ...(s.newChatReviewLoop ?? EMPTY_REVIEW_LOOP), ...patch },
   })),
 
-  setSelectedModel: (backend: string, model: string | null) => {
-    const key = `nerve_selected_model_${backend}`;
-    if (model) localStorage.setItem(key, model);
-    else localStorage.removeItem(key);
-    set((state) => ({
-      selectedModels: { ...state.selectedModels, [backend]: model },
+  setNewChatModel: (backend: string, model: string | null) => set((state) => ({
+    newChatModels: { ...state.newChatModels, [backend]: model },
+  })),
+
+  setSessionModel: async (sessionId: string, model: string) => {
+    // Optimistic: the picker and header badge read sessions[].model, so
+    // re-point the row immediately; revert if the server rejects the pick
+    // (e.g. a model the session's backend can't serve).
+    const prev = get().sessions.find(s => s.id === sessionId)?.model;
+    const repoint = (m: string | undefined) => set((state) => ({
+      sessions: state.sessions.map(s => s.id === sessionId ? { ...s, model: m } : s),
     }));
+    repoint(model);
+    try {
+      await api.updateSession(sessionId, { model });
+    } catch (e) {
+      console.error('Failed to update session model:', e);
+      repoint(prev);
+    }
   },
 
   sendMessage: async (content: string, fileIds?: string[], imageBlocks?: Array<{ url: string; filename: string; media_type: string }>) => {
@@ -831,12 +849,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
         return;
       }
     }
-    const state = get();
-    const backend = state.sessions.find(s => s.id === session)?.backend
-      ?? state.backendDefault ?? 'claude';
-    const status = ws.sendMessage(
-      content, session, fileIds, state.selectedModels[backend] ?? undefined,
-    );
+    // No per-message model override: the session row is the source of
+    // truth (bound at creation for new chats, PATCHed by setSessionModel
+    // for existing ones), so a pick in another chat can never leak here.
+    const status = ws.sendMessage(content, session, fileIds);
     if (status === 'dropped') {
       // The message could not reach the server. Revert the optimistic
       // state and surface the failure inline so the user knows to retry.


### PR DESCRIPTION
## Problem

Changing the model in the composer's picker changed it for **all** chats: the pick was a global `selectedModels[backend]` map in the chat store, persisted to localStorage, and sent as a per-message override with every message from every chat. Picking a model in one chat silently re-pointed every other chat's next turn (and every future new chat).

## Fix

The pick is now scoped to the chat it was made in, using the session row as the source of truth (matching the engine's existing per-turn resolution `per-message → sessions.model → backend default`):

- **Existing sessions:** the picker shows that session's own `model` (same source as the header badge) and changing it PATCHes `{model}` onto **that session's row** — `PATCH /api/sessions/{id}` now accepts `model`, validated against the session's sticky backend (same optional `validate_model` seam as creation). The engine re-reads the row each turn, so the switch applies on that session's next message. Optimistic UI update with revert if the server rejects the pick.
- **New (virtual) chats:** the pick lives in `newChatModels` (analogous to `newChatBackend`), binds at session creation (existing `POST /api/sessions` `model` param), and resets afterwards. `null` = server default.
- **No more per-message override from the composer:** `ws.sendMessage` no longer sends `model` (the server still accepts the WS field for compat).
- **Legacy global localStorage keys** (`nerve_selected_model*`) are removed on load, so a stale global pick can't keep overriding new chats.
- Picker also keeps a session's model visible when the catalog no longer offers it (retired id / uninstalled Ollama model) instead of snapping to the first option.

## Tests

- `tests/test_session_create_model.py`: +7 PATCH cases — re-point persists, **pick in one chat leaves other chats untouched**, blank model 400, backend validation (codex reject/accept), 404, title-only PATCH regression. Fixture lifted to module scope, shared by both classes.
- Full suite: 3021 passed. `npm run build` clean.
- Verified in the browser: sessions on `claude-fable-5` / `claude-opus-5` / `claude-opus-4-8` each show their own model; a pick in a new chat no longer leaks into other chats; failed PATCH reverts cleanly.

## Deploy note

Needs a gateway restart to pick up the PATCH support; until then, re-pointing an *existing* session from the UI is a graceful no-op (400 → picker reverts).

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*