### PR TITLE
Mobile web UI [3/7]: Stop the list pages scrolling sideways on a phone

### DIFF
--- a/web/src/components/ui/PageHeader.tsx
+++ b/web/src/components/ui/PageHeader.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The header strip every list page starts with: icon + title, filter pills,
+ * an optional search box and optional right-hand actions.
+ *
+ * It exists because the pattern had been copy-pasted per page as a single
+ * non-wrapping flex row. That row reaches ~750px once the pills and the
+ * search box are in it, so on a 412px viewport the *page itself* scrolled
+ * sideways and every filter past the third was unreachable.
+ *
+ * The single row returns at `lg`, not `md`. The desktop shell also spends 56px
+ * on the nav rail, so a 768px viewport leaves ~664px of content — less than the
+ * widest header needs (Notifications: nine pills plus two actions). Even `lg`
+ * is not enough for that one, which is why the filter strip keeps
+ * `overflow-x-auto` at every width: a header that outgrows its container
+ * scrolls inside itself instead of spilling into the controls after it.
+ *
+ * Nothing here is reordered with CSS. Below `lg` the actions are rendered in
+ * the title row and the desktop copy is dropped from the DOM (and vice versa),
+ * so tab order follows what is on screen at both sizes — a flex `order` swap
+ * would move them visually while leaving the keyboard to step through every
+ * filter and the search box first.
+ */
+export function PageHeader({ icon, title, filters, search, actions }: {
+  icon?: ReactNode;
+  title: ReactNode;
+  /** Filter pills. Laid out by the caller; scrolled horizontally here. */
+  filters?: ReactNode;
+  search?: ReactNode;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="border-b border-border-subtle bg-bg shrink-0 px-4 lg:px-6 py-2.5 lg:py-3
+      flex flex-wrap lg:flex-nowrap items-center gap-x-4 gap-y-2">
+      {/* Row one below `lg`: the title, with the page's primary buttons pinned
+          opposite it. With an icon, desktop keeps the 16px icon-to-title gap
+          and the 24px run-out to the filters the per-page headers used. */}
+      <div className={`flex items-center gap-2 min-w-0 w-full lg:w-auto lg:flex-none
+        ${icon ? 'lg:gap-4 lg:mr-2' : ''}`}>
+        {icon}
+        <h1 className="text-lg font-semibold truncate">{title}</h1>
+        {actions && (
+          <div className="ml-auto flex shrink-0 items-center gap-2 lg:hidden">{actions}</div>
+        )}
+      </div>
+
+      {filters && (
+        // The negative margins let the strip run to both screen edges, so a
+        // half-visible pill signals "there is more this way" instead of looking
+        // like a clipped layout. The width has to grow by the same 2rem the
+        // margins take back — `w-full` alone would only shift the strip left
+        // and leave it stopping 32px short of the right edge.
+        <div className="w-[calc(100%+2rem)] lg:w-auto min-w-0
+          -mx-4 px-4 lg:mx-0 lg:px-0
+          overflow-x-auto
+          [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <div className="flex items-center gap-1 w-max">{filters}</div>
+        </div>
+      )}
+
+      {search && (
+        <div className="w-full lg:w-auto">{search}</div>
+      )}
+
+      {/* Desktop copy of the actions: last in the DOM so `ml-auto` pins it to
+          the right edge without dragging the filters and search along with it. */}
+      {actions && (
+        <div className="hidden lg:flex items-center gap-2 shrink-0 lg:ml-auto">
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bell, X, CheckCheck, EyeOff, Check, XCircle, Moon, BellOff, Trash2, Plus, RotateCw, Clock } from 'lucide-react';
 import { useNotificationStore, type Notification, type Silence } from '../stores/notificationStore';
+import { PageHeader } from '../components/ui/PageHeader';
 
 const STATUS_STYLES: Record<string, string> = {
   pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
@@ -450,68 +451,70 @@ export function NotificationsPage() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="border-b border-border-subtle px-6 py-3 flex items-center gap-4 bg-bg shrink-0">
-        <Bell size={18} className="text-accent" />
-        <h1 className="text-lg font-semibold">Notifications</h1>
-
-        {/* Status filters */}
-        <div className="flex items-center gap-1 ml-2">
-          {STATUS_FILTERS.map(f => (
-            <button
-              key={f.value}
-              onClick={() => setFilter(f.value)}
-              className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors
-                ${filter === f.value
-                  ? 'bg-accent/15 text-accent border-accent/30'
-                  : 'text-text-dim border-border hover:border-border hover:text-text-muted'
-                }`}
-            >
-              {f.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Type filters */}
-        <div className="flex items-center gap-1 ml-1">
-          {TYPE_FILTERS.map(f => (
-            <button
-              key={f.value}
-              onClick={() => setTypeFilter(f.value)}
-              className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors
-                ${typeFilter === f.value
-                  ? 'bg-accent/15 text-accent border-accent/30'
-                  : 'text-text-dim border-border hover:border-border hover:text-text-muted'
-                }`}
-            >
-              {f.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Silences toggle */}
-        <button
-          onClick={() => setShowSilences(v => !v)}
-          className={`ml-auto flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border cursor-pointer transition-colors
-            ${showSilences
-              ? 'bg-accent/15 text-accent border-accent/30'
-              : 'border-border text-text-muted hover:text-text-secondary hover:bg-surface-raised'
-            }`}
-        >
-          <BellOff size={13} />
-          Silences
-        </button>
-
-        {/* Dismiss All */}
-        {pendingCount > 0 && (
+      <PageHeader
+        icon={<Bell size={18} className="text-accent shrink-0" />}
+        title="Notifications"
+        filters={
+          <>
+            {/* Status filters */}
+            {STATUS_FILTERS.map(f => (
+              <button
+                key={f.value}
+                onClick={() => setFilter(f.value)}
+                className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors whitespace-nowrap
+                  ${filter === f.value
+                    ? 'bg-accent/15 text-accent border-accent/30'
+                    : 'text-text-dim border-border hover:border-border hover:text-text-muted'
+                  }`}
+              >
+                {f.label}
+              </button>
+            ))}
+            {/* Type filters — separated by a rule rather than the old ml-1,
+                which read as one undifferentiated run of pills once they
+                shared a scroller. */}
+            <span className="mx-1 h-4 w-px shrink-0 bg-border-subtle" aria-hidden="true" />
+            {TYPE_FILTERS.map(f => (
+              <button
+                key={f.value}
+                onClick={() => setTypeFilter(f.value)}
+                className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors whitespace-nowrap
+                  ${typeFilter === f.value
+                    ? 'bg-accent/15 text-accent border-accent/30'
+                    : 'text-text-dim border-border hover:border-border hover:text-text-muted'
+                  }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </>
+        }
+        actions={
+          <>
           <button
-            onClick={dismissAll}
-            className="flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border border-border text-text-muted hover:text-text-secondary hover:border-border hover:bg-surface-raised cursor-pointer transition-colors"
+            onClick={() => setShowSilences(v => !v)}
+            className={`flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border cursor-pointer transition-colors whitespace-nowrap
+              ${showSilences
+                ? 'bg-accent/15 text-accent border-accent/30'
+                : 'border-border text-text-muted hover:text-text-secondary hover:bg-surface-raised'
+              }`}
           >
-            <CheckCheck size={13} />
-            Dismiss All
+            <BellOff size={13} />
+            Silences
           </button>
-        )}
-      </div>
+          {/* Dismiss All */}
+          {pendingCount > 0 && (
+            <button
+              onClick={dismissAll}
+              className="flex items-center gap-1.5 px-3 py-1 text-[12px] rounded-lg border border-border text-text-muted hover:text-text-secondary hover:border-border hover:bg-surface-raised cursor-pointer transition-colors whitespace-nowrap"
+            >
+              <CheckCheck size={13} />
+              Dismiss All
+            </button>
+          )}
+          </>
+        }
+      />
 
       <div className="flex-1 overflow-y-auto p-6">
         {showSilences && <SilencesPanel />}

--- a/web/src/pages/PlansPage.tsx
+++ b/web/src/pages/PlansPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Lightbulb } from 'lucide-react';
 import { usePlanStore, type Plan } from '../stores/planStore';
+import { PageHeader } from '../components/ui/PageHeader';
 
 const STATUS_STYLES: Record<string, string> = {
   pending: 'bg-yellow-400/10 text-hue-yellow border-yellow-400/20',
@@ -64,25 +65,23 @@ export function PlansPage() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="border-b border-border-subtle px-6 py-3 flex items-center gap-4 bg-bg shrink-0">
-        <Lightbulb size={18} className="text-accent" />
-        <h1 className="text-lg font-semibold">Plans</h1>
-        <div className="flex items-center gap-1 ml-2">
-          {FILTERS.map(f => (
-            <button
-              key={f.value}
-              onClick={() => setFilter(f.value)}
-              className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors
-                ${filter === f.value
-                  ? 'bg-accent/15 text-accent border-accent/30'
-                  : 'text-text-dim border-border hover:border-border hover:text-text-muted'
-                }`}
-            >
-              {f.label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <PageHeader
+        icon={<Lightbulb size={18} className="text-accent shrink-0" />}
+        title="Plans"
+        filters={FILTERS.map(f => (
+          <button
+            key={f.value}
+            onClick={() => setFilter(f.value)}
+            className={`px-3 py-1 text-[12px] rounded-full border cursor-pointer transition-colors whitespace-nowrap
+              ${filter === f.value
+                ? 'bg-accent/15 text-accent border-accent/30'
+                : 'text-text-dim border-border hover:border-border hover:text-text-muted'
+              }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      />
 
       <div className="flex-1 overflow-y-auto p-6">
         {loading ? (

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -12,6 +12,7 @@ import { BoardFilterBar } from '../components/Tasks/Board/BoardFilterBar';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { isModalOpen } from '../components/ui/modalStack';
 import type { ShortcutDef } from '../utils/keyboard';
+import { PageHeader } from '../components/ui/PageHeader';
 
 const SORT_OPTIONS: { value: TaskSort; label: string }[] = [
   { value: 'deadline', label: 'Deadline' },
@@ -128,32 +129,34 @@ export function TasksPage() {
 
   return (
     <div className="h-full flex flex-col min-w-0">
-      <div className="border-b border-border-subtle px-4 py-3 flex items-center justify-between gap-4 bg-bg shrink-0">
-        <div className="flex items-center gap-3 min-w-0">
-          <h1 className="text-lg font-semibold shrink-0">Tasks</h1>
+      <PageHeader
+        title="Tasks"
+        filters={
+          <>
+            <div className="flex items-center bg-surface-raised border border-border-subtle rounded-lg p-0.5 shrink-0 mr-2">
+              {VIEW_OPTIONS.map(({ value, label, Icon }) => (
+                <button
+                  key={value}
+                  onClick={() => setViewMode(value)}
+                  aria-pressed={viewMode === value}
+                  title={`${label} view`}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 text-[12px] rounded-md cursor-pointer transition-colors
+                    ${viewMode === value
+                      ? 'bg-surface text-text shadow-sm'
+                      : 'text-text-faint hover:text-text-secondary'}`}
+                >
+                  <Icon size={13} /> {label}
+                </button>
+              ))}
+            </div>
 
-          <div className="flex items-center bg-surface-raised border border-border-subtle rounded-lg p-0.5 shrink-0">
-            {VIEW_OPTIONS.map(({ value, label, Icon }) => (
-              <button
-                key={value}
-                onClick={() => setViewMode(value)}
-                aria-pressed={viewMode === value}
-                title={`${label} view`}
-                className={`flex items-center gap-1.5 px-2.5 py-1 text-[12px] rounded-md cursor-pointer transition-colors
-                  ${viewMode === value
-                    ? 'bg-surface text-text shadow-sm'
-                    : 'text-text-faint hover:text-text-secondary'}`}
-              >
-                <Icon size={13} /> {label}
-              </button>
-            ))}
-          </div>
-
-          {/* Status pills are the list's filter; on the board every status
-              is already a lane, so they'd only hide columns. */}
-          {!isBoard && <TaskFilters active={filter} onChange={setFilter} />}
-
-          <div className="relative ml-2 shrink-0">
+            {/* Status pills are the list's filter; on the board every status
+                is already a lane, so they'd only hide columns. */}
+            {!isBoard && <TaskFilters active={filter} onChange={setFilter} />}
+          </>
+        }
+        search={
+          <div className="relative">
             <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-text-faint" />
             <input
               ref={searchRef}
@@ -174,37 +177,49 @@ export function TasksPage() {
               </button>
             )}
           </div>
-        </div>
-        <div className="flex items-center gap-2 shrink-0">
-          {!isSearching && !isBoard && (
-            <label className="flex items-center gap-1.5 text-[12px] text-text-faint">
-              Sort by
-              <select
-                value={sort}
-                onChange={e => setSort(e.target.value as TaskSort)}
-                className="px-2 py-1.5 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary focus:outline-none focus:border-accent/50 cursor-pointer"
-              >
-                {SORT_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-            </label>
-          )}
-          <button
-            onClick={() => setShowStatusManager(true)}
-            title="Manage statuses"
-            className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] text-text-secondary bg-surface-raised border border-border-subtle hover:border-border rounded-lg cursor-pointer"
-          >
-            <SlidersHorizontal size={14} /> Statuses
-          </button>
-          <button
-            onClick={() => setShowCreateDialog(true)}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer"
-          >
-            <Plus size={14} /> New Task
-          </button>
-        </div>
-      </div>
+        }
+        actions={
+          <>
+            {!isSearching && !isBoard && (
+              // The "Sort by" label costs more than it explains once space is
+              // tight; the select still names itself via title/aria-label.
+              <label className="flex items-center gap-1.5 text-[12px] text-text-faint">
+                <span className="hidden lg:inline">Sort by</span>
+                <select
+                  value={sort}
+                  onChange={e => setSort(e.target.value as TaskSort)}
+                  title="Sort tasks"
+                  aria-label="Sort tasks"
+                  className="px-2 py-1.5 text-[13px] bg-surface-raised border border-border-subtle rounded-lg text-text-secondary focus:outline-none focus:border-accent/50 cursor-pointer"
+                >
+                  {SORT_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <button
+              onClick={() => setShowStatusManager(true)}
+              title="Manage statuses"
+              aria-label="Manage statuses"
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] text-text-secondary bg-surface-raised border border-border-subtle hover:border-border rounded-lg cursor-pointer whitespace-nowrap"
+            >
+              <SlidersHorizontal size={14} /> <span className="hidden sm:inline">Statuses</span>
+            </button>
+            <button
+              onClick={() => setShowCreateDialog(true)}
+              // The label collapses to an icon on narrow screens, so the
+              // button carries its name explicitly rather than relying on
+              // text that is not always rendered.
+              title="New task"
+              aria-label="New task"
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] bg-accent hover:bg-accent-hover text-white rounded-lg cursor-pointer whitespace-nowrap"
+            >
+              <Plus size={14} /> <span className="hidden sm:inline">New Task</span>
+            </button>
+          </>
+        }
+      />
 
       {isBoard && <BoardFilterBar />}
 


### PR DESCRIPTION
Third step on #271, stacked on #294 (which is stacked on #293). **Review those first** — this diff only makes sense on top of them.

## The problem

Every list page had copy-pasted the same header: one non-wrapping flex row holding an icon, a title, one or two runs of filter pills, a search box and the page's action buttons.

Measured at 412px that row reaches ~750px. The consequence is worse than it sounds — the **page itself** scrolled horizontally, so filters past the third were not clipped-but-scrollable, they were *unreachable*:

| route | page overflow | unreachable |
|---|---|---|
| `/notifications` | **708px** | "Answered", "Expired", "Silenced" |
| `/tasks` | **696px** | "Done", "Deferred" |
| `/plans` | 110px | — |

`/tasks` and `/notifications` are two of the four permanent bottom-bar destinations from #294, i.e. the pages most likely to be opened from a phone.

## The change

Extract the pattern as `ui/PageHeader` and migrate the three worst pages. All three now measure **0px** of page overflow.

Desktop keeps the original single row. Below `md` it breaks into title + actions / filters / search, and the filter strip becomes a horizontal scroller bled to the screen edge — a half-visible pill reads as "swipe for more" rather than as a broken layout.

## Notes for review

- **Actions are last in the DOM**, hoisted back up beside the title on mobile with `order-1`. I had them earlier in the DOM first, and it silently reordered the *desktop* header: an `ml-auto` on a middle flex item pushes everything after it right too, so the action buttons landed left of the filters. Worth knowing if this component grows more slots.
- **Buttons whose labels collapse to icons at `sm`** (`New Task`, `Statuses`) now carry `title` + `aria-label`. Hiding the only text in a button otherwise leaves it with no accessible name.
- **`/notifications` gains a divider** between its status and type pill groups. The old `ml-1` separated them only while they sat on a roomy row; once both groups shared one scroller they read as a single undifferentiated run of nine pills.
- **`/memory` and `/cron` use the same header shape but are not migrated here.** Both also need their multi-pane bodies stacked, and doing the header without the body would leave them half-converted. They come as one pass.

## Verification

- `npm run build` clean; `eslint` clean on the touched files (one pre-existing `no-explicit-any` in `NotificationsPage.tsx:377`, outside this change)
- Re-ran the measurement script at 412×915: 696/708/110 → **0/0/0**
- Desktop at 1280×900 compared against `main`: header order, spacing and every control identical

## Still to do for #271

`/cron` + `/memory` pane stacking, `/diagnostics` tables, touch-target pass, and the detail pages (`/tasks/:id`, `/plans/:id`, `/skills/:id`, `/mcp/:serverName`) which I have not surveyed yet.

Separately, and unrelated to layout: `/notifications` renders markdown literally — `**PR:**` shows as raw asterisks in the body. Broken on desktop too; I did not want to smuggle a content fix into a layout PR.
