### PR TITLE
Chat: show a datetime on each message (bottom-right)

### DIFF
--- a/web/src/components/Chat/AssistantMessage.tsx
+++ b/web/src/components/Chat/AssistantMessage.tsx
@@ -1,6 +1,7 @@
 import { Repeat } from 'lucide-react';
 import type { ChatMessage } from '../../types/chat';
 import { BlockRenderer } from './BlockRenderer';
+import { formatMessageTime } from '../../utils/messageTime';
 
 export function AssistantMessage({ message }: { message: ChatMessage }) {
   // Review-loop milestones are controller-written system entries, not the
@@ -30,6 +31,14 @@ export function AssistantMessage({ message }: { message: ChatMessage }) {
             <BlockRenderer blocks={message.blocks} />
           </div>
         </div>
+        {message.created_at && (
+          <div
+            className="mt-1 text-right text-[10px] text-text-faint/60 tabular-nums"
+            title={new Date(message.created_at).toLocaleString()}
+          >
+            {formatMessageTime(message.created_at)}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/Chat/UserMessage.tsx
+++ b/web/src/components/Chat/UserMessage.tsx
@@ -1,6 +1,7 @@
 import type { ChatMessage, ImageBlockData, FileBlockData } from '../../types/chat';
 import { Download, FileText } from 'lucide-react';
 import { getToken } from '../../api/client';
+import { formatMessageTime } from '../../utils/messageTime';
 
 function authUrl(url: string): string {
   const token = getToken();
@@ -63,6 +64,14 @@ export function UserMessage({ message }: { message: ChatMessage }) {
             )}
           </div>
         </div>
+        {message.created_at && (
+          <div
+            className="mt-1 text-right text-[10px] text-text-faint/60 tabular-nums"
+            title={new Date(message.created_at).toLocaleString()}
+          >
+            {formatMessageTime(message.created_at)}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -885,7 +885,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     // socket isn't open, send() returns 'queued' (will flush on reconnect)
     // or 'dropped' (revert below).
     set((state) => ({
-      messages: [...state.messages, { role: 'user' as const, blocks }],
+      messages: [...state.messages, { role: 'user' as const, blocks, created_at: new Date().toISOString() }],
       streamingBlocks: [],
       isStreaming: true,
       agentStatus: { state: 'thinking' as const },

--- a/web/src/stores/handlers/sessionHandlers.ts
+++ b/web/src/stores/handlers/sessionHandlers.ts
@@ -266,7 +266,7 @@ export function handleSessionRunning(
       if (finalBlocks.length > 0) {
         updates.messages = [
           ...s.messages,
-          { role: 'assistant' as const, blocks: finalBlocks },
+          { role: 'assistant' as const, blocks: finalBlocks, created_at: new Date().toISOString() },
         ];
       }
       updates.streamingBlocks = [];
@@ -309,6 +309,7 @@ export function handleAnswerInjected(
       messages: [...s.messages, {
         role: 'user' as const,
         blocks: [{ type: 'text' as const, content: msg.content }],
+        created_at: new Date().toISOString(),
       }],
     }));
   }
@@ -323,6 +324,6 @@ export function handleUserMessage(
   // bubble live. The sender is excluded server-side, so this never duplicates
   // its own optimistic message. hydrateMessage rebuilds any image/file blocks.
   if (msg.session_id !== get().activeSession) return;
-  const hydrated = hydrateMessage({ role: 'user', content: msg.content, blocks: msg.blocks ?? undefined });
+  const hydrated = hydrateMessage({ role: 'user', content: msg.content, blocks: msg.blocks ?? undefined, created_at: new Date().toISOString() });
   set(s => ({ messages: [...s.messages, hydrated] }));
 }

--- a/web/src/stores/handlers/streamingHandlers.ts
+++ b/web/src/stores/handlers/streamingHandlers.ts
@@ -463,7 +463,7 @@ export function handleDone(
         : b
     );
     set((s) => ({
-      messages: [...s.messages, { role: 'assistant' as const, blocks: finalBlocks }],
+      messages: [...s.messages, { role: 'assistant' as const, blocks: finalBlocks, created_at: new Date().toISOString() }],
       streamingBlocks: [],
       isStreaming: false,
       ...doneUpdate,
@@ -496,6 +496,7 @@ export function handleStopped(
       blocks: finalBlocks.length > 0
         ? finalBlocks
         : [{ type: 'text', content: '*[Stopped by user]*' }],
+      created_at: new Date().toISOString(),
     }],
     streamingBlocks: [],
     isStreaming: false,

--- a/web/src/utils/messageTime.ts
+++ b/web/src/utils/messageTime.ts
@@ -1,0 +1,16 @@
+/**
+ * Compact local datetime for a chat message's `created_at`,
+ * e.g. "Aug 13, 2:41 AM" (locale-aware; 24h where the locale uses it).
+ * Returns '' for missing/invalid input so callers can guard on falsy.
+ */
+export function formatMessageTime(input?: string): string {
+  if (!input) return '';
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}


### PR DESCRIPTION
## What

Adds a compact local **datetime to the bottom-right corner of every user prompt and assistant reply** in the chat view.

- Reuses the collapsed session-group counter styling (`text-[10px] text-text-faint/60 tabular-nums`); full precision on hover via `title`.
- Format: `Aug 13, 2:41 AM` (locale-aware; yearless, no seconds).

## How

Pure visualization of data that already exists: every message row persists `created_at`, `GET /api/sessions/{id}/messages` returns it, and `hydrateMessage` already copies it onto `ChatMessage` on history load. So historical/reloaded messages needed only a render.

Live (just-sent / just-streamed) messages are built client-side without a server timestamp, so they're stamped with the client clock at creation — the current turn shows a time immediately without a reload. Stamp sites: optimistic send (`chatStore`), assistant finalize done/stopped (`streamingHandlers`), backstop-finalize / answer-injected / cross-client user (`sessionHandlers`).

## Files

- **new** `web/src/utils/messageTime.ts` — `formatMessageTime()`
- `web/src/components/Chat/{UserMessage,AssistantMessage}.tsx` — render
- `web/src/stores/chatStore.ts`, `web/src/stores/handlers/{streamingHandlers,sessionHandlers}.ts` — client-stamp live messages

## Notes

- Skipped on review-loop milestone cards and transient error bubbles (not conversational turns).

## Test

- `npm run build` (tsc typecheck + vite bundle) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
