### PR TITLE
cron: gate the default inbox-processor on unread messages

### DIFF
--- a/docs/cron.md
+++ b/docs/cron.md
@@ -237,18 +237,19 @@ run_if:
 
 #### `messages`
 
-Satisfied when monitored sync sources have unread messages (compares each
-source's max ingested rowid against the consumer cursor; never advances it).
+Satisfied when the sync sources feeding a consumer have unread messages
+(compares each source's max ingested rowid against the consumer cursor; never
+advances it).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `sources` | list | — (required) | Source names to check (e.g. `gmail`, `github`) |
+| `sources` | list | *(any source)* | Source names to check (e.g. `gmail`, `github`). **Omit** to fire when *any* source the consumer already tracks has unread messages — handy for a shared/default inbox job that shouldn't hard-code the connected sources. |
 | `consumer` | string | `inbox` | Consumer cursor name used for the unread check |
 
 ```yaml
 run_if:
   - type: messages
-    sources: [gmail, github]
+    sources: [gmail, github]   # omit `sources` entirely for "any source"
     consumer: inbox
 ```
 

--- a/nerve/bootstrap.py
+++ b/nerve/bootstrap.py
@@ -77,6 +77,9 @@ PRODUCTIVITY_CRONS = [
         "session_mode": "persistent",
         "context_rotate_hours": 24,
         "reminder_mode": True,
+        # Skip idle polls: only wake when the inbox actually has new messages.
+        # No "sources" list → any source the "inbox" consumer tracks.
+        "run_if": [{"type": "messages", "consumer": "inbox"}],
         "prompt": (
             "Process the sync inbox by calling poll_all_sources(consumer=\"inbox\").\n\n"
             "If there are new messages, review them and take appropriate action:\n"

--- a/nerve/cron/gates.py
+++ b/nerve/cron/gates.py
@@ -102,7 +102,7 @@ class CronGate(ABC):
 
 
 class MessagesGate(CronGate):
-    """Satisfied when monitored sync sources have unread messages.
+    """Satisfied when the sync sources feeding a consumer have unread messages.
 
     Generalises the legacy ``skip_when_idle`` / ``idle_consumer`` fields:
     a job that only wants to run when an inbox has new mail.
@@ -110,11 +110,15 @@ class MessagesGate(CronGate):
     Config::
 
         type: messages
-        sources: [gmail, github]   # source names to check (required)
+        sources: [gmail, github]   # sources to check; omit for "any source"
         consumer: inbox            # consumer cursor name (default "inbox")
 
-    The check compares each source's max ingested rowid against the
-    consumer's cursor position; it never advances any cursor.
+    With an explicit ``sources`` list, each named source's max ingested rowid
+    is compared against the consumer's cursor. With ``sources`` omitted (or
+    empty), the gate fires when *any* source the consumer already tracks has
+    unread messages — so a shared/default inbox job can be gated without
+    hard-coding the particular set of connected sources. Either way the check
+    only reads cursor state; it never advances a cursor.
     """
 
     type = "messages"
@@ -124,37 +128,41 @@ class MessagesGate(CronGate):
         "sources", "consumer", "skip_when_idle", "idle_consumer",
     })
 
-    def __init__(self, sources: list[str], consumer: str = "inbox") -> None:
-        if not sources:
-            raise GateConfigError("'messages' gate requires at least one source")
-        self.sources = sources
+    def __init__(self, sources: list[str] | None = None, consumer: str = "inbox") -> None:
+        # An empty/omitted source list means "any source this consumer tracks".
+        self.sources = list(sources or [])
         self.consumer = consumer
 
     async def is_satisfied(self, ctx: GateContext) -> bool:
-        for source in self.sources:
-            cursor_seq = await ctx.db.get_consumer_cursor(self.consumer, source)
-            max_seq = await ctx.db.get_source_max_rowid(source)
-            if max_seq > cursor_seq:
-                return True
-        return False
+        if self.sources:
+            for source in self.sources:
+                cursor_seq = await ctx.db.get_consumer_cursor(self.consumer, source)
+                max_seq = await ctx.db.get_source_max_rowid(source)
+                if max_seq > cursor_seq:
+                    return True
+            return False
+        # No explicit sources: fire if any source the consumer tracks has
+        # unread messages. Listing cursors is read-only — unlike
+        # get_consumer_cursor it never initializes or advances a cursor.
+        cursors = await ctx.db.list_consumer_cursors(self.consumer)
+        return any((c.get("unread") or 0) > 0 for c in cursors)
 
     def describe(self) -> str:
-        return (
-            f"new messages in {', '.join(self.sources)} "
-            f"(consumer={self.consumer})"
-        )
+        where = ", ".join(self.sources) if self.sources else "any source"
+        return f"new messages in {where} (consumer={self.consumer})"
 
     @classmethod
     def from_config(cls, spec: dict) -> "MessagesGate":
         # Accept the new "sources" key, plus the legacy "skip_when_idle"
-        # spelling so an old shorthand maps cleanly onto this gate.
+        # spelling so an old shorthand maps cleanly onto this gate. An
+        # omitted/empty list means "any source the consumer tracks".
         sources = spec.get("sources")
         if sources is None:
             sources = spec.get("skip_when_idle", [])
         if isinstance(sources, str):
             sources = [sources]
         consumer = spec.get("consumer") or spec.get("idle_consumer") or "inbox"
-        return cls(sources=list(sources), consumer=consumer)
+        return cls(sources=list(sources or []), consumer=consumer)
 
 
 class TasksGate(CronGate):

--- a/nerve/cron/gates.py
+++ b/nerve/cron/gates.py
@@ -142,10 +142,10 @@ class MessagesGate(CronGate):
                     return True
             return False
         # No explicit sources: fire if any source the consumer tracks has
-        # unread messages. Listing cursors is read-only — unlike
-        # get_consumer_cursor it never initializes or advances a cursor.
-        cursors = await ctx.db.list_consumer_cursors(self.consumer)
-        return any((c.get("unread") or 0) > 0 for c in cursors)
+        # unread messages. Read-only and expiry-agnostic — it never
+        # initializes or advances a cursor (unlike get_consumer_cursor) and
+        # still sees a backlog after a quiet inbox's cursors pass their TTL.
+        return await ctx.db.consumer_has_unread(self.consumer)
 
     def describe(self) -> str:
         where = ", ".join(self.sources) if self.sources else "any source"

--- a/nerve/db/sources.py
+++ b/nerve/db/sources.py
@@ -395,6 +395,29 @@ class SourceStore:
         ) as cursor:
             return [dict(row) async for row in cursor]
 
+    async def consumer_has_unread(self, consumer: str) -> bool:
+        """True if any source this consumer tracks has messages past its cursor.
+
+        Read-only and expiry-agnostic: compares each tracked source's max
+        ingested rowid against the consumer's stored cursor position — even a
+        cursor past its TTL — and never initializes or advances a cursor.
+        Sources the consumer has no cursor row for are ignored (new consumers
+        see only future messages), matching get_consumer_cursor.
+
+        Unlike list_consumer_cursors, which hides expired cursors, this keeps
+        a run gate from wedging shut when an inbox goes quiet long enough for
+        its cursors to expire and then receives new mail.
+        """
+        async with self.db.execute(
+            """SELECT 1 FROM consumer_cursors cc
+               WHERE cc.consumer = ?
+                 AND (SELECT COALESCE(MAX(sm.rowid), 0) FROM source_messages sm
+                      WHERE sm.source = cc.source) > cc.cursor_seq
+               LIMIT 1""",
+            (consumer,),
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
     async def read_source_messages_by_rowid(
         self,
         source: str,

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -167,6 +167,20 @@ class TestNonInteractiveSetup:
         assert "inbox-processor" in choices.enabled_crons
         assert "task-planner" in choices.enabled_crons
 
+    def test_inbox_processor_default_has_idle_gate(self) -> None:
+        """The default inbox-processor ships gated so idle polls are skipped."""
+        from nerve.bootstrap import PRODUCTIVITY_CRONS
+        from nerve.cron.gates import MessagesGate, build_gate
+
+        inbox = next(c for c in PRODUCTIVITY_CRONS if c["id"] == "inbox-processor")
+        assert inbox.get("run_if"), "inbox-processor must ship a run gate"
+        spec = inbox["run_if"][0]
+        assert spec["type"] == "messages"
+        assert spec.get("consumer") == "inbox"
+        # No hard-coded sources → the generic "any source" form.
+        assert "sources" not in spec
+        assert isinstance(build_gate(spec), MessagesGate)
+
 
 class TestDeferredWrites:
     """Verify nothing is written until _apply()."""

--- a/tests/test_cron_gates.py
+++ b/tests/test_cron_gates.py
@@ -205,31 +205,22 @@ class TestMessagesGate:
         assert await gate.is_satisfied(_ctx(db)) is True
 
     @pytest.mark.asyncio
-    async def test_no_sources_fires_when_any_consumer_source_unread(self):
-        # Omitted sources → "any source": read the consumer's unread counts.
-        db = _db(list_consumer_cursors=[
-            {"source": "gmail", "unread": 0},
-            {"source": "github", "unread": 3},
-        ])
+    async def test_no_sources_fires_when_consumer_has_unread(self):
+        # Omitted sources → "any source": delegate to the read-only,
+        # expiry-agnostic consumer_has_unread check.
+        db = _db(consumer_has_unread=True)
         gate = MessagesGate()
         assert gate.sources == []
         assert await gate.is_satisfied(_ctx(db)) is True
-        db.list_consumer_cursors.assert_awaited_once_with("inbox")
-        # Read-only: the any-source path must not touch/advance cursors.
+        db.consumer_has_unread.assert_awaited_once_with("inbox")
+        # Read-only: the any-source path must not initialize or advance a cursor.
         db.get_consumer_cursor.assert_not_called()
+        db.set_consumer_cursor.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_no_sources_unsatisfied_when_all_caught_up(self):
-        db = _db(list_consumer_cursors=[
-            {"source": "gmail", "unread": 0},
-            {"source": "github", "unread": 0},
-        ])
+    async def test_no_sources_unsatisfied_when_consumer_caught_up(self):
+        db = _db(consumer_has_unread=False)
         assert await MessagesGate().is_satisfied(_ctx(db)) is False
-
-    @pytest.mark.asyncio
-    async def test_no_sources_unsatisfied_when_no_cursors(self):
-        db = _db(list_consumer_cursors=[])
-        assert await MessagesGate(consumer="inbox").is_satisfied(_ctx(db)) is False
 
     def test_empty_sources_means_any_source(self):
         # Empty/omitted sources is now valid (no raise) and means "any source".

--- a/tests/test_cron_gates.py
+++ b/tests/test_cron_gates.py
@@ -204,9 +204,38 @@ class TestMessagesGate:
         gate = MessagesGate(sources=["gmail", "github"])
         assert await gate.is_satisfied(_ctx(db)) is True
 
-    def test_empty_sources_raises(self):
-        with pytest.raises(GateConfigError):
-            MessagesGate(sources=[])
+    @pytest.mark.asyncio
+    async def test_no_sources_fires_when_any_consumer_source_unread(self):
+        # Omitted sources → "any source": read the consumer's unread counts.
+        db = _db(list_consumer_cursors=[
+            {"source": "gmail", "unread": 0},
+            {"source": "github", "unread": 3},
+        ])
+        gate = MessagesGate()
+        assert gate.sources == []
+        assert await gate.is_satisfied(_ctx(db)) is True
+        db.list_consumer_cursors.assert_awaited_once_with("inbox")
+        # Read-only: the any-source path must not touch/advance cursors.
+        db.get_consumer_cursor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_sources_unsatisfied_when_all_caught_up(self):
+        db = _db(list_consumer_cursors=[
+            {"source": "gmail", "unread": 0},
+            {"source": "github", "unread": 0},
+        ])
+        assert await MessagesGate().is_satisfied(_ctx(db)) is False
+
+    @pytest.mark.asyncio
+    async def test_no_sources_unsatisfied_when_no_cursors(self):
+        db = _db(list_consumer_cursors=[])
+        assert await MessagesGate(consumer="inbox").is_satisfied(_ctx(db)) is False
+
+    def test_empty_sources_means_any_source(self):
+        # Empty/omitted sources is now valid (no raise) and means "any source".
+        assert MessagesGate(sources=[]).sources == []
+        assert MessagesGate.from_config({"type": "messages"}).sources == []
+        assert "any source" in MessagesGate().describe()
 
     def test_from_config_sources(self):
         gate = MessagesGate.from_config(
@@ -263,8 +292,10 @@ class TestBuildGate:
                 {"type": "tasks", "status": "pending"},
                 {"type": "bogus"},
             ])
-        with pytest.raises(GateConfigError):
-            build_gates([{"type": "messages"}])  # no sources → invalid
+        # A "messages" gate with no sources is now valid ("any source"),
+        # so it builds rather than failing the lot.
+        gates = build_gates([{"type": "messages"}])
+        assert len(gates) == 1 and isinstance(gates[0], MessagesGate)
 
     def test_build_gates_builds_every_valid_spec(self):
         gates = build_gates([

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1334,6 +1334,33 @@ class TestConsumerCursors:
                 rowids.append(row[0])
         return rowids
 
+    async def test_consumer_has_unread_true_when_behind(self, db: Database):
+        rowids = await self._insert_messages(db, "github", 3)
+        await db.set_consumer_cursor("inbox", "github", rowids[0])
+        assert await db.consumer_has_unread("inbox") is True
+
+    async def test_consumer_has_unread_false_when_caught_up(self, db: Database):
+        rowids = await self._insert_messages(db, "github", 3)
+        await db.set_consumer_cursor("inbox", "github", rowids[-1])
+        assert await db.consumer_has_unread("inbox") is False
+
+    async def test_consumer_has_unread_ignores_untracked_source(self, db: Database):
+        """Messages exist but the consumer has no cursor for the source → not unread."""
+        await self._insert_messages(db, "github", 2)
+        assert await db.consumer_has_unread("inbox") is False
+
+    async def test_consumer_has_unread_counts_expired_cursor(self, db: Database):
+        """A quiet inbox whose cursor expired must still report a backlog.
+
+        list_consumer_cursors hides expired cursors; consumer_has_unread must
+        not, or a gate that uses it would wedge shut once cursors age out.
+        """
+        rowids = await self._insert_messages(db, "github", 3)
+        # Cursor behind the latest, and already past its TTL (negative ttl).
+        await db.set_consumer_cursor("inbox", "github", rowids[0], ttl_days=-1)
+        assert await db.list_consumer_cursors("inbox") == []
+        assert await db.consumer_has_unread("inbox") is True
+
     async def test_consumer_cursor_init_to_latest(self, db: Database):
         """New consumer cursor should initialize to MAX(rowid) so first poll returns nothing."""
         rowids = await self._insert_messages(db, "github", 3)


### PR DESCRIPTION
## What

The `messages` run gate required an explicit `sources` list, so the built-in **inbox-processor** shipped **ungated** — it woke every 30 minutes even when the inbox was empty. Each idle wake still spawns an agent and pays to re-prime the prompt cache (the poll interval is far longer than the cache TTL), so a large share of the cron's cost buys nothing.

This generalizes the gate and turns it on by default:

- **`messages` gate `sources` is now optional.** With no `sources`, the gate fires when *any* source the consumer already tracks has unread messages, via a new **read-only, expiry-agnostic** `db.consumer_has_unread(consumer)` — it compares each tracked source's max rowid against the stored cursor (even one past its TTL) and never initializes or advances a cursor.
- **The default inbox-processor now ships `run_if: [{type: messages, consumer: inbox}]`.** Idle polls are skipped (no agent spawned) without hard-coding the particular set of connected sources, so it works for every user regardless of which sources they've enabled — the same way `task-planner` already ships a `tasks` gate.

## Behavior / compatibility

- When the inbox has new messages, the job runs exactly as before — no message is ever skipped, only idle wakes.
- Explicit-source gates (`sources: [gmail, github]`) and the legacy `skip_when_idle` shorthand are unchanged. An empty/omitted `skip_when_idle` still means "don't gate" (a gate is synthesized only when it's non-empty).
- Expiry-agnostic by design: `list_consumer_cursors` hides cursors past their 2-day TTL, so gating on it would let a long-quiet inbox wedge shut once its cursors expire; `consumer_has_unread` avoids that.

## Testing

- Gate unit tests: no-sources gate satisfied iff the consumer has unread; the path is read-only (asserts neither `get_consumer_cursor` nor `set_consumer_cursor` is called); `from_config` / `describe` / empty-list semantics; default inbox-processor ships the generic (source-less) gate and it builds.
- DB tests for `consumer_has_unread`: true when behind, false when caught up, ignores an untracked source, and **still reports a backlog when the cursor has expired** (while `list_consumer_cursors` returns none).
- Full suite: `3029 passed` (the single failure is a pre-existing, unrelated `test_xmemory_bridge` test).
