### PR TITLE
auth: sliding web sessions + stop expiry from eating unsent drafts

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -238,7 +238,7 @@ A reload is always explicit. Two things cause one:
 | MCP servers (`mcp_servers`) | ✅ new sessions get the new set |
 | Skills (`skills/`) | ✅ re-scanned |
 | `lockdown` | ✅ the write guards and the layer stack both follow |
-| Web gateway auth (`auth.*`) | ✅ read per request. Only the gateway's own auth: the MCP endpoint checks `/mcp/v1` against the `auth.jwt_secret` it was mounted with, so rotating that secret is half-hot (see the restart table) |
+| Web gateway auth (`auth.*`) | ✅ read per request. Only the gateway's own auth: the MCP endpoint checks `/mcp/v1` against the `auth.jwt_secret` it was mounted with, so rotating that secret is half-hot (see the restart table). `auth.jwt_expiry_hours` governs tokens minted *after* the reload; already-issued tokens keep the window they were signed with until they next slide |
 | `notifications.*` | ✅ read per notification |
 | `workspace_sync.*` | ✅ from the next sync cycle |
 | `retention.*`, `backup.*`, and the `sessions.*` the background loops read | ✅ from the next cycle of that loop |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -144,8 +144,15 @@ telegram:
 auth:
   password_hash: "$2b$12$..."    # Generate below
   jwt_secret: "..."              # Generate below
+  jwt_expiry_hours: 720          # Optional — web-session idle timeout (default 30 days)
 EOF
 ```
+
+`jwt_expiry_hours` is an **idle** timeout, not a cap on a working session: the
+gateway re-mints the token whenever a request arrives past half its lifetime,
+so a tab in continuous use is never logged out. Only a tab left untouched for
+the whole window comes back to a password prompt. Lower it if the browser is
+somewhere you don't fully trust.
 
 ### Generate auth credentials
 

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -1871,6 +1871,12 @@ class RetentionConfig:
 class AuthConfig:
     password_hash: str = ""
     jwt_secret: str = ""
+    # Web-session lifetime. This is an *idle* timeout, not a cap on a working
+    # session: the gateway slides the token forward on every authenticated
+    # request (see gateway/auth.py), so an actively-used browser tab is never
+    # logged out mid-work. Only a tab left untouched for the whole window
+    # comes back to a password prompt.
+    jwt_expiry_hours: int = 720  # 30 days
 
     @classmethod
     @_coerced
@@ -1878,6 +1884,7 @@ class AuthConfig:
         return cls(
             password_hash=d.get("password_hash", ""),
             jwt_secret=d.get("jwt_secret", ""),
+            jwt_expiry_hours=max(1, _lenient_int(d.get("jwt_expiry_hours"), 720)),
         )
 
 

--- a/nerve/gateway/auth.py
+++ b/nerve/gateway/auth.py
@@ -18,7 +18,24 @@ from nerve.config import get_config
 logger = logging.getLogger(__name__)
 
 JWT_ALGORITHM = "HS256"
-JWT_EXPIRY_HOURS = 24
+
+# Fallback web-session lifetime, used only when the config can't be read.
+# The real value is ``auth.jwt_expiry_hours`` (default 720h / 30 days).
+#
+# Session tokens *slide*: ``require_auth`` re-mints one that is past
+# REFRESH_AFTER_RATIO of its lifetime and the gateway hands the fresh token
+# back on the response, so continuous use never expires. The configured
+# window is therefore an idle timeout — the old fixed 24h constant logged
+# you out mid-work exactly one day after login no matter what you were doing.
+DEFAULT_JWT_EXPIRY_HOURS = 720
+
+# Re-mint once a token is this far into its lifetime. At 0.5 an active
+# session is refreshed about every half-window (so it never dies), while a
+# fresh token costs no crypto on the vast majority of requests.
+REFRESH_AFTER_RATIO = 0.5
+
+# Response header carrying a slid session token back to the browser.
+SESSION_TOKEN_HEADER = "X-Nerve-Token"
 
 # Audience claim on session-bound MCP tokens (see create_mcp_session_token).
 MCP_AUDIENCE = "nerve-mcp"
@@ -32,14 +49,51 @@ def verify_password(plain: str, hashed: str) -> bool:
     return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
 
 
-def create_token(jwt_secret: str) -> str:
-    """Create a JWT token."""
+def session_expiry_hours() -> int:
+    """Configured web-session lifetime, in hours (never below 1)."""
+    try:
+        hours = int(get_config().auth.jwt_expiry_hours)
+    except Exception:  # config unreadable (very early boot / tests)
+        hours = DEFAULT_JWT_EXPIRY_HOURS
+    return max(1, hours)
+
+
+def create_token(jwt_secret: str, expiry_hours: int | None = None) -> str:
+    """Create a web-session JWT token."""
+    hours = max(1, int(expiry_hours)) if expiry_hours else session_expiry_hours()
+    now = datetime.now(timezone.utc)
     payload = {
-        "exp": datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRY_HOURS),
-        "iat": datetime.now(timezone.utc),
+        "exp": now + timedelta(hours=hours),
+        "iat": now,
         "sub": "user",
     }
     return jwt.encode(payload, jwt_secret, algorithm=JWT_ALGORITHM)
+
+
+def maybe_refresh_token(payload: dict, jwt_secret: str) -> str | None:
+    """Re-mint a session token that is past its refresh threshold.
+
+    Sliding expiry: each authenticated request carries the session further
+    into the future, so a tab in continuous use never hits the wall. Returns
+    ``None`` while the token is still fresh — the common case, and the reason
+    this costs nothing on most requests.
+
+    Only ordinary web-session tokens slide. Audience-scoped tokens (MCP
+    session/worker credentials) are minted per-process with deliberately
+    short TTLs and must expire on schedule.
+    """
+    if payload.get("aud") or payload.get("sub") != "user":
+        return None
+    iat, exp = payload.get("iat"), payload.get("exp")
+    if not isinstance(iat, (int, float)) or not isinstance(exp, (int, float)):
+        return None
+    lifetime = exp - iat
+    if lifetime <= 0:
+        return None
+    age = datetime.now(timezone.utc).timestamp() - iat
+    if age < lifetime * REFRESH_AFTER_RATIO:
+        return None
+    return create_token(jwt_secret)
 
 
 def create_mcp_session_token(
@@ -153,7 +207,14 @@ async def require_auth(request: Request) -> dict:
         return {"sub": "user"}
 
     token = get_token_from_request(request)
-    return decode_token(token, config.auth.jwt_secret)
+    payload = decode_token(token, config.auth.jwt_secret)
+    # Slide the session forward. Stashed on request.state rather than returned
+    # so every existing caller of this dependency is unaffected; the gateway's
+    # http middleware picks it up and emits SESSION_TOKEN_HEADER.
+    refreshed = maybe_refresh_token(payload, config.auth.jwt_secret)
+    if refreshed:
+        request.state.refreshed_token = refreshed
+    return payload
 
 
 async def authenticate_websocket(websocket: WebSocket) -> bool:

--- a/nerve/gateway/server.py
+++ b/nerve/gateway/server.py
@@ -14,7 +14,7 @@ import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
@@ -25,7 +25,7 @@ from nerve.agent.engine import AgentEngine
 from nerve.agent.streaming import broadcaster
 from nerve.config import NerveConfig, get_config
 from nerve.db import Database, init_db, close_db
-from nerve.gateway.auth import authenticate_websocket
+from nerve.gateway.auth import SESSION_TOKEN_HEADER, authenticate_websocket
 from nerve.gateway.routes import (
     init_deps,
     register_all_routes,
@@ -752,6 +752,20 @@ def create_app() -> FastAPI:
     async def _skill_id_handler(request, exc: SkillIdError):  # noqa: ANN001
         return JSONResponse(status_code=400, content={"detail": str(exc)})
 
+    # Sliding session tokens. `require_auth` re-mints a session token once it
+    # is past half its lifetime and stashes it on request.state; hand it back
+    # on the response so the browser can swap it in. Net effect: a tab in
+    # continuous use is never logged out, and the configured
+    # `auth.jwt_expiry_hours` becomes an idle timeout instead of a hard
+    # egg timer that fires mid-typing.
+    @app.middleware("http")
+    async def _slide_session_token(request: Request, call_next):  # noqa: ANN001
+        response = await call_next(request)
+        token = getattr(request.state, "refreshed_token", None)
+        if token:
+            response.headers[SESSION_TOKEN_HEADER] = token
+        return response
+
     # CORS for development
     app.add_middleware(
         CORSMiddleware,
@@ -759,6 +773,10 @@ def create_app() -> FastAPI:
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
+        # Browsers hide non-safelisted response headers from JS unless the
+        # server explicitly exposes them — without this the refreshed token
+        # is invisible to fetch() on any cross-origin (dev) setup.
+        expose_headers=[SESSION_TOKEN_HEADER],
     )
 
     # Compress JSON responses. Sessions with heavy tool-call blobs can

--- a/tests/test_auth_session_header.py
+++ b/tests/test_auth_session_header.py
@@ -1,0 +1,118 @@
+"""End-to-end test for the slid-token response header.
+
+``require_auth`` stashes a refreshed token on ``request.state`` and an http
+middleware turns that into ``X-Nerve-Token`` on the way out. That hand-off
+crosses Starlette's middleware boundary, so it is asserted against a real ASGI
+round-trip rather than reasoned about: if the header ever stops coming back,
+every browser tab silently returns to being logged out on a fixed timer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from nerve.config import AuthConfig, NerveConfig, set_config
+from nerve.gateway.auth import (
+    JWT_ALGORITHM,
+    SESSION_TOKEN_HEADER,
+    create_token,
+    maybe_refresh_token,
+    require_auth,
+)
+
+_SECRET = "test-secret-for-session-header-padded-32"
+
+
+@pytest.fixture
+def client():
+    """Minimal app wired exactly like the gateway: dependency + middleware."""
+    set_config(NerveConfig(auth=AuthConfig(jwt_secret=_SECRET, jwt_expiry_hours=720)))
+    app = FastAPI()
+
+    from fastapi import Request
+
+    @app.middleware("http")
+    async def _slide_session_token(request: Request, call_next):
+        response = await call_next(request)
+        token = getattr(request.state, "refreshed_token", None)
+        if token:
+            response.headers[SESSION_TOKEN_HEADER] = token
+        return response
+
+    @app.get("/api/thing")
+    async def thing(user: dict = Depends(require_auth)):
+        return {"ok": True}
+
+    with TestClient(app) as c:
+        yield c
+    set_config(NerveConfig())
+
+
+def _token(*, age_hours: float, lifetime_hours: int = 720) -> str:
+    iat = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return jwt.encode(
+        {
+            "iat": iat,
+            "exp": iat + timedelta(hours=lifetime_hours),
+            "sub": "user",
+        },
+        _SECRET,
+        algorithm=JWT_ALGORITHM,
+    )
+
+
+def test_fresh_token_gets_no_refresh_header(client):
+    res = client.get("/api/thing", headers={"Authorization": f"Bearer {create_token(_SECRET)}"})
+    assert res.status_code == 200
+    assert SESSION_TOKEN_HEADER not in res.headers
+
+
+def test_half_spent_token_comes_back_refreshed(client):
+    stale = _token(age_hours=400)
+    res = client.get("/api/thing", headers={"Authorization": f"Bearer {stale}"})
+    assert res.status_code == 200
+
+    fresh = res.headers.get(SESSION_TOKEN_HEADER)
+    assert fresh, "an aging session must be handed a replacement token"
+    assert fresh != stale
+
+    decoded = jwt.decode(fresh, _SECRET, algorithms=[JWT_ALGORITHM])
+    old = jwt.decode(stale, _SECRET, algorithms=[JWT_ALGORITHM])
+    assert decoded["exp"] > old["exp"]
+    # And the replacement must itself authenticate.
+    assert client.get(
+        "/api/thing", headers={"Authorization": f"Bearer {fresh}"},
+    ).status_code == 200
+
+
+def test_expired_token_is_rejected(client):
+    dead = _token(age_hours=800)  # older than its own 720h window
+    res = client.get("/api/thing", headers={"Authorization": f"Bearer {dead}"})
+    assert res.status_code == 401
+    assert SESSION_TOKEN_HEADER not in res.headers
+
+
+def test_refresh_is_not_triggered_by_an_unauthenticated_call(client):
+    res = client.get("/api/thing")
+    assert res.status_code == 401
+    assert SESSION_TOKEN_HEADER not in res.headers
+
+
+def test_query_param_token_also_slides(client):
+    """`<img src>`/downloads authenticate via ?token= and must slide too."""
+    stale = _token(age_hours=400)
+    res = client.get(f"/api/thing?token={stale}")
+    assert res.status_code == 200
+    assert res.headers.get(SESSION_TOKEN_HEADER)
+
+
+def test_maybe_refresh_agrees_with_the_route(client):
+    """Guard against the dependency and the helper drifting apart."""
+    stale = _token(age_hours=400)
+    payload = jwt.decode(stale, _SECRET, algorithms=[JWT_ALGORITHM])
+    assert maybe_refresh_token(payload, _SECRET) is not None

--- a/tests/test_auth_session_sliding.py
+++ b/tests/test_auth_session_sliding.py
@@ -1,0 +1,130 @@
+"""Tests for sliding web-session tokens.
+
+The gateway used to mint a fixed 24h token with no refresh path, so an
+actively-used browser tab was logged out exactly one day after login — mid
+work, with no warning. Session tokens now carry a configurable lifetime
+(``auth.jwt_expiry_hours``) and are re-minted once past half of it, which
+turns the window into an idle timeout.
+
+Covers: the configured TTL is honoured, a fresh token is left alone, a
+half-spent one is renewed, and audience-scoped (MCP) tokens — which are
+deliberately short-lived — never slide.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+
+from nerve.config import AuthConfig, NerveConfig, set_config
+from nerve.gateway.auth import (
+    JWT_ALGORITHM,
+    MCP_AUDIENCE,
+    create_mcp_session_token,
+    create_token,
+    maybe_refresh_token,
+    session_expiry_hours,
+)
+
+_SECRET = "test-secret-for-session-sliding-padded-to-32-bytes"
+
+
+def _decode(token: str) -> dict:
+    return jwt.decode(
+        token, _SECRET, algorithms=[JWT_ALGORITHM],
+        options={"verify_aud": False},
+    )
+
+
+def _aged_payload(*, lifetime_hours: int, age_hours: float) -> dict:
+    """A session payload minted ``age_hours`` ago with the given lifetime."""
+    iat = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    return {
+        "iat": iat.timestamp(),
+        "exp": (iat + timedelta(hours=lifetime_hours)).timestamp(),
+        "sub": "user",
+    }
+
+
+@pytest.fixture
+def config_720h():
+    set_config(NerveConfig(auth=AuthConfig(jwt_secret=_SECRET, jwt_expiry_hours=720)))
+    yield
+    set_config(NerveConfig())
+
+
+def test_expiry_hours_follows_config(config_720h):
+    assert session_expiry_hours() == 720
+
+
+def test_config_expiry_is_floored_at_one_hour():
+    # A nonsense value must not mint an already-dead token.
+    set_config(NerveConfig(auth=AuthConfig(jwt_secret=_SECRET, jwt_expiry_hours=0)))
+    try:
+        assert session_expiry_hours() == 1
+    finally:
+        set_config(NerveConfig())
+
+
+def test_token_lifetime_matches_configured_window(config_720h):
+    payload = _decode(create_token(_SECRET))
+    lifetime_hours = (payload["exp"] - payload["iat"]) / 3600
+    assert lifetime_hours == pytest.approx(720, abs=0.01)
+
+
+def test_explicit_expiry_overrides_config(config_720h):
+    payload = _decode(create_token(_SECRET, expiry_hours=6))
+    lifetime_hours = (payload["exp"] - payload["iat"]) / 3600
+    assert lifetime_hours == pytest.approx(6, abs=0.01)
+
+
+def test_fresh_token_is_not_refreshed(config_720h):
+    # Well inside the first half of its life — no new token, no crypto.
+    payload = _aged_payload(lifetime_hours=720, age_hours=1)
+    assert maybe_refresh_token(payload, _SECRET) is None
+
+
+def test_token_past_half_life_is_refreshed(config_720h):
+    payload = _aged_payload(lifetime_hours=720, age_hours=400)
+    refreshed = maybe_refresh_token(payload, _SECRET)
+    assert refreshed is not None
+    # The renewed token starts a fresh full window, so continuous use never
+    # reaches the wall.
+    new_payload = _decode(refreshed)
+    assert new_payload["exp"] > payload["exp"]
+    assert new_payload["sub"] == "user"
+
+
+def test_continuous_use_keeps_pushing_the_deadline_out(config_720h):
+    """Every refresh moves the wall further away than the token it replaced.
+
+    Chained over a working life this is what makes the window an *idle*
+    timeout: each request past half-life buys another full window, so the
+    deadline only ever arrives for a tab that stops asking.
+    """
+    for _ in range(12):
+        aged = _aged_payload(lifetime_hours=720, age_hours=400)
+        refreshed = maybe_refresh_token(aged, _SECRET)
+        assert refreshed is not None, "an active session must keep sliding"
+        assert _decode(refreshed)["exp"] > aged["exp"]
+
+
+def test_mcp_tokens_do_not_slide(config_720h):
+    """Audience-scoped credentials are short-lived on purpose."""
+    token = create_mcp_session_token(_SECRET, "sess1234", ttl_seconds=60)
+    payload = jwt.decode(
+        token, _SECRET, algorithms=[JWT_ALGORITHM], audience=MCP_AUDIENCE,
+    )
+    assert maybe_refresh_token(payload, _SECRET) is None
+
+
+def test_malformed_payload_is_not_refreshed(config_720h):
+    assert maybe_refresh_token({}, _SECRET) is None
+    assert maybe_refresh_token({"sub": "user"}, _SECRET) is None
+    # exp before iat — degenerate, must not be treated as "past half life".
+    now = datetime.now(timezone.utc).timestamp()
+    assert maybe_refresh_token(
+        {"sub": "user", "iat": now, "exp": now - 10}, _SECRET,
+    ) is None

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { useUIStore } from './stores/uiStore';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import type { ShortcutDef } from './utils/keyboard';
 import { LoginPage } from './components/Auth/LoginPage';
+import { SessionExpiredOverlay } from './components/Auth/SessionExpiredOverlay';
 import { AppShell } from './components/Layout/AppShell';
 import { ChatPage } from './pages/ChatPage';
 import { FilesPage } from './pages/FilesPage';
@@ -29,7 +30,7 @@ import { NotificationToast } from './components/Notifications/NotificationToast'
 import { ShortcutsModal } from './components/ShortcutsModal';
 
 function App() {
-  const { authenticated, checking, checkAuth } = useAuthStore();
+  const { authenticated, checking, checkAuth, sessionExpired } = useAuthStore();
   const { handleWSMessage, loadSessions } = useChatStore();
 
   useEffect(() => { checkAuth(); }, []);
@@ -43,10 +44,14 @@ function App() {
   }, [authenticated]);
 
   if (checking) return null;
-  if (!authenticated) return <LoginPage />;
+  // Only a *cold* start gets the full-page login. A session that expired
+  // under a mounted app keeps the app rendered and takes the password in an
+  // overlay, so nothing you had typed is thrown away to ask for it.
+  if (!authenticated && !sessionExpired) return <LoginPage />;
 
   return (
     <>
+      {sessionExpired && <SessionExpiredOverlay />}
       <GlobalShortcuts />
       <Routes>
         <Route element={<AppShell />}>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -216,6 +216,43 @@ export function getToken(): string | null {
   return authToken;
 }
 
+/** Response header carrying a server-refreshed session token. */
+const SESSION_TOKEN_HEADER = 'X-Nerve-Token';
+
+/**
+ * Adopt a slid session token. The gateway re-mints the token once it is past
+ * half its lifetime and returns it on the response, so a tab that keeps
+ * talking to the server never expires — no daily re-login, no logout
+ * mid-sentence.
+ */
+function absorbRefreshedToken(res: Response): void {
+  const fresh = res.headers.get(SESSION_TOKEN_HEADER);
+  if (fresh && fresh !== authToken) setToken(fresh);
+}
+
+/**
+ * What to do when the server says 401. Registered by the auth store so this
+ * module doesn't have to import it (that would be a cycle).
+ *
+ * The default is deliberately NOT `window.location.reload()`: a reload is how
+ * an expired token used to destroy whatever you were typing. Any background
+ * poll could trip it, the page would blow away mid-keystroke, and an unsent
+ * draft in a *new* chat — whose session id lives only in memory — was
+ * orphaned and then swept by pruneDrafts. The app now stays mounted and asks
+ * for the password over the top of your work.
+ */
+let onUnauthorized: (() => void) | null = null;
+
+export function setUnauthorizedHandler(handler: () => void): void {
+  onUnauthorized = handler;
+}
+
+function handleUnauthorized(): Error {
+  clearToken();
+  onUnauthorized?.();
+  return new Error('Unauthorized');
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -227,10 +264,10 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 
   const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
 
+  absorbRefreshedToken(res);
+
   if (res.status === 401) {
-    clearToken();
-    window.location.reload();
-    throw new Error('Unauthorized');
+    throw handleUnauthorized();
   }
 
   if (!res.ok) {
@@ -623,10 +660,10 @@ export const api = {
       body: formData,
     });
 
+    absorbRefreshedToken(res);
+
     if (res.status === 401) {
-      clearToken();
-      window.location.reload();
-      throw new Error('Unauthorized');
+      throw handleUnauthorized();
     }
     if (!res.ok) {
       const body = await res.text();

--- a/web/src/components/Auth/SessionExpiredOverlay.tsx
+++ b/web/src/components/Auth/SessionExpiredOverlay.tsx
@@ -1,0 +1,67 @@
+import { useState, type FormEvent } from 'react';
+import { useAuthStore } from '../../stores/authStore';
+
+/**
+ * Password prompt shown *over* the running app when a session expires.
+ *
+ * The app underneath stays mounted, so re-authenticating returns you to the
+ * exact chat, scroll position and half-written prompt you had. This replaces
+ * a `window.location.reload()` that used to fire from any background request
+ * the moment a token aged out — reliably destroying whatever was in the
+ * composer at the time.
+ */
+export function SessionExpiredOverlay() {
+  const [password, setPassword] = useState('');
+  const { login, loading, error, logout } = useAuthStore();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    login(password);
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-bg/80 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="session-expired-title"
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-surface-raised p-8 rounded-lg border border-border-subtle w-80 shadow-xl"
+      >
+        <h1 id="session-expired-title" className="text-xl font-semibold mb-2 text-center">
+          Session expired
+        </h1>
+        <p className="text-sm text-text-muted mb-6 text-center">
+          Your work is still here — log back in to continue.
+        </p>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          autoFocus
+          className="w-full px-3 py-2 bg-surface-raised border border-border-subtle rounded text-text outline-none focus:border-accent mb-4"
+        />
+        {error && <p className="text-hue-red text-sm mb-3">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 bg-accent hover:bg-accent-hover text-white rounded font-medium disabled:opacity-50 cursor-pointer"
+        >
+          {loading ? '...' : 'Unlock'}
+        </button>
+        {/* Explicit escape hatch. Unlike the overlay this *does* clear unsent
+            drafts, so it is deliberately the secondary action. */}
+        <button
+          type="button"
+          onClick={logout}
+          className="w-full mt-3 text-xs text-text-muted hover:text-text cursor-pointer"
+        >
+          Log out and discard unsent drafts
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -158,9 +158,14 @@ export function ChatPage() {
           switchSession(sessionId);
         }
       } else if (!activeSession) {
-        // No URL param and no active session yet — pick the most recent
-        const { sessions: loaded } = useChatStore.getState();
-        if (loaded.length > 0) {
+        // No URL param and no active session yet. A restored unsent chat wins
+        // over the most recent real one: it only survives a reload when it
+        // still holds draft text, and dropping the user somewhere else would
+        // hide the very prompt they were writing.
+        const { sessions: loaded, virtualSession } = useChatStore.getState();
+        if (virtualSession) {
+          switchSession(virtualSession.id);
+        } else if (loaded.length > 0) {
           switchSession(loaded[0].id);
         }
         // Otherwise, the server's session_switched WS message will set it

--- a/web/src/stores/authStore.ts
+++ b/web/src/stores/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { api, setToken, clearToken, getToken } from '../api/client';
+import { api, setToken, clearToken, getToken, setUnauthorizedHandler } from '../api/client';
 import { clearAllDrafts } from './helpers/draftStorage';
 
 interface AuthState {
@@ -7,23 +7,45 @@ interface AuthState {
   loading: boolean;
   checking: boolean;
   error: string | null;
+  /**
+   * The session died under a mounted app (token expired, or the gateway
+   * restarted with a new secret) rather than the app starting logged out.
+   *
+   * The distinction matters: a cold start shows the full-page login, but an
+   * expiry keeps the app — and everything you had typed — mounted and asks
+   * for the password in an overlay. Re-authenticating drops you back exactly
+   * where you were.
+   */
+  sessionExpired: boolean;
   login: (password: string) => Promise<void>;
   logout: () => void;
   checkAuth: () => Promise<void>;
 }
+
+/**
+ * Whether this tab has ever held a working session.
+ *
+ * Distinguishes "expired while you were using it" (keep the app mounted, ask
+ * in an overlay) from "opened with a dead token in storage" (nothing to
+ * preserve — show the normal login page). Module-level rather than store
+ * state because it's a fact about the page load, not rendered UI.
+ */
+let sessionEstablished = false;
 
 export const useAuthStore = create<AuthState>((set) => ({
   authenticated: !!getToken(),
   loading: false,
   checking: !getToken(),
   error: null,
+  sessionExpired: false,
 
   login: async (password: string) => {
     set({ loading: true, error: null });
     try {
       const { token } = await api.login(password);
       setToken(token);
-      set({ authenticated: true, loading: false });
+      sessionEstablished = true;
+      set({ authenticated: true, loading: false, sessionExpired: false });
     } catch (e: any) {
       set({ error: e.message || 'Login failed', loading: false });
     }
@@ -31,9 +53,12 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   logout: () => {
     clearToken();
-    // Purge unsent drafts so nothing leaks to the next user on a shared browser.
+    // Purge unsent drafts so nothing leaks to the next user on a shared
+    // browser. Only on a *deliberate* logout — an expired session must never
+    // take your unsent work with it.
     clearAllDrafts();
-    set({ authenticated: false });
+    sessionEstablished = false;  // back to a cold start: next 401 is not an "expiry"
+    set({ authenticated: false, sessionExpired: false });
   },
 
   checkAuth: async () => {
@@ -58,10 +83,32 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
     try {
       await api.checkAuth();
+      sessionEstablished = true;
       set({ authenticated: true, checking: false });
     } catch {
+      // On the startup path the stored token was already dead on arrival — a
+      // cold start, not an expiry under a live app, so fall through to the
+      // plain login page. Keyed off sessionEstablished rather than hardcoded
+      // so a later re-check of a session that *was* working still gets the
+      // overlay instead of silently discarding the screen.
       clearToken();
-      set({ authenticated: false, checking: false });
+      set({ authenticated: false, checking: false, sessionExpired: sessionEstablished });
     }
   },
 }));
+
+// Any 401 from the API layer lands here. Flag the session as expired instead
+// of reloading the page: the app stays mounted, unsent drafts stay in the
+// composer, and SessionExpiredOverlay collects the password over the top.
+// `checking: false` guards the case where a 401 arrives during the initial
+// checkAuth() — App renders nothing while `checking` is true.
+setUnauthorizedHandler(() => {
+  useAuthStore.setState({
+    authenticated: false,
+    checking: false,
+    // Only a session that was actually working gets the overlay treatment. A
+    // 401 on a tab that never authenticated is just "logged out" — the normal
+    // login page, not an overlay over an empty app.
+    sessionExpired: sessionEstablished,
+  });
+});

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -9,6 +9,7 @@ import { randomUUID } from '../utils/uuid';
 import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './helpers/blockHelpers';
 import { extractTodosFromMessages, extractCCTasksFromMessages } from './helpers/bufferReplay';
 import { loadDrafts, persistDraft, removeDraft, pruneDrafts } from './helpers/draftStorage';
+import { loadVirtualSession, persistVirtualSession, clearVirtualSession } from './helpers/virtualSessionStorage';
 // Handlers
 import { handleThinking, handleToken, handleToolUse, handleToolResult, handleToolOutput, handleDone, handleStopped, handleError, handleWakeup, handleAutoTurn, handleModelChanged } from './handlers/streamingHandlers';
 import { handleSessionUpdated, handleSessionStatus, handleSessionSwitched, handleSessionForked, handleSessionResumed, handleSessionArchived, handleSessionRunning, handleSessionAwaitingInput, handleAnswerInjected, handleUserMessage, handleReviewLoopUpdate } from './handlers/sessionHandlers';
@@ -236,10 +237,32 @@ interface ChatState {
   openFilesPanel: () => void;
 }
 
+/**
+ * Rebuild the unsent chat from its persisted id, if there is one. Dropped
+ * unless it still has draft text — a restored empty "New chat" is just noise
+ * in the sidebar, and the whole point of restoring is the unsent text.
+ */
+function restoreVirtualSession(): Session | null {
+  const stored = loadVirtualSession();
+  if (!stored) return null;
+  const drafts = loadDrafts();
+  if (!(drafts[stored.id] || '').trim()) {
+    clearVirtualSession();
+    return null;
+  }
+  return {
+    id: stored.id, title: '', source: 'web', status: 'created',
+    updated_at: stored.created, is_running: false,
+  };
+}
+
 export const useChatStore = create<ChatState>((set, get) => ({
   sessions: [],
   activeSession: '',
-  virtualSession: null,
+  // Rehydrated too: an unsent chat's id is the key its draft is stored under,
+  // so losing the id on reload orphaned the draft. Restoring it brings the
+  // half-written prompt back with the chat.
+  virtualSession: restoreVirtualSession(),
   // Rehydrated from localStorage so unsent composer text survives a reload.
   drafts: loadDrafts(),
   messages: [],
@@ -471,6 +494,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const rlDirty = !!(rl && (rl.goal.trim() || rl.verifier.trim()));
     if (vs && get().activeSession === vs.id && id !== vs.id
         && !(get().drafts[vs.id] || '').trim() && !rlDirty) {
+      clearVirtualSession();
       set((s) => {
         const drafts = { ...s.drafts };
         delete drafts[vs.id];
@@ -552,6 +576,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
       id, title: '', source: 'web', status: 'created',
       updated_at: now, is_running: false,
     };
+    // Persist the id: it's the key this chat's draft is written under, and
+    // without it on disk a reload strands the draft under an id nothing
+    // remembers.
+    persistVirtualSession(id, now);
     set({ virtualSession: virtual });
     await get().switchSession(id);
   },
@@ -611,6 +639,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // now owns the draft.
       removeDraft(vs.id);
       if (carried) persistDraft(real.id, carried);
+      // The chat is real now — nothing left to restore on reload.
+      clearVirtualSession();
       return {
         // Don't yank the view if the user navigated away during the POST.
         ...(state.activeSession === vs.id ? { activeSession: real.id } : {}),
@@ -634,6 +664,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     if (!vs) return;
     set({ newChatBackend: null, newChatReviewLoop: null });
     removeDraft(vs.id);
+    clearVirtualSession();
     set((s) => {
       const drafts = { ...s.drafts };
       delete drafts[vs.id];

--- a/web/src/stores/helpers/draftStorage.ts
+++ b/web/src/stores/helpers/draftStorage.ts
@@ -53,17 +53,83 @@ export function removeDraft(sessionId: string): void {
   try { localStorage.removeItem(keyFor(sessionId)); } catch { /* ignore */ }
 }
 
+// Orphan bookkeeping: { [sessionId]: firstSeenUnrecognizedMs }.
+const ORPHAN_KEY = 'nerve_draft_orphans';
+// How long an unrecognized draft is kept before it is reclaimed.
+const ORPHAN_GRACE_MS = 7 * 24 * 60 * 60 * 1000;  // 7 days
+
+function readOrphans(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(ORPHAN_KEY);
+    const parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, number> : {};
+  } catch { return {}; }
+}
+
+function writeOrphans(map: Record<string, number>): void {
+  try {
+    if (Object.keys(map).length) localStorage.setItem(ORPHAN_KEY, JSON.stringify(map));
+    else localStorage.removeItem(ORPHAN_KEY);
+  } catch { /* quota / disabled — bookkeeping is best-effort */ }
+}
+
 /**
- * Drop persisted drafts whose session id is not in `keep` — reclaims drafts for
- * sessions deleted or archived elsewhere (server-side, another tab, Telegram).
- * Callers must include the active session and any unsent virtual chat in `keep`.
+ * Reclaim persisted drafts whose session no longer exists (deleted or archived
+ * elsewhere — server-side, another tab, Telegram). Callers must include the
+ * active session and any unsent virtual chat in `keep`.
+ *
+ * A draft is NEVER deleted the first time it looks unrecognized; it is only
+ * marked, and reclaimed on a later pass once ORPHAN_GRACE_MS has passed. This
+ * used to delete on sight, which turned a transient blind spot into permanent
+ * data loss: a reload dropped the in-memory id of an unsent *new* chat, and
+ * the very next `loadSessions()` swept that chat's draft — a long unsent
+ * prompt — out of localStorage before anything could restore it.
  */
 export function pruneDrafts(keep: Set<string>): void {
+  const orphans = readOrphans();
+  const now = Date.now();
+  let changed = false;
+
   for (const k of draftKeys()) {
-    if (!keep.has(k.slice(PREFIX.length))) {
-      try { localStorage.removeItem(k); } catch { /* ignore */ }
+    const id = k.slice(PREFIX.length);
+
+    if (keep.has(id)) {
+      // Recognized again — clear any pending reclaim.
+      if (orphans[id] !== undefined) { delete orphans[id]; changed = true; }
+      continue;
     }
+
+    const firstSeen = orphans[id];
+    if (firstSeen === undefined) {
+      // First sighting: start the clock, keep the draft.
+      orphans[id] = now;
+      changed = true;
+      continue;
+    }
+    // Clock skew (or a cleared system clock) must not trigger an early sweep.
+    if (firstSeen > now) { orphans[id] = now; changed = true; continue; }
+    if (now - firstSeen < ORPHAN_GRACE_MS) continue;
+
+    try { localStorage.removeItem(k); } catch { /* ignore */ }
+    delete orphans[id];
+    changed = true;
   }
+
+  if (changed) writeOrphans(orphans);
+}
+
+/** Persisted drafts for sessions the app no longer knows about. */
+export function orphanedDrafts(keep: Set<string>): Array<{ id: string; text: string }> {
+  const out: Array<{ id: string; text: string }> = [];
+  for (const k of draftKeys()) {
+    const id = k.slice(PREFIX.length);
+    if (keep.has(id)) continue;
+    try {
+      const text = localStorage.getItem(k);
+      if (text && text.trim()) out.push({ id, text });
+    } catch { /* ignore a single unreadable key */ }
+  }
+  return out;
 }
 
 /** Wipe every persisted draft — the shared-browser safety control, run on logout. */
@@ -71,4 +137,5 @@ export function clearAllDrafts(): void {
   for (const k of draftKeys()) {
     try { localStorage.removeItem(k); } catch { /* ignore */ }
   }
+  writeOrphans({});
 }

--- a/web/src/stores/helpers/virtualSessionStorage.ts
+++ b/web/src/stores/helpers/virtualSessionStorage.ts
@@ -1,0 +1,43 @@
+// Persistence for the *virtual* (unsent) chat.
+//
+// A new chat is client-side only until its first message: `createSession()`
+// mints a random UUID and the server knows nothing about it. That id keyed the
+// composer draft — and lived only in React state, so any reload (an expired
+// token used to force one) dropped it, orphaning the draft and losing whatever
+// long prompt was being written. Persisting the id closes that hole: a reload
+// rehydrates the same virtual chat and its draft comes back with it.
+//
+// Only the id and creation time are stored. The rest of the row is cosmetic
+// and rebuilt on load.
+
+const KEY = 'nerve_virtual_session';
+
+export interface StoredVirtualSession {
+  id: string;
+  created: string;
+}
+
+/** Remember the current unsent chat so a reload can restore it. */
+export function persistVirtualSession(id: string, created: string): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify({ id, created }));
+  } catch { /* quota / disabled — the chat simply won't survive a reload */ }
+}
+
+/** Read back the unsent chat, if any. */
+export function loadVirtualSession(): StoredVirtualSession | null {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.id === 'string' && parsed.id) {
+      return { id: parsed.id, created: typeof parsed.created === 'string' ? parsed.created : new Date().toISOString() };
+    }
+  } catch { /* unreadable / malformed — treat as absent */ }
+  return null;
+}
+
+/** Forget it — the chat was sent (and adopted a real id) or discarded. */
+export function clearVirtualSession(): void {
+  try { localStorage.removeItem(KEY); } catch { /* ignore */ }
+}


### PR DESCRIPTION

Three stacked bugs. The third is the one that destroys work.

## 1. Forced re-login every 24h

`gateway/auth.py` minted tokens with a hardcoded `JWT_EXPIRY_HOURS = 24` and there was **no refresh path** — `/api/auth/` exposes only `login`, `status` and `check`. A token was minted at login and died exactly 24h later regardless of whether the tab had been in continuous use. Not a session; an egg timer.

## 2. The 401 handler nuked the page

```ts
if (res.status === 401) {
  clearToken();
  window.location.reload();   // immediate, unconditional
}
```

Any background request — session-list poll, the 15s review-loop poll, a models fetch — that caught the 401 hard-reloaded the tab. No prompt, no state preserved, and it can fire mid-keystroke.

## 3. …and that reload ate unsent drafts

Drafts are persisted per session (`nerve_draft_<id>`), so a draft in an **existing** chat survived. But a **new chat** is a *virtual* session: `createSession()` mints a `randomUUID()` that lives only in React state. So:

1. reload → the id is gone → the draft key is orphaned
2. `App` mount → `loadSessions()` → `pruneDrafts(keep)` with `keep` = real server sessions only
3. the orphan doesn't match → `localStorage.removeItem` → **the draft is deleted**, not merely lost

Precision-targeted at exactly the case of a long prompt composed in a new chat.

## Changes

**Backend**
- `auth.jwt_expiry_hours` (default `720` / 30 days) replaces the 24h constant
- `require_auth` re-mints a token past half its lifetime and stashes it on `request.state`; an http middleware returns it as `X-Nerve-Token`, and CORS exposes that header
- continuous use therefore never expires — the window becomes an **idle** timeout
- audience-scoped MCP tokens deliberately do **not** slide; they keep their short TTLs

**Frontend**
- 401 no longer reloads. The app stays mounted and `SessionExpiredOverlay` takes the password over the top, so the composer, scroll position and half-written prompt survive
- a cold start with a dead token still shows the normal full-page login
- the virtual session id is persisted, so a reload restores the unsent chat *and* its draft
- `pruneDrafts` marks unrecognized drafts and reclaims them after a 7-day grace window instead of deleting on first sight
- explicit logout still wipes drafts (the shared-browser control); expiry never does

## Testing

- `tests/test_auth_session_sliding.py` — TTL config, refresh threshold, MCP tokens not sliding, malformed payloads
- `tests/test_auth_session_header.py` — real ASGI round-trip asserting `X-Nerve-Token` survives the middleware boundary, that the replacement authenticates, and that expired/anonymous requests get no header
- full backend suite: **3038 passed**
- frontend `tsc -b` clean, production build clean, new/edited files lint-clean
- the draft-loss chain was reproduced against the new code with a localStorage harness (all 10 scenarios pass, including "draft survives the post-reload prune")

## Note

There is no frontend test framework in the repo, so the draft-storage logic — which is the actual data-loss fix — is verified by harness rather than committed tests. Worth adding vitest separately; deliberately not smuggled into this PR.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*
