### PR TITLE
Cap mcp below 2.0 so fresh installs start

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,16 @@ dependencies = [
     "pyyaml>=6.0",
     "python-telegram-bot>=21.0",
     "claude-agent-sdk>=0.2.82",
+    # Declared explicitly because nerve/mcp_server/ imports `mcp` directly
+    # rather than only through claude-agent-sdk. The upper bound is load-bearing:
+    # mcp 2.0.0 dropped the module-level `request_ctx` contextvar from
+    # mcp.server.lowlevel.server, which nerve/mcp_server/http.py imports at
+    # module scope, so an unbounded resolve breaks startup on every fresh
+    # install. claude-agent-sdk itself allows `mcp<3`, so nothing else in the
+    # tree caps it — this is the only place the bound can live. Lift it once
+    # nerve/mcp_server/ is ported to the 2.x request-context API.
+    # Floor mirrors claude-agent-sdk's own `mcp>=1.23.0`.
+    "mcp>=1.23,<2",
     "apscheduler>=3.11.0",
     "pyjwt>=2.10.0",
     "bcrypt>=4.2.0",


### PR DESCRIPTION
Fixes #316.

## What

Declares `mcp` explicitly in `pyproject.toml` with an upper bound: `mcp>=1.23,<2`.
One dependency line plus the comment explaining why the bound exists and when to
lift it. Nothing else changes.

## Why

`mcp` 2.0.0 removed the module-level `request_ctx` contextvar from
`mcp.server.lowlevel.server`. `nerve/mcp_server/http.py` imports it at module
scope (line 32, used in `_resolve_client_info` and
`_bound_identity_from_request`), so a fresh install dies at startup with the
`ImportError` in the issue.

`mcp` was never declared in `pyproject.toml` — it arrived transitively through
`claude-agent-sdk`, whose constraint is `mcp<3.0.0,>=1.23.0`. Nothing else in
the tree caps it, so once 2.0.0 landed on PyPI (2026-07-28, four minutes after
1.29.0) every fresh resolve picked it up.

Declaring it explicitly is also the right hygiene independent of this bug: three
modules under `nerve/mcp_server/` import `mcp` directly, and an upper bound on an
otherwise-transitive dependency can only be expressed by declaring it. The floor
mirrors `claude-agent-sdk`'s own `>=1.23.0`, so nothing is narrowed except the
top end.

### Why CI never caught it

`.github/workflows/ci.yml` keys its uv cache on `pyproject.toml`
(`cache-dependency-glob`). The restored cache carried stale index metadata, so
runs kept resolving the old version — [run 32061993270](https://github.com/ClickHouse/nerve/actions/runs/32061993270)
(main, 2026-08-17, green) installed `mcp==1.29.0` three weeks after 2.0.0 shipped.
CI was green on stale metadata while every genuinely fresh install broke.

Usefully, touching `pyproject.toml` changes that cache key — so this PR's own run
performs a real resolve rather than restoring the stale one.

That blind spot is worth closing separately (dependency drift stays invisible
until `pyproject.toml` happens to change), but it's a CI-config change and not
this PR's job.

## Testing

Verified both directions in a throwaway Python 3.13 venv, resolving with
`--refresh` so no stale index metadata could mask the result.

**With the bound** — resolves `mcp==1.29.0`, the newest 1.x:

- [x] `uv pip install -e ".[test]" --refresh` → `mcp==1.29.0` (and no longer pulls the 2.x-only `mcp-types`)
- [x] `from mcp.server.lowlevel.server import request_ctx` → OK
- [x] `import nerve.gateway.server` (the `nerve start` path) → OK
- [x] `pytest tests/ -q` → **3303 passed** in 107s

**Negative control**, forcing `mcp==2.0.0` into the same venv to confirm the
bound is load-bearing rather than cosmetic:

- [x] `import nerve.mcp_server.http` → reproduces the issue's `ImportError` exactly
- [x] `import nerve.gateway.server` → same `ImportError`, i.e. startup is what breaks
- [x] `pytest tests/ --co` → 8 collection errors (`test_mcp_loopback`, `test_mcp_session_binding`, `test_satellite_sessions`, `test_server_periodic_loops`, …)

Frontend is untouched by a Python dependency change, so `npm run build` was not
run locally; CI covers it.

## Follow-up

This is a stopgap. `claude-agent-sdk` already allows `mcp<3`, so the real work is
porting `nerve/mcp_server/` from `request_ctx` to the 2.x request-context API
(2.0 keeps a `ServerRequestContext` class but no module-level contextvar). The
comment on the pin says as much so the bound doesn't quietly become permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)