### PR TITLE
Workflows: nest each child under its origin session & name it accordingly

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -2523,7 +2523,9 @@ class AgentEngine:
             if session:
                 parent_id = session.get("parent_session_id")
                 fork_msg = session.get("forked_from_message")
-                if parent_id and session.get("status") == SessionStatus.CREATED.value:
+                # Workflow legs carry parent_session_id for sidebar nesting only — never fork their fresh prompt from the parent (nor cross-backend).
+                if (parent_id and session.get("status") == SessionStatus.CREATED.value
+                        and session.get("source") != "workflow"):
                     parent = await self.db.get_session(parent_id)
                     if parent and parent.get("sdk_session_id"):
                         if parent.get("backend") != session.get("backend"):

--- a/nerve/workflows/service.py
+++ b/nerve/workflows/service.py
@@ -484,18 +484,28 @@ class WorkflowRunService:
             # (SessionSpec.extra["sandbox"] beats the global codex.sandbox).
             metadata = {"codex_sandbox": str(spec["sandbox"])}
         try:
+            # Nest the leg under the session it was started from and name it
+            # "[<parent title>] <slug>"; engine skips the fork path for
+            # source=="workflow", so parent_session_id is display-only here.
+            origin = await self._origin_session_id(run)
+            parent_title = None
+            if origin:
+                parent = await self.db.get_session(origin)
+                parent_title = (parent or {}).get("title")
+            label = run.get("title") or run_id
+            leg_title = (
+                f"[{parent_title}] {label}" if parent_title
+                else f"Workflow: {label}"
+            )
             await self.engine.sessions.get_or_create(
                 session_id,
-                title=f"Workflow: {run.get('title') or run_id}",
+                title=leg_title,
                 source="workflow",
                 metadata=metadata,
                 backend=backend,
                 model=model,
                 cwd=spec.get("cwd") or None,
             )
-            # Nest the leg under the session it was started from (display-only;
-            # engine skips the fork path for source=="workflow").
-            origin = await self._origin_session_id(run)
             if origin:
                 await self.db.update_session_fields(
                     session_id, {"parent_session_id": origin},

--- a/nerve/workflows/service.py
+++ b/nerve/workflows/service.py
@@ -397,6 +397,27 @@ class WorkflowRunService:
     def _session_id(self, run_id: str) -> str:
         return f"{_SESSION_PREFIX}{run_id}"
 
+    async def _origin_session_id(self, run: dict) -> str | None:
+        """The session a run was started from, for sidebar nesting.
+
+        ``created_by`` encodes the origin: ``session:``/``mcp:<id>`` for a
+        direct start, ``review-loop:<loop_id>`` for a review-loop leg (whose
+        observer session is the origin). Returns None for a non-session origin
+        (``user``/``cron``) or a reference that no longer resolves.
+        """
+        cb = str(run.get("created_by") or "")
+        sid: str | None = None
+        if cb.startswith("session:"):
+            sid = cb[len("session:"):]
+        elif cb.startswith("mcp:"):
+            sid = cb[len("mcp:"):]
+        elif cb.startswith("review-loop:"):
+            loop = await self.db.get_review_loop(cb[len("review-loop:"):])
+            sid = (loop or {}).get("session_id")
+        if not sid or sid == self._session_id(run["id"]):
+            return None
+        return sid if await self.db.get_session(sid) else None
+
     def _default_model(self, backend: str) -> str:
         if backend == "codex":
             return self.config.codex.model
@@ -472,6 +493,13 @@ class WorkflowRunService:
                 model=model,
                 cwd=spec.get("cwd") or None,
             )
+            # Nest the leg under the session it was started from (display-only;
+            # engine skips the fork path for source=="workflow").
+            origin = await self._origin_session_id(run)
+            if origin:
+                await self.db.update_session_fields(
+                    session_id, {"parent_session_id": origin},
+                )
             await self.db.update_workflow_run(run_id, {"session_id": session_id})
             run = await self.db.get_workflow_run(run_id) or run
             self._journal_event(run, "started", {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -550,6 +550,48 @@ async def test_engine_fails_turn_when_eof_follows_content(db, tmp_path):
     assert json.dumps(asst["blocks"] or []).count("half an answer") == 1
 
 
+@pytest.mark.asyncio
+async def test_workflow_session_never_forks_from_parent(db, tmp_path):
+    """A source=='workflow' leg carries parent_session_id for sidebar nesting
+    only — its first turn must NOT fork the parent's native session (that would
+    contaminate the fresh orchestration prompt, and cross-backend it raises).
+    A non-workflow child with identical setup still forks: source is the only
+    discriminator."""
+    engine, _made = await _engine_with_scripted_clients(
+        db, tmp_path, "seed", [[("text", "ok"), ("result", "sdk-ok")]],
+    )
+    # Parent with a resumable native session — the fork target.
+    await engine.sessions.get_or_create(
+        "parent", title="t", source="web", backend="claude",
+    )
+    await db.update_session_fields("parent", {"sdk_session_id": "sdk-parent"})
+
+    forks: dict[str, str | None] = {}
+    served = engine._get_or_create_client
+
+    async def _cap(sid, source, model, **kw):
+        forks[sid] = kw.get("fork_from")
+        return await served(sid, source, model, **kw)
+
+    engine._get_or_create_client = _cap
+
+    # Workflow leg nested under the parent, still in 'created' state.
+    await engine.sessions.get_or_create(
+        "workflow:wfr-x", title="t", source="workflow", backend="claude",
+    )
+    await db.update_session_fields("workflow:wfr-x", {"parent_session_id": "parent"})
+    await engine.run("workflow:wfr-x", "go", source="workflow", channel="web")
+    assert forks["workflow:wfr-x"] is None
+
+    # Control: a non-workflow child with the same setup DOES fork.
+    await engine.sessions.get_or_create(
+        "web-child", title="t", source="web", backend="claude",
+    )
+    await db.update_session_fields("web-child", {"parent_session_id": "parent"})
+    await engine.run("web-child", "go", source="web", channel="web")
+    assert forks["web-child"] == "sdk-parent"
+
+
 # ---------------------------------------------------------------------------
 # ClaudeBackend.validate_resume_target
 # ---------------------------------------------------------------------------

--- a/tests/test_workflow_runs.py
+++ b/tests/test_workflow_runs.py
@@ -455,16 +455,29 @@ class TestExecute:
         assert result_md.read_text(encoding="utf-8") == "final answer"
         assert any("finished" in c.kwargs["title"] for c in _notif_calls(engine))
 
-    async def test_leg_is_nested_under_origin_session(self, service, db, engine):
-        """The leg session nests under the session the run was started from,
-        so the sidebar shows it as a child instead of a top-level orphan."""
-        await db.create_session("human-1", source="web")
+    async def test_leg_is_nested_and_named_after_origin_session(self, service, db, engine):
+        """The leg nests under the session the run was started from AND is
+        titled ``[<origin title>] <slug>`` so the sidebar shows the lineage."""
+        await db.create_session("human-1", source="web", title="Azure 403")
         run = await service.start_run(
-            ENGINE_CLAUDE, {"prompt": "p"}, 5.0, created_by="session:human-1",
+            ENGINE_CLAUDE, {"prompt": "p"}, 5.0, title="fix the thing",
+            created_by="session:human-1",
         )
         await _drain(service)
         leg = await db.get_session(f"workflow:{run['id']}")
         assert leg["parent_session_id"] == "human-1"
+        assert leg["title"] == "[Azure 403] fix the thing"
+
+    async def test_leg_without_session_origin_keeps_plain_title(self, service, db, engine):
+        """A non-session origin (e.g. created_by 'user') gets no parent and
+        falls back to the plain ``Workflow: <slug>`` title."""
+        run = await service.start_run(
+            ENGINE_CLAUDE, {"prompt": "p"}, 5.0, title="solo", created_by="user",
+        )
+        await _drain(service)
+        leg = await db.get_session(f"workflow:{run['id']}")
+        assert leg["parent_session_id"] in (None, "")
+        assert leg["title"] == "Workflow: solo"
 
     async def test_origin_session_id_resolves_every_created_by_shape(self, service, db):
         """created_by → origin session: direct (session:/mcp:), review-loop leg

--- a/tests/test_workflow_runs.py
+++ b/tests/test_workflow_runs.py
@@ -455,6 +455,40 @@ class TestExecute:
         assert result_md.read_text(encoding="utf-8") == "final answer"
         assert any("finished" in c.kwargs["title"] for c in _notif_calls(engine))
 
+    async def test_leg_is_nested_under_origin_session(self, service, db, engine):
+        """The leg session nests under the session the run was started from,
+        so the sidebar shows it as a child instead of a top-level orphan."""
+        await db.create_session("human-1", source="web")
+        run = await service.start_run(
+            ENGINE_CLAUDE, {"prompt": "p"}, 5.0, created_by="session:human-1",
+        )
+        await _drain(service)
+        leg = await db.get_session(f"workflow:{run['id']}")
+        assert leg["parent_session_id"] == "human-1"
+
+    async def test_origin_session_id_resolves_every_created_by_shape(self, service, db):
+        """created_by → origin session: direct (session:/mcp:), review-loop leg
+        (→ observer), and None for non-session/dangling origins."""
+        await db.create_session("s1", source="web")
+        await db.create_review_loop(
+            "rvl-orig", title="t", session_id="s1", goal_prompt="g",
+            verifier_prompt="v", criteria_adoption="no", criteria=[],
+            implementer={}, verifier={}, cwd=None, max_iterations=3,
+            budget_usd=1.0,
+        )
+
+        async def origin(created_by: str) -> str | None:
+            return await service._origin_session_id(
+                {"created_by": created_by, "id": "wfr-orig"},
+            )
+
+        assert await origin("session:s1") == "s1"
+        assert await origin("mcp:s1") == "s1"
+        assert await origin("review-loop:rvl-orig") == "s1"
+        assert await origin("user") is None            # non-session origin
+        assert await origin("session:ghost") is None   # dangling reference
+        assert await origin("") is None
+
     async def test_codex_engine_uses_codex_backend(self, service, db, engine):
         run = await service.start_run(
             ENGINE_CODEX, {"prompt": "parallelize the tests"}, 5.0,


### PR DESCRIPTION
Workflow-run sessions (`workflow:<run-id>`) were created without a `parent_session_id`, so review-loop legs and direct runs showed up as top-level orphans in the sidebar even though their origin is known.

- `_execute` resolves the origin from `created_by` (`session:`/`mcp:` → that session; `review-loop:` → the loop's observer) and sets it as the leg's `parent_session_id`, then titles the leg `[<origin title>] <slug>` (falls back to `Workflow: <slug>` when there's no session origin).
- The engine's `created`-status fork guard now skips `source=="workflow"`, so the leg nests for display only — it never forks the parent's context (which would also crash cross-backend Claude→Codex legs).

Stacked on #305 (the drag-to-nest tree it extends). Tests cover nesting, `[origin] slug` naming, `created_by` resolution, and the workflow fork-skip (with a non-workflow control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
