### PR TITLE
memU: index-sargable content-hash dedup + hot-path indexes

### DIFF
--- a/nerve/memory/memu_bridge.py
+++ b/nerve/memory/memu_bridge.py
@@ -311,6 +311,118 @@ def _log_audit_failure(future: Any) -> None:
         logger.warning("Audit log failed: %s", exc)
 
 
+def _content_hash_reinforce(
+    repo: Any,
+    *,
+    resource_id: str,
+    memory_type: Any,
+    summary: str,
+    embedding: Any,
+    user_data: dict[str, Any],
+) -> Any:
+    """Index-sargable port of ``SQLiteMemoryItemRepo.create_item_reinforce``.
+
+    Line-for-line copy of memu-py 1.4.0's implementation with ONE change: the
+    content-hash dedup predicate is rendered as a *literal* SQL expression
+    (``literal_column``) instead of ``func.json_extract(col, path)``.
+    SQLAlchemy compiles the latter with the JSON path as a bound parameter
+    (``json_extract(extra, ?)``), and SQLite never matches a parameterized
+    expression against an expression index, so the lookup degrades to a full
+    table scan of the items table. On a multi-GB corpus with a cold page
+    cache one scan is minutes-to-hours of serial 4 KiB reads — and because
+    the memorize pipeline is serialized on the memU loop thread and the scan
+    is synchronous (uncancellable mid-statement), it wedges every memorize
+    call behind it until it finishes (2026-08-07 incident: ~90 min per
+    lookup on a 26 GB / 728K-item corpus, every memorize timing out).
+
+    With the literal expression the lookup is an index seek on
+    ``ix_<table>_content_hash`` (created by
+    :meth:`MemUBridge._ensure_sqlite_indexes`). The *value* being compared
+    stays a bound parameter — only the indexed expression must be literal.
+    """
+    from sqlalchemy import literal_column
+    from sqlmodel import select as _sel
+
+    from memu.database.models import MemoryItem, compute_content_hash
+
+    content_hash = compute_content_hash(summary, memory_type)
+
+    with repo._sessions.session() as session:
+        # Check for existing item with same hash in same scope (deduplication).
+        # Literal JSON path — required for the expression index to apply.
+        content_hash_col = literal_column("json_extract(extra, '$.content_hash')")
+        filters = [content_hash_col == content_hash]
+        filters.extend(repo._build_filters(repo._memory_item_model, user_data))
+
+        existing = session.exec(_sel(repo._memory_item_model).where(*filters)).first()
+
+        if existing:
+            # Reinforce existing memory instead of creating duplicate
+            current_extra = existing.extra or {}
+            current_count = current_extra.get("reinforcement_count", 1)
+            existing.extra = {
+                **current_extra,
+                "reinforcement_count": current_count + 1,
+                "last_reinforced_at": repo._now().isoformat(),
+            }
+            existing.updated_at = repo._now()
+            session.add(existing)
+            session.commit()
+            session.refresh(existing)
+
+            item = MemoryItem(
+                id=existing.id,
+                resource_id=existing.resource_id,
+                memory_type=existing.memory_type,
+                summary=existing.summary,
+                embedding=repo._normalize_embedding(existing.embedding_json),
+                created_at=existing.created_at,
+                updated_at=existing.updated_at,
+                extra=existing.extra,
+                **repo._scope_kwargs_from(existing),
+            )
+            repo.items[existing.id] = item
+            return item
+
+        # Create new item with salience tracking in extra
+        now = repo._now()
+        item_extra = user_data.pop("extra", {}) if "extra" in user_data else {}
+        item_extra.update({
+            "content_hash": content_hash,
+            "reinforcement_count": 1,
+            "last_reinforced_at": now.isoformat(),
+        })
+
+        row = repo._memory_item_model(
+            resource_id=resource_id,
+            memory_type=memory_type,
+            summary=summary,
+            embedding_json=repo._prepare_embedding(embedding),
+            extra=item_extra,
+            created_at=now,
+            updated_at=now,
+            **user_data,
+        )
+
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+
+    item = MemoryItem(
+        id=row.id,
+        resource_id=row.resource_id,
+        memory_type=row.memory_type,
+        summary=row.summary,
+        embedding=embedding,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        extra=row.extra,
+        **repo._scope_kwargs_from(row),
+    )
+    repo.items[row.id] = item
+    return item
+
+
 class _BedrockLLMClient:
     """Drop-in replacement for memU's OpenAISDKClient that uses AsyncAnthropicBedrock.
 
@@ -1226,14 +1338,39 @@ class MemUBridge:
                             matched.updated_at = now
                             return matched
 
-                return _original_sqlite_reinforce(
-                    self,
-                    resource_id=resource_id,
-                    memory_type=memory_type,
-                    summary=summary,
-                    embedding=embedding,
-                    user_data=user_data,
-                )
+                # Content-hash dedup via the indexed port — the upstream
+                # implementation renders the JSON path as a bound parameter,
+                # which SQLite cannot serve from the expression index, so
+                # every call full-scans the items table (2026-08-07: on a
+                # 26 GB / 728K-item corpus with a cold page cache that is a
+                # ~90-minute serial read which wedged the whole memorize
+                # lane; see _content_hash_reinforce).
+                _user_data_snapshot = dict(user_data)
+                try:
+                    return _content_hash_reinforce(
+                        self,
+                        resource_id=resource_id,
+                        memory_type=memory_type,
+                        summary=summary,
+                        embedding=embedding,
+                        user_data=user_data,
+                    )
+                except Exception:
+                    # The port reaches into memu-py internals — if the pinned
+                    # upstream ever shifts under it, degrade to the original
+                    # (scanning) implementation instead of failing memorize.
+                    logger.exception(
+                        "content-hash reinforce fast path failed — falling "
+                        "back to memu-py's create_item_reinforce",
+                    )
+                    return _original_sqlite_reinforce(
+                        self,
+                        resource_id=resource_id,
+                        memory_type=memory_type,
+                        summary=summary,
+                        embedding=embedding,
+                        user_data=_user_data_snapshot,
+                    )
 
             SQLiteMemoryItemRepo.create_item_reinforce = _semantic_sqlite_reinforce
 
@@ -1369,6 +1506,63 @@ class MemUBridge:
             )
         except Exception as exc:
             logger.warning("memU WAL startup checkpoint skipped: %s", exc)
+
+    @staticmethod
+    def _ensure_sqlite_indexes(sqlite_dsn: str, table: str = "memu_memory_items") -> None:
+        """Create the hot-path indexes memu-py's schema is missing.
+
+        - ``ix_<table>_content_hash`` — expression index over
+          ``json_extract(extra, '$.content_hash')``. Serves the per-item
+          dedup lookup in :func:`_content_hash_reinforce` (which runs for
+          every item the memorize pipeline persists). Without it that lookup
+          is a full scan of the items table; the table carries inline
+          embedding JSON, so on a large corpus a single scan reads the whole
+          multi-GB file — and wedges the serialized memorize lane whenever
+          the page cache is cold. NOTE: SQLite only uses an expression index
+          when the query renders the expression literally, which is exactly
+          why ``_content_hash_reinforce`` exists.
+        - ``ix_<table>_created_at`` — serves the event-date sweep
+          (``created_at >= :cutoff ORDER BY created_at DESC LIMIT :n`` in
+          ``_resolve_event_dates_sync``), which otherwise also scans.
+
+        Runs after MemoryService init so the tables exist. Idempotent; the
+        first run on a large corpus pays a one-time O(table) build, which is
+        logged with its duration.
+        """
+        import sqlite3 as _sqlite3
+
+        db_path = sqlite_dsn.replace("sqlite:///", "")
+        ddl = (
+            (
+                f"ix_{table}_content_hash",
+                f"CREATE INDEX IF NOT EXISTS ix_{table}_content_hash "
+                f"ON {table} (json_extract(extra, '$.content_hash'))",
+            ),
+            (
+                f"ix_{table}_created_at",
+                f"CREATE INDEX IF NOT EXISTS ix_{table}_created_at "
+                f"ON {table} (created_at)",
+            ),
+        )
+        try:
+            conn = _sqlite3.connect(db_path, timeout=60)
+            conn.execute("PRAGMA busy_timeout=60000")
+            for name, stmt in ddl:
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+                    (name,),
+                ).fetchone()
+                if exists:
+                    continue
+                t0 = time.monotonic()
+                conn.execute(stmt)
+                conn.commit()
+                logger.info(
+                    "memU index %s built in %.1fs", name, time.monotonic() - t0,
+                )
+            conn.close()
+        except Exception as exc:
+            logger.warning("memU index setup skipped: %s", exc)
 
     def _attach_engine_pragmas(self) -> None:
         """Per-connection pragmas for memU's SQLAlchemy engine.
@@ -1571,6 +1765,20 @@ class MemUBridge:
 
             # Per-connection pragmas (busy_timeout, synchronous=NORMAL).
             self._attach_engine_pragmas()
+
+            # Hot-path indexes memu-py's schema is missing (idempotent; the
+            # first run on a large corpus pays a one-time build). Must run
+            # after MemoryService init so the tables exist.
+            item_table = getattr(
+                getattr(
+                    getattr(self._service.database, "memory_item_repo", None),
+                    "_memory_item_model",
+                    None,
+                ),
+                "__tablename__",
+                None,
+            ) or "memu_memory_items"
+            self._ensure_sqlite_indexes(sqlite_dsn, item_table)
 
             # ── Bedrock client injection ──
             # Replace the placeholder OpenAISDKClient instances with real

--- a/tests/test_memu_bridge.py
+++ b/tests/test_memu_bridge.py
@@ -17,6 +17,7 @@ from nerve.memory.memu_bridge import (
     _KNOWLEDGE_CUSTOM_RULES,
     _KNOWLEDGE_CUSTOM_EXAMPLES,
     _SEMANTIC_DEDUP_THRESHOLD,
+    _content_hash_reinforce,
     _is_sqlite_locked_error,
 )
 
@@ -1134,3 +1135,244 @@ class TestMemorizeFileLockRetry:
             await bridge.memorize_file(str(target))
 
         assert bridge._service.memorize.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _ensure_sqlite_indexes — hot-path index DDL
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureSqliteIndexes:
+    """MemUBridge._ensure_sqlite_indexes creates the dedup/sweep indexes."""
+
+    def _index_names(self, db_path: str) -> set[str]:
+        db = sqlite3.connect(db_path)
+        names = {
+            r[0]
+            for r in db.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        }
+        db.close()
+        return names
+
+    def test_creates_both_indexes(self, tmp_path):
+        db_path = str(tmp_path / "memu.sqlite")
+        _create_memu_schema(db_path)
+
+        MemUBridge._ensure_sqlite_indexes(f"sqlite:///{db_path}")
+
+        names = self._index_names(db_path)
+        assert "ix_memu_memory_items_content_hash" in names
+        assert "ix_memu_memory_items_created_at" in names
+
+    def test_idempotent(self, tmp_path):
+        db_path = str(tmp_path / "memu.sqlite")
+        _create_memu_schema(db_path)
+
+        MemUBridge._ensure_sqlite_indexes(f"sqlite:///{db_path}")
+        MemUBridge._ensure_sqlite_indexes(f"sqlite:///{db_path}")  # must not raise
+
+        assert "ix_memu_memory_items_content_hash" in self._index_names(db_path)
+
+    def test_missing_table_is_nonfatal(self, tmp_path):
+        db_path = str(tmp_path / "empty.sqlite")
+        sqlite3.connect(db_path).close()
+
+        MemUBridge._ensure_sqlite_indexes(f"sqlite:///{db_path}")  # logs, no raise
+
+        assert self._index_names(db_path) == set()
+
+    def test_literal_content_hash_lookup_uses_index(self, tmp_path):
+        """The dedup predicate as _content_hash_reinforce renders it (literal
+        JSON path) is served by the expression index — an index seek, not a
+        table scan."""
+        db_path = str(tmp_path / "memu.sqlite")
+        _create_memu_schema(db_path)
+        MemUBridge._ensure_sqlite_indexes(f"sqlite:///{db_path}")
+
+        db = sqlite3.connect(db_path)
+        plan = " ".join(
+            r[3]
+            for r in db.execute(
+                "EXPLAIN QUERY PLAN SELECT id FROM memu_memory_items "
+                "WHERE json_extract(extra, '$.content_hash') = ?",
+                ("h",),
+            )
+        )
+        db.close()
+        assert "USING INDEX ix_memu_memory_items_content_hash" in plan
+
+    def test_bound_parameter_path_cannot_use_index(self, tmp_path):
+        """Documents WHY _content_hash_reinforce exists: SQLAlchemy compiles
+        func.json_extract(col, path) with the JSON path as a bound parameter,
+        and SQLite never matches a parameterized expression against an
+        expression index — the lookup degrades to a full table scan even with
+        the index present."""
+        db_path = str(tmp_path / "memu.sqlite")
+        _create_memu_schema(db_path)
+        MemUBridge._ensure_sqlite_indexes(f"sqlite:///{db_path}")
+
+        db = sqlite3.connect(db_path)
+        plan = " ".join(
+            r[3]
+            for r in db.execute(
+                "EXPLAIN QUERY PLAN SELECT id FROM memu_memory_items "
+                "WHERE json_extract(extra, ?) = ?",
+                ("$.content_hash", "h"),
+            )
+        )
+        db.close()
+        assert "SCAN" in plan
+        assert "ix_memu_memory_items_content_hash" not in plan
+
+
+# ---------------------------------------------------------------------------
+# _content_hash_reinforce — index-sargable port of create_item_reinforce
+# ---------------------------------------------------------------------------
+
+
+_upstream_reinforce = None  # memu-py's create_item_reinforce, captured pre-patch
+_shared_memu_repo = None  # module singleton — memu model classes are process-global
+
+
+def _memu_repo():
+    """Build a real SQLiteMemoryItemRepo the way production does.
+
+    memu-py 1.4.0's sqlite factory only works after the bridge's
+    monkey-patches (``_patch_sqlite_bugs``), and the patched model classes
+    are process-global (a second ``build_database`` re-binds the same Column
+    objects and fails) — so build ONE database for the test process, exactly
+    like production, and isolate tests by user scope. The pristine upstream
+    ``create_item_reinforce`` is captured before the patch swaps it out.
+    """
+    global _shared_memu_repo, _upstream_reinforce
+    if _shared_memu_repo is not None:
+        return _shared_memu_repo
+
+    import tempfile
+
+    from memu.app.service import MemoryService  # noqa: F401 — import order breaks the factory/app cycle
+    from memu.app.settings import DatabaseConfig, DefaultUserModel
+    from memu.database.factory import build_database
+    from memu.database.sqlite.repositories.memory_item_repo import (
+        SQLiteMemoryItemRepo,
+    )
+
+    if _upstream_reinforce is None:
+        _upstream_reinforce = SQLiteMemoryItemRepo.create_item_reinforce
+    MemUBridge._patch_sqlite_bugs()
+
+    db_dir = tempfile.mkdtemp(prefix="nerve-memu-reinforce-test-")
+    db = build_database(
+        config=DatabaseConfig(
+            metadata_store={
+                "provider": "sqlite",
+                "dsn": f"sqlite:///{db_dir}/memu.sqlite",
+            },
+        ),
+        user_model=DefaultUserModel,
+    )
+    _shared_memu_repo = db.memory_item_repo
+    return _shared_memu_repo
+
+
+def _scope_count(repo, user_id: str) -> int:
+    """Count items in a user scope from the DB (the in-memory MemoryItem
+    models don't carry scope fields — upstream drops the kwargs)."""
+    from sqlmodel import select as _sel
+
+    with repo._sessions.session() as session:
+        rows = session.exec(
+            _sel(repo._memory_item_model).where(
+                repo._memory_item_model.user_id == user_id
+            )
+        ).all()
+    return len(rows)
+
+
+class TestContentHashReinforce:
+    """Behavior and upstream parity of the index-sargable dedup port."""
+
+    def test_creates_then_reinforces_duplicate(self):
+        repo = _memu_repo()
+        kwargs = dict(
+            resource_id="res-1",
+            memory_type="knowledge",
+            summary="ClickHouse uses MergeTree",
+            embedding=[0.1, 0.2, 0.3],
+        )
+
+        first = _content_hash_reinforce(repo, user_data={"user_id": "dup-u1"}, **kwargs)
+        assert first.extra["reinforcement_count"] == 1
+        assert first.extra["content_hash"]
+
+        second = _content_hash_reinforce(repo, user_data={"user_id": "dup-u1"}, **kwargs)
+        assert second.id == first.id
+        assert second.extra["reinforcement_count"] == 2
+        # in-memory cache tracks the reinforcement
+        assert repo.items[first.id].extra["reinforcement_count"] == 2
+
+    def test_different_scope_is_not_deduped(self):
+        repo = _memu_repo()
+        kwargs = dict(
+            resource_id="res-1",
+            memory_type="knowledge",
+            summary="same fact",
+            embedding=[0.1, 0.2],
+        )
+
+        first = _content_hash_reinforce(repo, user_data={"user_id": "scope-u1"}, **kwargs)
+        second = _content_hash_reinforce(repo, user_data={"user_id": "scope-u2"}, **kwargs)
+
+        assert second.id != first.id
+        assert second.extra["reinforcement_count"] == 1
+
+    def test_different_summary_is_not_deduped(self):
+        repo = _memu_repo()
+
+        first = _content_hash_reinforce(
+            repo,
+            resource_id="res-1",
+            memory_type="knowledge",
+            summary="fact one",
+            embedding=[0.1],
+            user_data={"user_id": "sum-u1"},
+        )
+        second = _content_hash_reinforce(
+            repo,
+            resource_id="res-2",
+            memory_type="knowledge",
+            summary="fact two",
+            embedding=[0.2],
+            user_data={"user_id": "sum-u1"},
+        )
+
+        assert second.id != first.id
+        assert _scope_count(repo, "sum-u1") == 2
+
+    def test_parity_with_upstream_create_item_reinforce(self):
+        """Run the same call sequence through memu-py's pinned implementation
+        (in one user scope) and through the port (in another); the resulting
+        rows must agree on everything scope-independent."""
+        repo = _memu_repo()
+        assert _upstream_reinforce is not None
+
+        sequence = [
+            dict(resource_id="r1", memory_type="knowledge", summary="fact one", embedding=[0.1] * 4),
+            dict(resource_id="r2", memory_type="knowledge", summary="fact one", embedding=[0.1] * 4),  # dup → reinforce
+            dict(resource_id="r3", memory_type="event", summary="fact one", embedding=[0.1] * 4),  # other type → new
+            dict(resource_id="r4", memory_type="knowledge", summary="fact two", embedding=[0.2] * 4),  # other text → new
+        ]
+
+        for kwargs in sequence:
+            up = _upstream_reinforce(
+                repo, user_data={"user_id": "par-up"}, **kwargs
+            )
+            port = _content_hash_reinforce(
+                repo, user_data={"user_id": "par-port"}, **kwargs
+            )
+            assert port.memory_type == up.memory_type
+            assert port.summary == up.summary
+            assert port.extra["content_hash"] == up.extra["content_hash"]
+            assert port.extra["reinforcement_count"] == up.extra["reinforcement_count"]
+
+        assert _scope_count(repo, "par-port") == _scope_count(repo, "par-up") == 3


### PR DESCRIPTION
## Problem

`SQLiteMemoryItemRepo.create_item_reinforce` (memu-py 1.4.0) deduplicates **every item the memorize pipeline persists** with:

```sql
SELECT ... WHERE json_extract(extra, '$.content_hash') = :hash AND <scope> LIMIT 1
```

No index can serve this, so it is a full scan of the items table — and the table carries inline embedding JSON, so a scan reads essentially the whole DB file.

On a large corpus (26 GB / 728K items) this only held up while the file was in page cache. On 2026-08-07 other workloads evicted the cache and each lookup became **~90 minutes of serial 4 KiB reads** at EBS latency (~1,200 IOPS, queue depth 1). The scan runs synchronously on the dedicated memU loop thread — asyncio cancellation cannot interrupt a running statement — so one cold lookup wedged the entire memorize lane: every `memorize` call and conversation sweep queued behind it, timed out at 300 s, and retried into the same wall. Symptom signature: `memorize_file starting` lines with no subsequent LLM steps, and 100% `timed out after 300s` failures with no "stuck on" step info.

Even in the healthy warm-cache state this scan is the dominant per-item cost of memorize.

## Why not just `CREATE INDEX`

SQLAlchemy compiles `func.json_extract(col, "$.content_hash")` with the JSON path as a **bound parameter** (`json_extract(extra, ?)`), and SQLite never matches a parameterized expression against an expression index — the plan stays `SCAN` even with the index present (proved by `test_bound_parameter_path_cannot_use_index`). The query itself has to render the expression literally.

## Fix

- **`_content_hash_reinforce`** — line-for-line port of the pinned upstream `create_item_reinforce` with one change: the dedup predicate is rendered as a literal SQL expression (`literal_column("json_extract(extra, '$.content_hash')")`); only the compared value stays a parameter. The `_semantic_sqlite_reinforce` fallthrough now calls the port, with a snapshot-protected fallback to the original on any exception (if the pinned upstream ever shifts, memorize degrades to the scan instead of failing).
- **`MemUBridge._ensure_sqlite_indexes`** — idempotent DDL after MemoryService init (tables exist by then):
  - `ix_memu_memory_items_content_hash` on `json_extract(extra, '$.content_hash')` → the dedup lookup becomes an index seek, immune to page-cache state.
  - `ix_memu_memory_items_created_at` → serves the event-date sweep (`created_at >= :cutoff ORDER BY created_at DESC LIMIT :n` in `_resolve_event_dates_sync`), which otherwise also scans.
  
  The first startup on an existing large corpus pays a one-time index build (logged with duration).

## Tests

9 new tests: index DDL creation / idempotency / missing-table robustness; `EXPLAIN QUERY PLAN` proof that the literal path uses the index while the parameterized path scans; behavior + parity tests of the port against the pinned upstream implementation on a real repo (duplicate → reinforce, scope isolation, type/text separation, identical resulting rows).

`tests/test_memu_bridge.py` + `tests/test_memorize_background.py` + `tests/test_xmemory_bridge.py`: 151 passed.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*