### PR TITLE
Chat: "Run later" - send a prompt, but schedule it for execution, instead of running immediately

### DIFF
--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -1337,6 +1337,10 @@ class CronService:
     def _dispatch_wakeup(self, session_id: str, wakeup: dict) -> None:
         """Spawn the engine run for a claimed wakeup with error logging."""
         prompt = _resolve_wakeup_prompt(wakeup["prompt"])
+        # "Run later" deferrals are scheduled dispatches — fire them through
+        # the cron source so they mirror plan_service/cron-dispatched runs;
+        # model-requested ScheduleWakeup rows keep the "wakeup" source.
+        source = "cron" if wakeup.get("reason") == "run-later" else "wakeup"
         logger.info(
             "Firing wakeup %s for session %s", wakeup["id"], session_id[:8],
         )
@@ -1344,7 +1348,7 @@ class CronService:
             self.engine.run(
                 session_id=session_id,
                 user_message=prompt,
-                source="wakeup",
+                source=source,
                 internal=True,
             )
         )

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -94,6 +95,25 @@ class ForkRequest(BaseModel):
     source_session_id: str
     at_message_id: str | None = None
     title: str | None = None
+
+
+class RunLaterRequest(BaseModel):
+    """Defer a composed prompt into an already-created session.
+
+    The session is materialized by the caller first (the same
+    ``ensureRealSession`` path a normal first send uses), so this only
+    persists the pending message + acknowledgment and, for timed options,
+    schedules the one-shot wakeup.
+    """
+
+    session_id: str
+    message: str = ""
+    # One of the four composer options: "30m" | "1h" | "24h" | "none".
+    delay: str = "none"
+    # Attachments already uploaded against the session (mirrors the shape
+    # the composer sends on a normal message).
+    file_ids: list[str] | None = None
+    image_blocks: list[dict] | None = None
 
 
 # --- Session endpoints ---
@@ -445,6 +465,117 @@ async def fork_session(req: ForkRequest, user: dict = Depends(require_auth)):
         return fork
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+
+# "Run later" — defer a prompt without spending tokens now. The three timed
+# options map to a delay in seconds + the synthetic acknowledgment text; the
+# manual option schedules nothing.
+_RUN_LATER_TIMED = {
+    "30m": (30 * 60, "Acknowledged — scheduled to run in 30 minutes."),
+    "1h": (60 * 60, "Acknowledged — scheduled to run in 1 hour."),
+    "24h": (24 * 60 * 60, "Acknowledged — scheduled to run in 24 hours."),
+}
+_RUN_LATER_MANUAL_ACK = "Acknowledged — saved to run manually later."
+
+
+@router.post("/api/sessions/run-later")
+async def run_later(req: RunLaterRequest, user: dict = Depends(require_auth)):
+    """Defer a composed prompt: persist it as the session's pending user
+    message plus a synthetic assistant acknowledgment (written directly, with
+    no LLM call and zero token spend), and — for the three timed options —
+    schedule a one-shot wakeup that fires ``engine.run`` on the stored prompt
+    after the delay. The wakeup reuses the ScheduleWakeup substrate swept by
+    ``CronService._sweep_wakeups``; the manual option ("Just accept it")
+    schedules nothing and is run by the user later.
+    """
+    deps = get_deps()
+    session = await deps.db.get_session(req.session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    message = (req.message or "").strip()
+    if not message and not req.file_ids:
+        raise HTTPException(status_code=400, detail="Nothing to defer")
+
+    delay = (req.delay or "none").strip().lower()
+    if delay != "none" and delay not in _RUN_LATER_TIMED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown delay {delay!r} (want one of: 30m, 1h, 24h, none)",
+        )
+
+    # Pending user message — mirror the block shape a normal send persists:
+    # a text block plus one block per uploaded attachment. Resolve file_ids
+    # to records so BOTH images and ordinary files are carried into the
+    # deferred session (mirrors server._load_uploaded_files' image_refs:
+    # image type -> "image" block, everything else -> "file" block). Fall
+    # back to the caller-supplied image_blocks when no file_ids are given.
+    blocks: list[dict] = []
+    if message:
+        blocks.append({"type": "text", "content": message})
+    if req.file_ids:
+        records = await deps.db.get_uploaded_files_by_ids(req.file_ids)
+        by_id = {rec["id"]: rec for rec in records}
+        for fid in req.file_ids:
+            rec = by_id.get(fid)
+            if not rec:
+                continue
+            url = f"/api/files/uploads/{fid}"
+            if rec["file_type"] == "image":
+                blocks.append({
+                    "type": "image",
+                    "url": url,
+                    "filename": rec["filename"],
+                    "media_type": rec["media_type"],
+                })
+            else:
+                blocks.append({
+                    "type": "file",
+                    "url": url,
+                    "filename": rec["filename"],
+                    "media_type": rec["media_type"],
+                })
+    else:
+        for img in req.image_blocks or []:
+            blocks.append({
+                "type": "image",
+                "url": img.get("url"),
+                "filename": img.get("filename"),
+                "media_type": img.get("media_type"),
+            })
+    await deps.db.add_message(
+        req.session_id, role="user", content=message,
+        blocks=blocks or None, channel="web",
+    )
+
+    scheduled = delay != "none"
+    fire_at: str | None = None
+    if scheduled:
+        seconds, ack = _RUN_LATER_TIMED[delay]
+        # Compute fire_at directly (not via engine._wakeup_fire_at, which
+        # clamps to <=3600s) so the 24h option works. The wakeup store keeps
+        # a single pending wakeup per session, which suits a fresh session.
+        fire_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=seconds)
+        ).isoformat()
+        await deps.db.add_wakeup(
+            req.session_id, prompt=message, fire_at=fire_at, reason="run-later",
+        )
+    else:
+        ack = _RUN_LATER_MANUAL_ACK
+
+    # Synthetic acknowledgment — persisted as a plain assistant row, never
+    # generated by the model (zero tokens to create the deferred session).
+    await deps.db.add_message(
+        req.session_id, role="assistant", content=ack, channel="web",
+    )
+
+    return {
+        "session_id": req.session_id,
+        "scheduled": scheduled,
+        "ack": ack,
+        "fire_at": fire_at,
+    }
 
 
 @router.post("/api/sessions/{session_id}/resume")

--- a/tests/test_run_later.py
+++ b/tests/test_run_later.py
@@ -1,0 +1,148 @@
+"""Tests for the "Run later" deferred-prompt endpoint.
+
+Exercises the route handler directly against a real :class:`Database` with a
+fake engine wired via ``init_deps``. Covers the deferred-scheduling path: a
+timed option persists the pending user message + a synthetic assistant ack and
+schedules exactly one one-shot wakeup with the stored prompt (never calling the
+LLM); "Just accept it" persists the same messages but schedules no wakeup.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nerve.db import Database
+from nerve.gateway.routes._deps import init_deps
+from nerve.gateway.routes.sessions import RunLaterRequest, run_later
+
+
+def _fake_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.run = AsyncMock()  # must never be awaited by run-later
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_run_later_timed_schedules_one_shot_wakeup(db: Database):
+    engine = _fake_engine()
+    init_deps(engine=engine, db=db)
+    await db.create_session("rl-timed", source="web", backend="claude")
+
+    res = await run_later(
+        RunLaterRequest(session_id="rl-timed", message="do the thing", delay="30m"),
+        user={},
+    )
+
+    assert res["scheduled"] is True
+    assert "30 minutes" in res["ack"]
+
+    # Pending user message + synthetic assistant ack, in order — no LLM call.
+    msgs = await db.get_messages("rl-timed")
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+    assert msgs[0]["content"] == "do the thing"
+    assert "30 minutes" in msgs[1]["content"]
+    engine.run.assert_not_awaited()
+
+    # Exactly one one-shot wakeup, carrying the stored prompt, ~30 min out.
+    pending = await db.list_pending_wakeups("rl-timed")
+    assert len(pending) == 1
+    assert pending[0]["prompt"] == "do the thing"
+    assert pending[0]["reason"] == "run-later"
+    delta = (
+        datetime.fromisoformat(pending[0]["fire_at"]) - datetime.now(timezone.utc)
+    ).total_seconds()
+    assert 1700 < delta < 1900
+
+
+@pytest.mark.asyncio
+async def test_run_later_24h_uses_full_delay_unclamped(db: Database):
+    """The 24h option must not be clamped to the 1h wakeup-tool ceiling."""
+    engine = _fake_engine()
+    init_deps(engine=engine, db=db)
+    await db.create_session("rl-24h", source="web", backend="claude")
+
+    await run_later(
+        RunLaterRequest(session_id="rl-24h", message="tomorrow", delay="24h"),
+        user={},
+    )
+
+    pending = await db.list_pending_wakeups("rl-24h")
+    assert len(pending) == 1
+    delta = (
+        datetime.fromisoformat(pending[0]["fire_at"]) - datetime.now(timezone.utc)
+    ).total_seconds()
+    assert 86000 < delta < 86500  # ~24h, not clamped to 3600s
+
+
+@pytest.mark.asyncio
+async def test_run_later_just_accept_schedules_nothing(db: Database):
+    engine = _fake_engine()
+    init_deps(engine=engine, db=db)
+    await db.create_session("rl-manual", source="web", backend="claude")
+
+    res = await run_later(
+        RunLaterRequest(session_id="rl-manual", message="later", delay="none"),
+        user={},
+    )
+
+    assert res["scheduled"] is False
+    assert res["fire_at"] is None
+    assert "manually" in res["ack"]
+
+    msgs = await db.get_messages("rl-manual")
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+    assert "manually" in msgs[1]["content"]
+
+    assert await db.list_pending_wakeups("rl-manual") == []
+    engine.run.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_later_persists_all_attachments(db: Database):
+    """Every uploaded attachment — images AND ordinary files — must be
+    carried into the deferred session's pending user message, not just
+    image blocks."""
+    engine = _fake_engine()
+    init_deps(engine=engine, db=db)
+    await db.create_session("rl-files", source="web", backend="claude")
+    await db.save_uploaded_file(
+        "img1", "rl-files", "pic.png", "image/png", "image", 10, "/tmp/pic.png",
+    )
+    await db.save_uploaded_file(
+        "doc1", "rl-files", "report.pdf", "application/pdf", "pdf", 20,
+        "/tmp/report.pdf",
+    )
+
+    await run_later(
+        RunLaterRequest(
+            session_id="rl-files",
+            message="see attached",
+            delay="none",
+            file_ids=["img1", "doc1"],
+        ),
+        user={},
+    )
+
+    msgs = await db.get_messages("rl-files")
+    blocks = msgs[0]["blocks"]
+    kinds = [(b["type"], b.get("filename")) for b in blocks]
+    assert ("text", None) in kinds
+    assert ("image", "pic.png") in kinds
+    # The ordinary (non-image) file must survive as a "file" block.
+    assert ("file", "report.pdf") in kinds
+
+
+@pytest.mark.asyncio
+async def test_run_later_unknown_session_404(db: Database):
+    from fastapi import HTTPException
+
+    init_deps(engine=_fake_engine(), db=db)
+    with pytest.raises(HTTPException) as exc:
+        await run_later(
+            RunLaterRequest(session_id="missing", message="x", delay="1h"),
+            user={},
+        )
+    assert exc.value.status_code == 404

--- a/tests/test_wakeups.py
+++ b/tests/test_wakeups.py
@@ -167,6 +167,23 @@ class TestWakeupSweep:
         assert await svc.db.list_pending_wakeups("s1") == []
 
     @pytest.mark.asyncio
+    async def test_run_later_wakeup_fires_with_cron_source(self, svc):
+        # A deferred "Run later" wakeup must dispatch through the cron
+        # source (mirroring plan_service/cron dispatch), not "wakeup".
+        await svc.db.add_wakeup(
+            "s1", prompt="deferred prompt", fire_at=_past(), reason="run-later",
+        )
+
+        await svc._sweep_wakeups()
+        await asyncio.sleep(0.05)
+
+        svc.engine.run.assert_awaited_once()
+        kwargs = svc.engine.run.await_args.kwargs
+        assert kwargs["source"] == "cron"
+        assert kwargs["user_message"] == "deferred prompt"
+        assert kwargs["internal"] is True
+
+    @pytest.mark.asyncio
     async def test_skips_running_session(self, svc):
         svc.engine.sessions.is_running = MagicMock(return_value=True)
         await svc.db.add_wakeup("s1", prompt="ping", fire_at=_past())

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -350,6 +350,29 @@ export const api = {
         ...(reviewLoop ? { review_loop: reviewLoop } : {}),
       }),
     }),
+  // Run later — defer a composed prompt into a (freshly created) session
+  // without spending tokens now. Persists the prompt as the pending user
+  // message + a synthetic ack; timed delays schedule a one-shot wakeup.
+  runLater: (
+    sessionId: string,
+    message: string,
+    delay: string,
+    fileIds?: string[],
+    imageBlocks?: Array<{ url: string; filename: string; media_type: string }>,
+  ) =>
+    request<{ session_id: string; scheduled: boolean; ack: string; fire_at: string | null }>(
+      '/sessions/run-later',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          session_id: sessionId,
+          message,
+          delay,
+          ...(fileIds && fileIds.length ? { file_ids: fileIds } : {}),
+          ...(imageBlocks && imageBlocks.length ? { image_blocks: imageBlocks } : {}),
+        }),
+      },
+    ),
   listReviewLoops: (status?: string) =>
     request<{ loops: ReviewLoop[] }>(`/review-loops${status ? `?status=${status}` : ''}`),
   getReviewLoop: (loopId: string) =>

--- a/web/src/components/Chat/ChatInput.tsx
+++ b/web/src/components/Chat/ChatInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useLayoutEffect, useCallback, type KeyboardEvent, type ClipboardEvent, type DragEvent } from 'react';
-import { Send, Square, X, Plus, Trash2, Sparkles, HelpCircle, StickyNote, Paperclip, FileText, Loader2, Repeat } from 'lucide-react';
+import { Send, Square, X, Plus, Trash2, Sparkles, HelpCircle, StickyNote, Paperclip, FileText, Loader2, Repeat, MoreHorizontal, Clock, ChevronRight } from 'lucide-react';
 import { useChatStore, EMPTY_REVIEW_LOOP } from '../../stores/chatStore';
 import type { QuoteAction, QuoteEntry } from '../../stores/chatStore';
 import { api } from '../../api/client';
@@ -18,6 +18,16 @@ const ACTION_CONFIG: Record<QuoteAction, { icon: typeof Plus; label: string; col
 
 // Actions that auto-focus the instruction input (need user input)
 const FOCUS_ACTIONS = new Set<QuoteAction>(['add', 'question', 'note']);
+
+// "Run later" submenu — exactly these four, in this order. The three timed
+// delays schedule a one-shot wakeup; "none" ("Just accept it") saves the
+// prompt for the user to run manually.
+const RUN_LATER_OPTIONS: Array<{ delay: string; label: string }> = [
+  { delay: '30m', label: 'Run in 30 mins' },
+  { delay: '1h', label: 'Run in 1 hour' },
+  { delay: '24h', label: 'Run in 24 hours' },
+  { delay: 'none', label: 'Just accept it' },
+];
 
 // Prompt rewrite — refine the first message of a new chat before sending.
 const REWRITE_PREF_KEY = 'nerve_prompt_rewrite';
@@ -49,6 +59,10 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
   const [input, setInput] = useState('');
   const [attachments, setAttachments] = useState<AttachmentFile[]>([]);
   const [isDragging, setIsDragging] = useState(false);
+  // "Run later" kebab menu (mirrors the SessionSidebar three-dots menu).
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [runLaterOpen, setRunLaterOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lastInstructionRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -65,6 +79,7 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
   const setDraft = useChatStore(s => s.setDraft);
   const activeSession = useChatStore(s => s.activeSession);
   const ensureRealSession = useChatStore(s => s.ensureRealSession);
+  const runLater = useChatStore(s => s.runLater);
   const isNewChat = useChatStore(s => s.messages.length === 0);
 
   // Persist the composer draft, but NOT on every keystroke. Writing to the
@@ -364,6 +379,51 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
     }
 
     dispatchSend(message);
+  };
+
+  // Close the kebab menu on an outside click (mirrors SessionSidebar).
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+        setRunLaterOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [menuOpen]);
+
+  /** Defer the composed message via a chosen "Run later" option, then clear
+   *  the composer exactly as a normal send does. */
+  const handleRunLater = (delay: string) => {
+    const message = composeMessage();
+    if (!message && attachments.length === 0) return;
+    const fileIds = attachments.filter(a => a.uploadedId).map(a => a.uploadedId!);
+    const imageBlocks = attachments
+      .filter(a => a.uploadedId && a.uploadedMeta?.file_type === 'image')
+      .map(a => ({
+        url: `/api/files/uploads/${a.uploadedId}`,
+        filename: a.uploadedMeta!.filename,
+        media_type: a.uploadedMeta!.media_type,
+      }));
+    setMenuOpen(false);
+    setRunLaterOpen(false);
+    // Fire the deferred create, then clear the composer synchronously — same
+    // ordering as dispatchSend so the carried draft ends up empty.
+    void runLater(
+      message, delay,
+      fileIds.length > 0 ? fileIds : undefined,
+      imageBlocks.length > 0 ? imageBlocks : undefined,
+    ).catch((e) => console.error('Run later failed:', e));
+    cancelDraftFlush();
+    setInput('');
+    historyIndexRef.current = -1;
+    historyStashRef.current = '';
+    setDraft(activeSession, '');
+    clearQuotes();
+    attachments.forEach(a => { if (a.preview) URL.revokeObjectURL(a.preview); });
+    setAttachments([]);
   };
 
   // Previously-sent user prompts of this chat, newest first (adjacent dupes dropped).
@@ -706,6 +766,45 @@ export function ChatInput({ onSend, onStop, isStreaming, disabled }: {
             // above them. Both are undone at `md`, back to a single row.
             className="flex-1 basis-full order-1 md:basis-0 md:order-none px-4 py-3 bg-surface-raised border border-border rounded-xl text-[15px] text-text outline-none focus:border-accent/50 resize-none disabled:opacity-50 placeholder:text-text-faint"
           />
+          {/* Run-later kebab — three-dots menu next to Send. Its submenu
+              defers the composed prompt into a new session without spending
+              tokens now (opens upward; the composer sits at the bottom). */}
+          <div className="relative shrink-0 order-2 md:order-none" ref={menuRef}>
+            <button
+              onClick={() => { setMenuOpen(v => !v); setRunLaterOpen(false); }}
+              disabled={disabled || isStreaming || rewriteActive}
+              className="w-10 h-10 text-text-muted hover:text-text-secondary rounded-xl flex items-center justify-center cursor-pointer transition-colors shrink-0 disabled:opacity-30"
+              title="More options"
+            >
+              <MoreHorizontal size={18} />
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 bottom-full mb-1 z-50 bg-surface-raised border border-border-subtle rounded-lg shadow-xl py-1 min-w-[170px]">
+                <button
+                  onClick={() => setRunLaterOpen(v => !v)}
+                  className="flex items-center justify-between gap-2.5 w-full px-3 py-1.5 text-[13px] text-text-secondary hover:bg-border-subtle cursor-pointer transition-colors"
+                >
+                  <span className="flex items-center gap-2.5"><Clock size={14} /> Run later</span>
+                  <ChevronRight size={14} className={`transition-transform ${runLaterOpen ? 'rotate-90' : ''}`} />
+                </button>
+                {runLaterOpen && (
+                  <div className="border-t border-border mt-1 pt-1">
+                    {RUN_LATER_OPTIONS.map(opt => (
+                      <button
+                        key={opt.delay}
+                        onClick={() => handleRunLater(opt.delay)}
+                        disabled={!canSend}
+                        className="w-full text-left px-3 py-1.5 pl-8 text-[13px] text-text-secondary hover:bg-border-subtle cursor-pointer transition-colors disabled:opacity-30"
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
           {isStreaming ? (
             <button
               onClick={onStop}

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -220,6 +220,14 @@ interface ChatState {
   /** Trigger the sidebar to mount + focus the search input (used by Cmd+K). */
   requestSearchFocus: () => void;
   sendMessage: (content: string) => void;
+  /** Defer a composed prompt into a new session without running the model
+   *  now. ``delay`` is one of "30m" | "1h" | "24h" | "none". */
+  runLater: (
+    content: string,
+    delay: string,
+    fileIds?: string[],
+    imageBlocks?: Array<{ url: string; filename: string; media_type: string }>,
+  ) => Promise<void>;
   /** Fetch selectable models for the composer picker (GET /api/models). */
   loadModels: () => Promise<void>;
   setNewChatBackend: (backend: string | null) => void;
@@ -933,6 +941,60 @@ export const useChatStore = create<ChatState>((set, get) => ({
         agentStatus: { state: 'idle' },
       }));
     }
+  },
+
+  runLater: async (content, delay, fileIds, imageBlocks) => {
+    // Build the optimistic block list once (pending user message shape).
+    const buildBlocks = (): import('../types/chat').MessageBlock[] => {
+      const blocks: import('../types/chat').MessageBlock[] = [];
+      if (content) blocks.push({ type: 'text', content });
+      if (imageBlocks) {
+        for (const img of imageBlocks) {
+          blocks.push({ type: 'image', url: img.url, filename: img.filename, media_type: img.media_type });
+        }
+      }
+      return blocks;
+    };
+    // Run later ALWAYS mints a brand-new session — it must never write the
+    // deferred prompt into the current chat (fresh, virtual, or existing).
+    // If a composer model/backend pick is in flight for a new chat, carry it
+    // onto the created row so the header badge is right from the first render.
+    const vs = get().virtualSession;
+    const effBackend = get().newChatBackend ?? null;
+    const pickedModel = effBackend
+      ? (get().newChatModels[effBackend] ?? null)
+      : null;
+    const real: Session = await api.createSession(
+      undefined, effBackend, undefined, null, pickedModel,
+    );
+    const res = await api.runLater(real.id, content, delay, fileIds, imageBlocks);
+    const now = new Date().toISOString();
+    set((state) => {
+      // Drop the transient new-chat state so we don't strand an empty virtual
+      // chat or leak its draft/model picks into the next new chat.
+      const drafts = { ...state.drafts };
+      if (vs) delete drafts[vs.id];
+      return {
+        sessions: [
+          { ...real, title: 'New chat', is_running: false, updated_at: now },
+          ...state.sessions,
+        ],
+        activeSession: real.id,
+        virtualSession: null,
+        newChatBackend: null,
+        newChatModels: {},
+        newChatReviewLoop: null,
+        drafts,
+        streamingBlocks: [],
+        isStreaming: false,
+        agentStatus: { state: 'idle' as const },
+        messages: [
+          { role: 'user' as const, blocks: buildBlocks(), created_at: now },
+          { role: 'assistant' as const, blocks: [{ type: 'text', content: res.ack }], created_at: now },
+        ],
+      };
+    });
+    if (vs) clearVirtualSession();
   },
 
   stopSession: () => {


### PR DESCRIPTION
Problems to be solved:
Sometimes you want to queue a follow-up prompt for an actively running session, but you don't want to disturb it - this new feature allows you to send this new prompt for a new or an existing session (it'll be reliably registered and stored), but its actual execution will be scheduled for some later time.

Changes:
- Adds a three-dots menu next to Send whose "Run later" entry opens a submenu with "Run in 30 mins", "Run in 1 hour", "Run in 24 hours", and "Just accept it".
- Selecting any option creates a new session seeded with the composed prompt (and any attachments) and clears the composer, exactly like sending.
- Creation triggers no LLM turn, so a deferred prompt costs zero tokens until it actually runs.
- The three timed options schedule a one-shot wakeup that runs the stored prompt after the chosen delay via the existing cron/wakeup mechanism.
- "Just accept it" persists the session with no wakeup, leaving you to run it manually whenever ready.
- A synthetic assistant acknowledgment is written into the new session so it shows a clear "scheduled / saved" state.
- Adds backend tests covering the timed-schedule and accept-only paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
