### PR TITLE
Mobile web UI [5/7]: Give notification body text the width of its card

### DIFF
--- a/web/src/pages/NotificationsPage.tsx
+++ b/web/src/pages/NotificationsPage.tsx
@@ -194,10 +194,17 @@ function NotificationCard({ notif }: { notif: Notification }) {
     <div className={`p-4 bg-surface border rounded-lg transition-colors ${
       notif.status === 'pending' ? 'border-border-subtle' : 'border-border-subtle'
     }`}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            {priorityDot && <span className={`w-2 h-2 rounded-full shrink-0 ${priorityDot}`} />}
+      {/* The badge column is shrink-0, so beside the text it costs a fixed
+          ~127px — over a third of the card on a phone, which left the body
+          wrapping at ~190px. Below `sm` the badges take a row of their own
+          above the title instead, and the text gets the full card width. */}
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-3">
+        <div className="min-w-0 flex-1 order-1 sm:order-none">
+          {/* items-start, not items-center: a title long enough to wrap was
+              centring the priority dot against the whole block, leaving it
+              floating beside the second line. */}
+          <div className="flex items-start gap-2">
+            {priorityDot && <span className={`w-2 h-2 mt-1.5 rounded-full shrink-0 ${priorityDot}`} />}
             <h3 className="font-medium text-[15px] text-text">{notif.title}</h3>
           </div>
           {notif.body && (
@@ -209,7 +216,7 @@ function NotificationCard({ notif }: { notif: Notification }) {
             </p>
           )}
         </div>
-        <div className="flex items-center gap-2 text-[12px] shrink-0">
+        <div className="flex flex-wrap items-center gap-2 text-[12px] shrink-0 order-0 sm:order-none">
           {(notif.redelivery_count ?? 0) > 0 && (
             <span
               className="flex items-center gap-1 px-2 py-0.5 rounded-full border bg-sky-400/10 text-hue-blue border-sky-400/20"
@@ -516,7 +523,7 @@ export function NotificationsPage() {
         }
       />
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
         {showSilences && <SilencesPanel />}
         {loading ? (
           <div className="text-text-faint text-center py-10">Loading...</div>

--- a/web/src/pages/PlansPage.tsx
+++ b/web/src/pages/PlansPage.tsx
@@ -83,7 +83,7 @@ export function PlansPage() {
         ))}
       />
 
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
         {loading ? (
           <div className="text-text-faint text-center py-10">Loading...</div>
         ) : plans.length === 0 ? (

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -229,7 +229,7 @@ export function TasksPage() {
         // and no max-width — filling the viewport is the whole point.
         <TaskBoard onOpenTask={openTask} />
       ) : (
-      <div className="flex-1 overflow-y-auto p-6">
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
         {loading ? (
           <div className="text-text-faint text-center py-10">Loading...</div>
         ) : tasks.length === 0 ? (


### PR DESCRIPTION
Follow-up on #271, stacked on #296. Reported from the phone: notification body text was not using the width of its card.

## The measurement

The card's inner row is 330px on a 412px viewport, but the body only got **191px**:

```
card inner row          330px
  └─ text column        191px   flex-1, min-w-0
  └─ badge column       127px   shrink-0   ← fixed, whatever the viewport
```

Two short chips (`pending`, `notify`) held over a third of the card, and prose broke every four or five words.

## The change

Below `sm` the badges take a row of their own above the title, and the text gets the full card. **Body width 191px → 346px (+81%).**

Two things found alongside it:

- **Page padding.** The scroll containers used `p-6` — 48px of a 412px viewport spent on padding before the card's own `p-4`. Now `p-4 md:p-6` across the three list pages.
- **The priority dot** was centred against the whole title block, so a title long enough to wrap left the dot floating beside its *second* line instead of marking the first. Now top-aligned with a small offset.

## Also corrects a line from #295

`PageHeader`'s title went `flex-1` → `flex-auto` in #296 to stop the filter row collapsing it. That fixed the collapse but introduced a smaller problem: `flex-auto` *grows* to fill the line, which pushed the action buttons onto a row of their own and cost a row of vertical space.

The title never needed to grow — `md:ml-auto` on the actions is what right-aligns them on desktop. `flex-initial` (`0 1 auto`) sizes to content, which is the property that keeps the filter row from collapsing it, still truncates via `min-w-0`, and lets the actions sit alongside.

For the record, all three values behave differently in a wrapping flex row, and only the third is right here:

| | | effect in this header |
|---|---|---|
| `flex-1` | `1 1 0%` | contributes nothing to line-fitting → title collapses to 0px |
| `flex-auto` | `1 1 auto` | grows to fill → actions pushed to their own row |
| `flex-initial` | `0 1 auto` | sizes to content, shrinks to truncate → correct |

## Verification

- `npm run build` clean; `eslint` clean on the touched files (pre-existing warnings only)
- Re-measured all five migrated pages: 0px page overflow, every `<h1>` a real width
- 1280×900: desktop unchanged — badges stay beside the title from `sm` up, single header row, `p-6` restored at `md`

## Where this belongs

Every line here amends a file introduced in #295, so if you would rather it were folded into that PR than stacked on top, say so — it needs a force-push across the stack, which I did not want to do unasked.
