### PR TITLE
Mobile web UI [7/7]: Give task titles the width the status select was holding

### DIFF
--- a/web/src/components/Tasks/TaskCard.tsx
+++ b/web/src/components/Tasks/TaskCard.tsx
@@ -15,30 +15,46 @@ export function TaskCard({ task, onStatusChange }: {
       onClick={() => navigate(`/tasks/${task.id}`)}
       className="p-4 bg-surface border border-border-subtle rounded-lg hover:border-border transition-colors cursor-pointer"
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <h3 className="font-medium text-[15px] text-text mb-1">{task.title}</h3>
-          <div className="flex items-center gap-3 text-[12px]">
+      {/* On a phone the status select held ~110px against a title that then
+          had to wrap inside ~200px. It drops to the meta line instead, where
+          there is room to spare, and the title gets the full card width.
+          Ordering does it without duplicating anything:
+
+            phone   title / meta + controls
+            ≥ sm    title + controls / meta                                */}
+      <div className="flex flex-wrap items-start gap-x-3 gap-y-2">
+        <h3 className="font-medium text-[15px] text-text min-w-0 basis-full sm:basis-0 sm:flex-1 order-0">
+          {task.title}
+        </h3>
+
+        <div className="flex items-center gap-3 text-[12px] min-w-0 order-2 sm:order-3 sm:basis-full">
+          {/* Hidden on a phone: the select sitting beside it already names
+              the status, and one value is not worth showing twice. */}
+          <span className="hidden sm:flex">
             <StatusBadge status={task.status} />
-            {task.deadline && (
-              <span className="flex items-center gap-1 text-text-dim">
-                <Calendar size={11} /> {task.deadline}
-              </span>
-            )}
-            {task.updated_at && (
-              <span
-                className="flex items-center gap-1 text-text-faint"
-                title={`Updated ${task.updated_at}`}
-              >
-                <Clock size={11} /> {formatTimeAgo(task.updated_at)}
-              </span>
-            )}
-            {task.source && (
-              <span className="text-text-faint">from {task.source}</span>
-            )}
-          </div>
+          </span>
+          {task.deadline && (
+            <span className="flex items-center gap-1 text-text-dim whitespace-nowrap">
+              <Calendar size={11} /> {task.deadline}
+            </span>
+          )}
+          {task.updated_at && (
+            <span
+              className="flex items-center gap-1 text-text-faint whitespace-nowrap"
+              title={`Updated ${task.updated_at}`}
+            >
+              <Clock size={11} /> {formatTimeAgo(task.updated_at)}
+            </span>
+          )}
+          {task.source && (
+            <span className="text-text-faint truncate">from {task.source}</span>
+          )}
         </div>
-        <div className="flex items-center gap-2 shrink-0" onClick={e => e.stopPropagation()}>
+
+        <div
+          className="flex items-center gap-2 shrink-0 ml-auto order-3 sm:order-2"
+          onClick={e => e.stopPropagation()}
+        >
           {task.source_url && (
             <a
               href={task.source_url}


### PR DESCRIPTION
Follow-up on #271, stacked on #298. Reported from the phone: the task status select was crowding out the title.

## Before

The select sat beside the title in a `shrink-0` column, holding ~110px of a ~330px card whatever the viewport. The title wrapped in what was left, so an ordinary task ran to three lines:

```
Mobile responsiveness      [In Progress ▾]
backlog for nerve #271
(prioritized)
[In Progress]  5m ago  from manual
```

## After

Below `sm` the select drops to the meta line — where `5m ago · from manual` leaves room to spare — and the title takes the full card:

```
Mobile responsiveness backlog for nerve
#271 (prioritized)
5m ago  from manual        [In Progress ▾]
```

Three-line titles become two, and a screenful goes from five cards to six.

The **status badge is hidden at the same breakpoint**. The select beside it already names the status, so on a phone it was one value rendered twice, costing a row of vertical space to say nothing new.

## How

Ordering, not duplication — one DOM, no second copy of the select to keep in sync:

| | layout |
|---|---|
| phone | title / meta + controls |
| ≥ `sm` | title + controls / meta |

The meta block carries `sm:basis-full` so it wraps beneath on desktop, and the controls carry `ml-auto` so they stay right-aligned in both arrangements.

## Verification

- `npm run build` and `eslint` clean
- 412×915: titles use the full card, select right-aligned on the meta line, badge gone, tapping the select still does not navigate into the task (the `stopPropagation` wrapper moved with it)
- 1280×900: unchanged — badge present, select at the top right, meta line beneath
