### PR TITLE
Mobile web UI [1/7]: Make the chat page usable on a phone

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -132,7 +132,10 @@ function GlobalShortcuts() {
       action: () => {
         const focusNow = () => {
           const store = useChatStore.getState();
-          if (store.sidebarCollapsed) store.toggleSidebar();
+          // On a phone the list is an off-canvas drawer, on desktop a collapsible
+          // column; revealSessionList opens whichever one this viewport uses, so
+          // the search field is never focused inside a closed, inert drawer.
+          store.revealSessionList();
           // The sidebar search input is unmounted until something asks for it.
           // requestSearchFocus bumps a nonce the sidebar subscribes to.
           store.requestSearchFocus();

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -4,6 +4,7 @@ import { Plus, X, MessageSquare, ChevronRight, ChevronDown, Bot, Loader2, Search
 import type { Session, AgentStatus } from '../../types/chat';
 import { groupByDate, parseTimestamp } from '../../utils/dateGroups';
 import { useChatStore } from '../../stores/chatStore';
+import { useModalSurface } from '../../hooks/useModalSurface';
 
 /** Strip leading '#' and 'Implement: ' prefixes from generated titles. */
 function cleanTitle(session: Session): string {
@@ -54,13 +55,17 @@ function saveCollapsedGroups(groups: Set<string>): void {
   } catch { /* quota exceeded / disabled — keep the in-memory state only */ }
 }
 
-export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate, onDelete, collapsed }: {
+export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate, onDelete, collapsed, mobile = false, onRequestClose }: {
   sessions: Session[];
   activeSession: string;
   agentStatus: AgentStatus;
   onCreate: () => void;
   onDelete: (id: string) => void;
   collapsed?: boolean;
+  /** Render as an off-canvas drawer instead of an inline column. */
+  mobile?: boolean;
+  /** Drawer mode only — tapping the scrim asks the parent to close. */
+  onRequestClose?: () => void;
 }) {
   const [systemExpanded, setSystemExpanded] = useState(false);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(loadCollapsedGroups);
@@ -78,6 +83,19 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
 
   const { searchResults, searchLoading, searchSessions, clearSearch, renameSession, toggleStar, archiveSession, virtualSession, discardVirtualSession, sidebarWidth, setSidebarWidth } = useChatStore();
   const searchFocusNonce = useChatStore(s => s.searchFocusNonce);
+
+  // In drawer mode the list is a modal overlay: it needs focus, Tab
+  // containment, Escape, and focus restoration. Declared before the search
+  // effects below so that when Cmd+K opens the drawer and asks for search
+  // focus in the same tick, the search input wins the race.
+  const drawerOpen = mobile && !collapsed;
+  const { dialogProps } = useModalSurface<HTMLDivElement>(drawerOpen, onRequestClose);
+
+  // Opening a conversation should reveal it, so every row dismisses the
+  // drawer. Leaving this to the parent's `activeSession` watcher isn't enough:
+  // re-tapping the conversation that is already open never changes the route,
+  // and the drawer would stay parked over the transcript.
+  const handleSelect = mobile ? onRequestClose : undefined;
 
   // Drag-to-resize the session list. It is left-anchored against the nav rail,
   // so the width tracks the cursor 1:1. The width transition is disabled while
@@ -279,12 +297,31 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
   }, [runningSystemCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
+    <>
+      {/* Drawer scrim. Only in mobile mode, and only while open — a phone has
+          no room for a persistent column, so the list sits above the
+          transcript and the scrim is what dismisses it. */}
+      {drawerOpen && (
+        <div
+          onClick={onRequestClose}
+          className="fixed inset-0 z-40 bg-black/60 transition-opacity duration-200"
+          aria-hidden="true"
+        />
+      )}
     <div
-      className={`bg-surface border-r border-border-subtle flex flex-col shrink-0 overflow-hidden relative ${collapsed ? 'border-r-0' : ''} ${isDragging ? '' : 'transition-all duration-200'}`}
-      style={{ width: collapsed ? 0 : sidebarWidth }}
+      {...(mobile ? dialogProps : {})}
+      aria-label={mobile ? 'Conversations' : undefined}
+      className={mobile
+        ? `bg-surface border-r border-border-subtle flex flex-col overflow-hidden fixed inset-y-0 left-0 z-50 w-[85vw] max-w-[320px] transition-transform duration-200 outline-none ${collapsed ? '-translate-x-full' : 'translate-x-0'}`
+        : `bg-surface border-r border-border-subtle flex flex-col shrink-0 overflow-hidden relative ${collapsed ? 'border-r-0' : ''} ${isDragging ? '' : 'transition-all duration-200'}`}
+      style={mobile ? undefined : { width: collapsed ? 0 : sidebarWidth }}
+      // Keep the closed drawer out of the tab order: it stays mounted so the
+      // slide transition has something to animate, but it is off-canvas.
+      inert={mobile && collapsed ? true : undefined}
     >
-      {/* Drag-to-resize handle on the right edge (hidden when collapsed). */}
-      {!collapsed && (
+      {/* Drag-to-resize handle on the right edge (hidden when collapsed).
+          Pointer-driven and mouse-only, so it has no place in drawer mode. */}
+      {!collapsed && !mobile && (
         <div
           onMouseDown={handleResizeStart}
           className="group/resize absolute top-0 right-0 bottom-0 z-20 w-2 cursor-col-resize"
@@ -310,7 +347,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
 
           {/* New chat pill (hidden under input when open) */}
           <button
-            onClick={onCreate}
+            onClick={() => { onCreate(); handleSelect?.(); }}
             title="New chat"
             className="absolute right-0 top-1/2 -translate-y-1/2 h-6 pl-1.5 pr-2.5 rounded-full border border-border-subtle flex items-center gap-1 text-[11px] text-text-faint hover:text-text-muted hover:bg-surface-hover cursor-pointer"
           >
@@ -379,6 +416,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
                       onRename={renameSession}
                       onToggleStar={toggleStar}
                       onArchive={archiveSession}
+                      onSelect={handleSelect}
                       showDate
                     />
                   ))
@@ -393,6 +431,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
             {virtualSession && (
               <Link
                 to={`/chat/${virtualSession.id}`}
+                onClick={handleSelect}
                 className={`group flex items-center gap-2 px-3 py-1.5 mx-1 mt-1 rounded-md cursor-pointer text-sm transition-colors no-underline
                   ${virtualSession.id === activeSession
                     ? 'bg-accent/10 text-text'
@@ -436,6 +475,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
                     onRename={renameSession}
                     onToggleStar={toggleStar}
                     onArchive={archiveSession}
+                    onSelect={handleSelect}
                   />
                 ))}
               </div>
@@ -462,6 +502,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
                     onRename={renameSession}
                     onToggleStar={toggleStar}
                     onArchive={archiveSession}
+                    onSelect={handleSelect}
                   />
                 ))}
               </div>
@@ -490,6 +531,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
                     onRename={renameSession}
                     onToggleStar={toggleStar}
                     onArchive={archiveSession}
+                    onSelect={handleSelect}
                   />
                 ))}
               </div>
@@ -525,6 +567,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
                   <Link
                     key={s.id}
                     to={`/chat/${s.id}`}
+                    onClick={handleSelect}
                     className={`group flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md cursor-pointer text-[12px] transition-colors no-underline
                       ${s.id === activeSession
                         ? 'bg-accent/10 text-text-muted'
@@ -548,6 +591,7 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
         )}
       </div>
     </div>
+    </>
   );
 }
 
@@ -662,7 +706,7 @@ function StatusIndicator({ session, isActive, isRunning }: {
 }
 
 
-function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggleStar, onArchive, showDate }: {
+function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggleStar, onArchive, onSelect, showDate }: {
   session: Session;
   isActive: boolean;
   isRunning: boolean;
@@ -670,6 +714,8 @@ function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggl
   onRename: (id: string, title: string) => Promise<void>;
   onToggleStar: (id: string) => Promise<void>;
   onArchive: (id: string) => Promise<void>;
+  /** Fired when the row itself is opened (not its menu) — drawer mode uses it to close. */
+  onSelect?: () => void;
   showDate?: boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -727,6 +773,7 @@ function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggl
   return (
     <Link
       to={`/chat/${session.id}`}
+      onClick={onSelect}
       className={`group flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md cursor-pointer text-sm transition-colors no-underline
         ${isActive
           ? 'bg-accent/10 text-text'

--- a/web/src/components/Chat/SidePanel.tsx
+++ b/web/src/components/Chat/SidePanel.tsx
@@ -1,6 +1,8 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { X, Lightbulb, Bot, Search, Wrench, Files, Loader2, Check, Ban, Workflow as WorkflowIcon } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
+import { useIsMobile } from '../../hooks/useMediaQuery';
+import { useModalSurface } from '../../hooks/useModalSurface';
 import { MarkdownContent } from './MarkdownContent';
 import { SelectionToolbar } from './SelectionToolbar';
 import { BlockRenderer } from './BlockRenderer';
@@ -266,9 +268,18 @@ export function SidePanel() {
   const focusPanelTab = useChatStore(s => s.focusPanelTab);
   const closePanelTab = useChatStore(s => s.closePanelTab);
   const setPanelWidth = useChatStore(s => s.setPanelWidth);
+  const mobile = useIsMobile();
 
   const activeTab = panels.find(p => p.id === activePanelId) || panels[0] || null;
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // On a phone this panel covers the whole viewport, which makes it a modal:
+  // without this, the transcript and the navigation underneath stay in the tab
+  // order and Tab lands on controls nobody can see.
+  const { dialogProps } = useModalSurface<HTMLDivElement>(
+    mobile && panelVisible && panels.length > 0,
+    togglePanel,
+  );
 
   // Drag-to-resize (disable transition during drag for responsiveness)
   const [isDragging, setIsDragging] = useState(false);
@@ -305,6 +316,36 @@ export function SidePanel() {
 
   const isOpen = panelVisible;
   const showTabs = panels.length > 1;
+
+  // A phone has no room to split the viewport: at 412px a 45% panel leaves the
+  // transcript an unreadable sliver. Cover it instead, and dismiss the same way
+  // as on desktop — via the tab header's close button.
+  if (mobile) {
+    return (
+      <div
+        {...dialogProps}
+        aria-label={activeTab.label || 'Panel'}
+        className={`side-panel fixed inset-0 z-30 flex flex-col bg-bg-sunken outline-none ${isOpen ? '' : 'hidden'}`}
+      >
+        {showTabs && (
+          <TabBar
+            panels={panels}
+            activeId={activePanelId}
+            onFocus={focusPanelTab}
+            onClose={closePanelTab}
+          />
+        )}
+        <TabHeader tab={activeTab} onClose={togglePanel} />
+        {activeTab.type === 'files'
+          ? <FileChangesPanel />
+          : activeTab.type === 'workflow'
+            ? <WorkflowPanel tab={activeTab} />
+            : <TabContent tab={activeTab} containerRef={containerRef} />
+        }
+        {activeTab.type === 'plan' && <PlanActions tab={activeTab} />}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -1,0 +1,44 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * Everything below Tailwind's `md` breakpoint (768px) is treated as "mobile":
+ * one hand, one column, no room for a persistent sidebar. Kept in sync with
+ * the `md:` prefixes used in the markup — change both together.
+ */
+export const MOBILE_QUERY = '(max-width: 767px)';
+
+/**
+ * Subscribe to a CSS media query.
+ *
+ * `useSyncExternalStore` rather than `useState` + an effect so the first
+ * render already has the right answer: an effect-based version paints one
+ * frame of the desktop layout before correcting itself, which on the chat
+ * page means a visible flash of the squeezed three-column shell.
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    const mql = window.matchMedia(query);
+    mql.addEventListener('change', onStoreChange);
+    return () => mql.removeEventListener('change', onStoreChange);
+  }, [query]);
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    // Server snapshot: assume desktop, matching the pre-JS markup.
+    () => false,
+  );
+}
+
+/** True on phone-sized viewports (below Tailwind's `md`). */
+export function useIsMobile(): boolean {
+  return useMediaQuery(MOBILE_QUERY);
+}
+
+/**
+ * One-shot check for code that runs outside React — store actions and keyboard
+ * shortcut handlers, which need the current layout but cannot call hooks.
+ */
+export function isMobileViewport(): boolean {
+  return window.matchMedia(MOBILE_QUERY).matches;
+}

--- a/web/src/hooks/useModalSurface.ts
+++ b/web/src/hooks/useModalSurface.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Controls that can hold keyboard focus. Excludes what the browser has already
+ * taken out of the tab order (`disabled`, `tabindex="-1"`).
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function focusableWithin(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    // `offsetParent === null` drops `display:none` subtrees (e.g. a panel
+    // hidden with Tailwind's `hidden`): the selector still matches them, but
+    // they cannot take focus.
+    .filter(el => el.offsetParent !== null && !el.closest('[inert]'));
+}
+
+/**
+ * Modal plumbing for an overlay that covers the page on a phone — a drawer or
+ * a full-screen panel.
+ *
+ * Covering the page visually is not enough. Left alone, the transcript and the
+ * navigation underneath stay in the tab order, so Tab walks focus onto controls
+ * the user cannot see. This gives the surface the four things a modal owes the
+ * keyboard:
+ *
+ * 1. focus moves into it when it opens,
+ * 2. Tab cycles inside it instead of escaping behind it,
+ * 3. Escape dismisses it — and is claimed here, so it does not *also* reach the
+ *    global Escape shortcut and stop a streaming response,
+ * 4. focus returns to whatever opened it when it closes.
+ *
+ * `role="dialog"` + `aria-modal` cover the same ground for assistive
+ * technology, which treats everything outside an aria-modal dialog as inert.
+ *
+ * Spread `dialogProps` onto the surface element; add an `aria-label` there so
+ * the dialog has a name.
+ */
+export function useModalSurface<T extends HTMLElement>(active: boolean, onClose?: () => void) {
+  const ref = useRef<T>(null);
+  // Held in a ref so a new `onClose` identity cannot re-run the focus effect,
+  // which would yank focus back to the top of the surface mid-interaction.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
+
+  useEffect(() => {
+    const surface = ref.current;
+    if (!active || !surface) return;
+
+    const restoreTo = document.activeElement as HTMLElement | null;
+    // Focus the surface itself rather than its first control: that control is
+    // usually a search box or a close button, and starting there skips the
+    // surface's own heading for a screen reader.
+    surface.focus();
+
+    return () => {
+      if (!restoreTo?.isConnected) return;
+      const current = document.activeElement;
+      // Hand focus back only if it is still inside the surface, or adrift on
+      // <body> because the surface was dismissed by tapping the scrim. If the
+      // user has already moved focus elsewhere, leave it there.
+      const adrift = !current || current === document.body;
+      if (adrift || surface.contains(current)) restoreTo.focus();
+    };
+  }, [active]);
+
+  const onKeyDown = useCallback((e: React.KeyboardEvent<T>) => {
+    const surface = ref.current;
+    if (!surface) return;
+
+    if (e.key === 'Escape') {
+      const close = onCloseRef.current;
+      if (!close) return;
+      // Claim it before it bubbles to the document-level shortcut handler,
+      // where Escape means "stop the agent".
+      e.preventDefault();
+      e.stopPropagation();
+      close();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+    const focusables = focusableWithin(surface);
+    if (focusables.length === 0) {
+      // Nothing to move to — better to hold focus on the surface than to let
+      // it land on something hidden behind the overlay.
+      e.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const current = document.activeElement;
+    // Shift+Tab off the top would leave through the start of the surface;
+    // Tab off the bottom would leave through the end. Wrap both.
+    if (e.shiftKey && (current === first || current === surface)) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && current === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
+
+  return {
+    dialogProps: {
+      ref,
+      role: 'dialog' as const,
+      'aria-modal': active,
+      // Lets the surface hold focus without joining the tab order itself.
+      tabIndex: -1,
+      onKeyDown,
+    },
+  };
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useChatStore } from '../stores/chatStore';
 import { SessionSidebar } from '../components/Chat/SessionSidebar';
@@ -15,6 +15,7 @@ import { ReviewLoopCard } from '../components/Chat/ReviewLoopCard';
 import { Loader2, PanelLeftOpen, PanelLeftClose, Files, ExternalLink } from 'lucide-react';
 import { api } from '../api/client';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
+import { useIsMobile } from '../hooks/useMediaQuery';
 import type { ShortcutDef } from '../utils/keyboard';
 import { copyToClipboard } from '../utils/clipboard';
 import type { ChatMessage, TextBlockData } from '../types/chat';
@@ -42,12 +43,41 @@ export function ChatPage() {
     sessions, activeSession, virtualSession, messages,
     streamingBlocks, isStreaming, loading,
     agentStatus, contextUsage, backendStatus, currentTodos, currentCCTasks,
-    sidebarCollapsed, panels,
+    sidebarCollapsed, mobileSidebarOpen, panels,
     modifiedFiles, modifiedFilesCount,
     backendDefault, newChatBackend,
     loadSessions, switchSession, createSession, deleteSession,
-    sendMessage, stopSession, toggleSidebar, openFilesPanel,
+    sendMessage, stopSession, toggleSessionList, setMobileSidebarOpen, openFilesPanel,
   } = useChatStore();
+
+  // Below `md` the session list becomes an off-canvas drawer. Its open state is
+  // deliberately NOT `sidebarCollapsed`: that one is a persisted desktop
+  // preference (default: expanded), and reusing it would both pop the drawer
+  // open on first load and let a phone overwrite the desktop layout. It lives
+  // in the store rather than here so the global Cmd+K shortcut can open it.
+  const isMobile = useIsMobile();
+  const sessionListOpen = isMobile ? mobileSidebarOpen : !sidebarCollapsed;
+
+  // Retire the drawer on the way out of the phone layout, so a later resize
+  // back down doesn't arrive with an overlay already on screen. Nothing
+  // flashes on the way out: above `md` the drawer state is not read at all.
+  useEffect(() => {
+    if (!isMobile) setMobileSidebarOpen(false);
+  }, [isMobile, setMobileSidebarOpen]);
+
+  // Picking a conversation should reveal it, not leave the list covering it.
+  // The drawer closes itself the moment one of its links is tapped — including
+  // a tap on the conversation that is already open, which never reaches here
+  // because `activeSession` doesn't change. This is the backstop for switches
+  // from anywhere else (browser Back, a deep link). The first resolution of
+  // `activeSession` out of '' is skipped: it lands after the initial load and
+  // would otherwise slam the drawer shut right after Cmd+K opened it.
+  const previousSession = useRef(activeSession);
+  useEffect(() => {
+    const switched = previousSession.current && previousSession.current !== activeSession;
+    previousSession.current = activeSession;
+    if (switched) setMobileSidebarOpen(false);
+  }, [activeSession, setMobileSidebarOpen]);
 
   // Chat-scoped keyboard shortcuts. Global ones (new chat, search, modal,
   // Esc cascade) live in <GlobalShortcuts /> in App.tsx.
@@ -64,7 +94,9 @@ export function ChatPage() {
       combo: { mod: true, shift: true, key: 's' },
       description: 'Toggle session sidebar',
       section: 'chat',
-      action: () => useChatStore.getState().toggleSidebar(),
+      // Not `toggleSidebar`: below `md` that would silently rewrite the
+      // persisted desktop preference and move nothing on screen.
+      action: () => useChatStore.getState().toggleSessionList(),
     },
     {
       id: 'chat-focus-input',
@@ -189,7 +221,9 @@ export function ChatPage() {
         agentStatus={agentStatus}
         onCreate={handleCreateSession}
         onDelete={handleDeleteSession}
-        collapsed={sidebarCollapsed}
+        collapsed={!sessionListOpen}
+        mobile={isMobile}
+        onRequestClose={() => setMobileSidebarOpen(false)}
       />
 
       {/* Main content area: chat column + optional plan panel */}
@@ -197,16 +231,17 @@ export function ChatPage() {
         {/* Chat column */}
         <div className="flex-1 flex flex-col min-w-0">
           {/* Header */}
-          <div className="border-b border-border-subtle px-5 py-2.5 flex items-center justify-between bg-bg shrink-0">
-            <div className="flex items-center gap-2">
+          <div className="border-b border-border-subtle px-3 md:px-5 py-2.5 flex items-center justify-between gap-2 bg-bg shrink-0">
+            <div className="flex items-center gap-2 min-w-0">
               <button
-                onClick={toggleSidebar}
-                className="w-6 h-6 flex items-center justify-center text-text-faint hover:text-text-muted cursor-pointer transition-colors rounded"
-                title={sidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+                onClick={toggleSessionList}
+                className="w-6 h-6 shrink-0 flex items-center justify-center text-text-faint hover:text-text-muted cursor-pointer transition-colors rounded"
+                title={sessionListOpen ? 'Hide sidebar' : 'Show sidebar'}
+                aria-expanded={sessionListOpen}
               >
-                {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+                {sessionListOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
               </button>
-              <span className="font-medium text-[15px]">
+              <span className="font-medium text-[15px] truncate">
                 {virtualSession?.id === activeSession
                   ? 'New chat'
                   : (sessions.find(s => s.id === activeSession)?.title || activeSession)}
@@ -218,7 +253,7 @@ export function ChatPage() {
                 return (
                   <span
                     title={`Agent backend: ${backend}`}
-                    className={`text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border ${
+                    className={`hidden md:inline shrink-0 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded border ${
                       backend === 'codex'
                         ? 'text-hue-teal border-teal-400/25 bg-teal-400/10'
                         : 'text-hue-orange border-orange-400/25 bg-orange-400/10'
@@ -231,7 +266,7 @@ export function ChatPage() {
               {(() => {
                 const model = sessions.find(s => s.id === activeSession)?.model;
                 return model ? (
-                  <span className="text-[11px] text-text-faint bg-surface-raised px-1.5 py-0.5 rounded">
+                  <span className="hidden md:inline shrink-0 text-[11px] text-text-faint bg-surface-raised px-1.5 py-0.5 rounded">
                     {formatModelLabel(model)}
                   </span>
                 ) : null;
@@ -266,9 +301,9 @@ export function ChatPage() {
                 );
               })()}
               {statusLabel && (
-                <div className="flex items-center gap-1.5 text-[12px] text-text-muted">
-                  <Loader2 size={12} className="animate-spin text-accent" />
-                  <span>{statusLabel}</span>
+                <div className="flex items-center gap-1.5 min-w-0 text-[12px] text-text-muted">
+                  <Loader2 size={12} className="shrink-0 animate-spin text-accent" />
+                  <span className="truncate">{statusLabel}</span>
                 </div>
               )}
               {backendStatus?.subtype === 'codex_rate_limits' && (() => {
@@ -286,7 +321,7 @@ export function ChatPage() {
                 );
               })()}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 shrink-0">
               <BackgroundJobs
                 sessions={sessions}
                 activeSession={activeSession}
@@ -306,13 +341,17 @@ export function ChatPage() {
                   <span className="tabular-nums">{fileCount}</span>
                 </button>
               )}
-              {contextUsage && <ContextBar usage={contextUsage} sessionCostUsd={sessions.find(s => s.id === activeSession)?.total_cost_usd} />}
+              {contextUsage && (
+                <div className="hidden md:flex">
+                  <ContextBar usage={contextUsage} sessionCostUsd={sessions.find(s => s.id === activeSession)?.total_cost_usd} />
+                </div>
+              )}
               {langfuse?.enabled && langfuse.host && activeSession && (
                 <a
                   href={`${langfuse.host}/sessions?sessionId=${encodeURIComponent(activeSession)}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1 px-2 py-1 rounded text-[12px] text-text-faint hover:text-text-secondary hover:bg-surface-raised transition-colors cursor-pointer"
+                  className="hidden md:flex items-center gap-1 px-2 py-1 rounded text-[12px] text-text-faint hover:text-text-secondary hover:bg-surface-raised transition-colors cursor-pointer"
                   title="View this session's trace in Langfuse"
                 >
                   <ExternalLink size={12} />

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -4,6 +4,7 @@ import { ws } from '../api/websocket';
 import type { WSMessage } from '../api/websocket';
 import type { ChatMessage, MessageBlock, Session, AgentStatus, PanelTab, ModifiedFileSummary } from '../types/chat';
 import { hydrateMessage } from '../utils/hydrateMessage';
+import { isMobileViewport } from '../hooks/useMediaQuery';
 import { randomUUID } from '../utils/uuid';
 // Helpers
 import { cancelAutoClose, clearAllAutoCloseTimers, MAX_COMPLETED_TABS } from './helpers/blockHelpers';
@@ -152,8 +153,16 @@ interface ChatState {
     toolInput: Record<string, unknown>;
   } | null;
 
-  // Sidebar collapse
+  // Sidebar collapse (desktop column — persisted)
   sidebarCollapsed: boolean;
+  /**
+   * Whether the phone-sized off-canvas session drawer is showing. Deliberately
+   * separate from `sidebarCollapsed`: that one is a persisted *desktop*
+   * preference, so driving the drawer with it would both pop the drawer open on
+   * first load and let a phone overwrite the desktop layout. Lives in the store
+   * rather than in ChatPage so the global Cmd+K shortcut can open it.
+   */
+  mobileSidebarOpen: boolean;
 
   // Modified files tracking
   modifiedFiles: ModifiedFileSummary[];
@@ -240,6 +249,11 @@ interface ChatState {
   answerInteraction: (result: Record<string, string> | null) => void;
   denyInteraction: (message?: string) => void;
   toggleSidebar: () => void;
+  setMobileSidebarOpen: (open: boolean) => void;
+  /** Show/hide the session list, whichever form it takes on this viewport. */
+  toggleSessionList: () => void;
+  /** Make sure the session list is on screen (Cmd+K, before focusing search). */
+  revealSessionList: () => void;
   // Modified files
   fetchModifiedFiles: (sessionId: string) => Promise<void>;
   openFilesPanel: () => void;
@@ -291,6 +305,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   sidebarWidth: parseFloat(localStorage.getItem('nerve_sidebar_width') || '240'),
   pendingInteraction: null,
   sidebarCollapsed: localStorage.getItem('nerve_sidebar_collapsed') === 'true',
+  mobileSidebarOpen: false,
   modifiedFiles: [],
   modifiedFilesCount: 0,
   backgroundTasks: [],
@@ -429,6 +444,21 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const next = !get().sidebarCollapsed;
     localStorage.setItem('nerve_sidebar_collapsed', String(next));
     set({ sidebarCollapsed: next });
+  },
+
+  setMobileSidebarOpen: (open: boolean) => set({ mobileSidebarOpen: open }),
+
+  // Both entry points below branch on the viewport so that the header button
+  // and the keyboard shortcuts stay in agreement — and so neither writes the
+  // persisted desktop preference from a phone.
+  toggleSessionList: () => {
+    if (isMobileViewport()) set({ mobileSidebarOpen: !get().mobileSidebarOpen });
+    else get().toggleSidebar();
+  },
+
+  revealSessionList: () => {
+    if (isMobileViewport()) set({ mobileSidebarOpen: true });
+    else if (get().sidebarCollapsed) get().toggleSidebar();
   },
 
   // ------------------------------------------------------------------ //


### PR DESCRIPTION
First step on #271. Scoped to the chat page, which is both the landing route and the page in the issue's screenshot.

## The problem

The chat page is three inline columns — session list, transcript, side panel. Below ~768px there is no width left to split between them. On a 412px viewport:

```
nav rail 56 + session list 240 = 296px of chrome,  leaving ~116px for the transcript
```

The transcript wrapped one word per line and the session list sat half off-screen. That is exactly the screenshot in #271.

## The change

Below Tailwind's `md`, the two side columns stop taking inline width and become overlays:

| | before | after (< `md`) |
|---|---|---|
| session list | inline column, 240px, always present | off-canvas drawer over a tap-to-dismiss scrim, closed by default |
| side panel | inline, 45% split | covers the transcript |
| header | 6 chips + title | title truncates; backend/model chips, context bar and Langfuse link are desktop-only |

The transcript gets the full viewport width. Everything is opened and dismissed through controls that already existed — the header's sidebar toggle and the panel's close button — so there is nothing new to learn.

## Notes for review

- **Drawer state is deliberately not `sidebarCollapsed`.** That flag is a persisted *desktop* preference that defaults to expanded; reusing it would pop the drawer open on first load and let a phone overwrite the desktop layout. It is separate local state, forced shut when the conversation changes or the layout crosses the breakpoint.
- **That reset is done during render, not in an effect.** An effect paints the stale state for a frame first — here a full-screen overlay flashing over the transcript. This is the "adjusting state when a prop changes" pattern from the React docs, and it keeps `react-hooks/set-state-in-effect` quiet.
- **`useMediaQuery` uses `useSyncExternalStore`**, so the first render already knows the viewport. The effect-based version renders the desktop shell for one frame before correcting, which on this page is a visible flash of the squeezed three-column layout.
- **Both resize handles are mouse-only** (`onMouseDown` + `col-resize`), so neither is rendered in overlay mode.
- **The closed drawer stays mounted** so the slide transition has something to animate, and carries `inert` so it is out of the tab order.

## Verification

- `npm run build` (tsc + vite) clean; `eslint` clean on all four touched files
- Checked at 412×915 and 1280×900 in Chromium via Playwright: drawer opens/closes, tapping a conversation reveals it, side panel covers and closes, and the desktop layout is pixel-identical to `main` (all chips, inline sidebar, both resize handles present)

## Not in this PR

Still to do for #271, in rough priority order: the nav rail (56px on every page), the `/cron` two-pane split and wide tables, and the `/tasks` status tab row. Happy to keep them as separate PRs.
