### PR TITLE
Sessions: archive a session make all its children to get archived as well

### DIFF
--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -684,6 +684,75 @@ class SessionManager:
         await self.db.log_session_event(session_id, "archived", {})
         logger.info("Archived session %s", session_id)
 
+    async def _resolve_descendants(self, root_id: str) -> list[str]:
+        """Every session in ``root_id``'s subtree, discovery order (root first).
+
+        Walks children via ``parent_session_id`` breadth-first with a seen-set
+        cycle guard (same pattern as the drag-to-nest guard) so a malformed
+        parent loop still terminates. Because a parent is always discovered
+        before its children, reversing this list yields a bottom-up order.
+        """
+        order: list[str] = []
+        seen: set[str] = set()
+        queue: list[str] = [root_id]
+        while queue:
+            cur = queue.pop(0)
+            if cur in seen:
+                continue
+            seen.add(cur)
+            order.append(cur)
+            for child in await self.db.list_child_sessions(cur):
+                cid = child.get("id")
+                if cid and cid not in seen:
+                    queue.append(cid)
+        return order
+
+    async def archive_session_cascade(self, session_id: str) -> dict:
+        """Archive a session and its ENTIRE descendant subtree, bottom-up.
+
+        The default archive behavior. Resolves the full descendant set up front,
+        then archives deepest-first so no archived session is ever briefly left
+        with a still-active descendant. Fault tolerant: a node that cannot be
+        archived (e.g. currently running) is skipped, and its un-archived
+        ancestors are left alone — never producing an archived parent over an
+        active child. Fully-archivable sibling subtrees still complete.
+
+        Returns ``{"archived": [ids], "skipped": [{"id", "reason"}]}``.
+        """
+        # Compute the whole subtree BEFORE mutating anything.
+        order = await self._resolve_descendants(session_id)
+        children_of: dict[str, list[str]] = {sid: [] for sid in order}
+        # Build parent->children within the resolved set.
+        subtree = set(order)
+        for sid in order:
+            for child in await self.db.list_child_sessions(sid):
+                cid = child.get("id")
+                if cid in subtree:
+                    children_of[sid].append(cid)
+
+        archived: list[str] = []
+        skipped: dict[str, str] = {}
+        # Bottom-up: children precede parents in the reversed discovery order.
+        for sid in reversed(order):
+            # Refuse to archive over a descendant that did not archive.
+            blocking = [c for c in children_of.get(sid, []) if c not in archived]
+            if blocking:
+                skipped[sid] = f"descendant(s) not archived: {', '.join(blocking)}"
+                continue
+            if self.is_running(sid):
+                skipped[sid] = "session is running"
+                continue
+            try:
+                await self.archive_session(sid)
+                archived.append(sid)
+            except Exception as e:  # keep going; sibling subtrees still complete
+                logger.warning("Cascade archive failed for %s: %s", sid, e)
+                skipped[sid] = str(e)
+        return {
+            "archived": archived,
+            "skipped": [{"id": sid, "reason": reason} for sid, reason in skipped.items()],
+        }
+
     async def unarchive_session(self, session_id: str) -> None:
         """Restore an archived session to ``idle`` so it's resumable again."""
         session = await self.db.get_session(session_id)

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -661,12 +661,15 @@ class SessionManager:
 
     async def archive_session(self, session_id: str) -> None:
         """Archive a session: memorize, disconnect client, update status."""
-        # Memorize before losing the context
+        # Memorize in the background: memU indexing can take ~90s; awaiting it
+        # here would hang the archive (and, in a cascade, the whole request on the root).
         if self._on_memorize:
-            try:
-                await self._on_memorize(session_id)
-            except Exception as e:
-                logger.warning("Memorize before archive failed for %s: %s", session_id, e)
+            async def _memorize_bg(sid: str = session_id) -> None:
+                try:
+                    await self._on_memorize(sid)
+                except Exception as e:
+                    logger.warning("Background memorize for %s failed: %s", sid, e)
+            asyncio.create_task(_memorize_bg())
 
         client = self.remove_client(session_id)
         if client:

--- a/nerve/db/sessions.py
+++ b/nerve/db/sessions.py
@@ -411,6 +411,18 @@ class SessionStore:
         ) as cursor:
             return [dict(row) async for row in cursor]
 
+    async def list_child_sessions(self, parent_id: str) -> list[dict]:
+        """Direct children of ``parent_id`` (the sidebar nesting relationship).
+
+        Returns full rows regardless of status so an archive cascade sees the
+        whole subtree; callers walk this recursively to resolve descendants.
+        """
+        async with self.db.execute(
+            "SELECT * FROM sessions WHERE parent_session_id = ?",
+            (parent_id,),
+        ) as cursor:
+            return [dict(row) async for row in cursor]
+
     async def get_stale_sessions(
         self, before_iso: str, exclude_ids: list[str] | None = None,
     ) -> list[dict]:

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -561,10 +561,20 @@ async def resume_session(session_id: str, user: dict = Depends(require_auth)):
 
 @router.post("/api/sessions/{session_id}/archive")
 async def archive_session(session_id: str, user: dict = Depends(require_auth)):
-    """Archive a session (soft delete)."""
+    """Archive a session and its entire descendant subtree (soft delete).
+
+    Cascade is the default: children, grandchildren and deeper are archived
+    bottom-up. Returns a structured report of which session ids were archived
+    vs skipped (with reasons) so a still-running descendant never silently
+    leaves an archived-parent-with-active-child orphan.
+    """
     deps = get_deps()
-    await deps.engine.sessions.archive_session(session_id)
-    return {"archived": True}
+    result = await deps.engine.sessions.archive_session_cascade(session_id)
+    return {
+        "archived": True,
+        "archived_ids": result["archived"],
+        "skipped": result["skipped"],
+    }
 
 
 @router.post("/api/sessions/{session_id}/unarchive")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -975,6 +975,86 @@ class TestUnarchiveRoute:
         assert any(e["event_type"] == "unarchived" for e in events)
 
 
+@pytest.mark.asyncio
+class TestArchiveCascade:
+    """Archiving a session cascades to its whole descendant subtree."""
+
+    async def _tree(self, db: Database):
+        """Build root -> {a -> a1, b} (a1 is a grandchild)."""
+        await db.create_session("root", source="web")
+        await db.create_session("a", source="web", parent_session_id="root")
+        await db.create_session("b", source="web", parent_session_id="root")
+        await db.create_session("a1", source="web", parent_session_id="a")
+
+    async def _status(self, db: Database, sid: str) -> str:
+        return (await db.get_session(sid))["status"]
+
+    async def test_multilevel_tree_archived_wholesale(
+        self, sm: SessionManager, db: Database,
+    ):
+        await self._tree(db)
+        result = await sm.archive_session_cascade("root")
+
+        # Every node in the subtree is archived.
+        for sid in ("root", "a", "b", "a1"):
+            assert await self._status(db, sid) == SessionStatus.ARCHIVED.value
+        assert set(result["archived"]) == {"root", "a", "b", "a1"}
+        assert result["skipped"] == []
+
+    async def test_bottom_up_order_children_before_parents(
+        self, sm: SessionManager, db: Database,
+    ):
+        await self._tree(db)
+        result = await sm.archive_session_cascade("root")
+        order = result["archived"]
+        # Deepest descendants archived before their ancestors; target last.
+        assert order.index("a1") < order.index("a")
+        assert order.index("a") < order.index("root")
+        assert order.index("b") < order.index("root")
+        assert order[-1] == "root"
+
+    async def test_partial_failure_no_orphaned_archived_parent(
+        self, sm: SessionManager, db: Database,
+    ):
+        """A running grandchild blocks itself AND its un-archived ancestors,
+        while the fully-archivable sibling subtree still completes."""
+        await self._tree(db)
+        sm.mark_running("a1")  # deepest node cannot be archived
+
+        result = await sm.archive_session_cascade("root")
+
+        # a1 running -> skipped; its ancestors a and root left active (no orphan).
+        assert await self._status(db, "a1") != SessionStatus.ARCHIVED.value
+        assert await self._status(db, "a") != SessionStatus.ARCHIVED.value
+        assert await self._status(db, "root") != SessionStatus.ARCHIVED.value
+        # Sibling subtree b has no blocked descendant -> still archived.
+        assert await self._status(db, "b") == SessionStatus.ARCHIVED.value
+
+        assert "b" in result["archived"]
+        assert {"root", "a", "a1"}.isdisjoint(result["archived"])
+        skipped_ids = {s["id"] for s in result["skipped"]}
+        assert {"root", "a", "a1"} == skipped_ids
+        # No archived session retains an active (non-archived) descendant.
+        for sid in result["archived"]:
+            for child in await db.list_child_sessions(sid):
+                assert child["status"] == SessionStatus.ARCHIVED.value
+
+    async def test_cycle_guard_terminates(self, sm: SessionManager, db: Database):
+        """A malformed parent cycle must not hang the descendant walk.
+
+        The seen-set guarantees termination; every node is accounted for in
+        the structured result (archived or skipped), and the call returns.
+        """
+        await db.create_session("c1", source="web")
+        await db.create_session("c2", source="web", parent_session_id="c1")
+        # Force a cycle: c1's parent points back at its own child c2.
+        await db.update_session_fields("c1", {"parent_session_id": "c2"})
+
+        result = await asyncio.wait_for(sm.archive_session_cascade("c1"), timeout=5)
+        accounted = set(result["archived"]) | {s["id"] for s in result["skipped"]}
+        assert {"c1", "c2"} == accounted
+
+
 class MockClient:
     """Mock SDK client for testing."""
 

--- a/web/src/stores/chatStore.ts
+++ b/web/src/stores/chatStore.ts
@@ -826,10 +826,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
       await api.archiveSession(id);
       removeDraft(id);
       set(s => { const drafts = { ...s.drafts }; delete drafts[id]; return { drafts }; });
+      // Archiving cascades to the whole descendant subtree server-side, so
+      // loadSessions() drops the parent AND its children from the active feed.
       await get().loadSessions();
-      if (get().activeSession === id) {
-        // Switch to most recent remaining session
-        const remaining = get().sessions.filter(s => s.id !== id);
+      // The active chat may have been the target OR a now-archived descendant;
+      // switch away whenever it's no longer in the active list.
+      const active = get().activeSession;
+      const stillActive = get().sessions.some(s => s.id === active);
+      if (active && !stillActive) {
+        const remaining = get().sessions;
         if (remaining.length > 0) {
           await get().switchSession(remaining[0].id);
         }


### PR DESCRIPTION
Problem to be solved:
Archiving a session left its child sessions (and deeper descendants) behind as active orphans instead of archiving the whole tree together.

Changes:
- Archiving a session now cascades to its entire descendant subtree by default, resolved recursively via `parent_session_id` with a cycle guard.
- The cascade runs bottom-up (deepest first, target last) so a partial failure never leaves an archived session above a still-active descendant.
- It is fault-tolerant: the full set is computed up front, un-archivable nodes (e.g. currently running) and their un-archived ancestors are skipped, and the endpoint returns a structured archived-vs-skipped report.
- The sidebar reflects the cascade, so archiving a parent removes its whole subtree from the active feed.
- Memorization on archive now runs in the background, so memU indexing (which can take ~90s) no longer blocks the request — previously it hung the cascade on the root while the children had already disappeared.
- Adds tests for wholesale multi-level archiving and the partial-failure / no-orphan case.

Stacked on #312 (→ #309 → #305 → #269); those merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
