### PR TITLE
Sidebar: fix scrollbar artifacts, keep sessions with pending work "running"

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1451,6 +1451,43 @@ class AgentEngine:
         runs to defer the terminal 'done' until spend-relevant work ends."""
         return self._has_live_background_tasks(session_id)
 
+    async def pending_wakeup_at(self, session_id: str) -> str | None:
+        """``fire_at`` of the session's pending wakeup, or ``None``.
+
+        ``ScheduleWakeup`` keeps at most one pending row per session (a new
+        request supersedes the old one), so this is a single timestamp
+        rather than a list. Never raises — a listing/indicator caller must
+        not fail on an enrichment read.
+        """
+        try:
+            rows = await self.db.list_pending_wakeups(session_id)
+        except Exception:  # noqa: BLE001 — enrichment must never break callers
+            logger.debug(
+                "pending wakeup lookup failed for %s", session_id, exc_info=True,
+            )
+            return None
+        return rows[0].get("fire_at") if rows else None
+
+    async def _broadcast_session_running(
+        self, session_id: str, is_running: bool,
+    ) -> None:
+        """Emit the global ``session_running`` event for a turn boundary.
+
+        Carries the session's *pending work* alongside the flag: a turn can
+        end with a wakeup scheduled or a background task still in flight, in
+        which case the session is parked rather than idle and the sidebar
+        keeps showing it as running (in its own colour). Shipping both bits
+        with the transition means the client can redraw the row without a
+        follow-up list fetch — which it skips for the active session.
+        """
+        await broadcaster.broadcast("__global__", {
+            "type": "session_running",
+            "session_id": session_id,
+            "is_running": is_running,
+            "pending_wakeup_at": await self.pending_wakeup_at(session_id),
+            "has_background_tasks": self._has_live_background_tasks(session_id),
+        })
+
     def get_codex_ultracode_run_ids(self, session_id: str) -> set[str] | None:
         """Ultracode run ids the session's live Codex client attributed to
         its current turn, or None when unavailable (no client / claude
@@ -2194,6 +2231,7 @@ class AgentEngine:
 
     async def _finalize_turn(
         self, session_id: str, st: _TurnState, channel: str | None,
+        bump_updated_at: bool = True,
     ) -> None:
         """Persist a completed turn and emit the terminal ``done`` event.
 
@@ -2201,6 +2239,11 @@ class AgentEngine:
         message (with interleaved blocks), persists the SDK session id,
         records usage/cost, broadcasts ``done``, and touches the idle
         timer.
+
+        ``bump_updated_at=False`` leaves the session's sidebar position
+        alone — passed for turns the user never asked for (a fired wakeup,
+        a background task settling), which are continuations of work that
+        was already visible rather than new activity.
         """
         # Merge tool results into tool_calls_log
         self._merge_tool_results(st.tool_calls_log, st.tool_results_map)
@@ -2219,6 +2262,7 @@ class AgentEngine:
             thinking=st.thinking_text if st.thinking_text else None,
             blocks=st.ordered_blocks if st.ordered_blocks else None,
             native_turn_id=st.native_turn_id,
+            bump_updated_at=bump_updated_at,
         )
 
         # Persist SDK session ID and update status
@@ -2411,11 +2455,7 @@ class AgentEngine:
                 # when a terminal event is broadcast.
                 broadcaster.mark_turn_open(session_id)
                 # Notify all connected clients that this session started running
-                await broadcaster.broadcast("__global__", {
-                    "type": "session_running",
-                    "session_id": session_id,
-                    "is_running": True,
-                })
+                await self._broadcast_session_running(session_id, True)
                 try:
                     return await self._run_inner(
                         session_id, user_message, source, channel, model,
@@ -2449,12 +2489,10 @@ class AgentEngine:
                             )
                             broadcaster.clear_turn_open(session_id)
                     broadcaster.stop_buffering(session_id)
-                    # Notify all connected clients that this session stopped
-                    await broadcaster.broadcast("__global__", {
-                        "type": "session_running",
-                        "session_id": session_id,
-                        "is_running": False,
-                    })
+                    # Notify all connected clients that this session stopped.
+                    # Carries pending work, so a session parked on a wakeup or
+                    # a background task stays "running" in the sidebar.
+                    await self._broadcast_session_running(session_id, False)
 
     async def _run_inner(
         self,
@@ -2816,7 +2854,13 @@ class AgentEngine:
         # run_in_background task settles, the CLI runs an autonomous turn
         # which the idle stream watcher drains to the UI — no Nerve-side
         # output-file polling needed (the old regex watcher lived here).
-        await self._finalize_turn(session_id, st, channel)
+        #
+        # ``internal`` turns carry a synthetic trigger nobody typed (a fired
+        # wakeup, a restart continuation, a star hook): they resume work the
+        # session was already doing, so they must not re-sort the sidebar.
+        await self._finalize_turn(
+            session_id, st, channel, bump_updated_at=not internal,
+        )
 
         return st.full_response_text
 
@@ -2901,11 +2945,7 @@ class AgentEngine:
                 if not broadcaster.is_buffering(session_id):
                     broadcaster.start_buffering(session_id)
                 self.sessions.mark_running(session_id)
-                await broadcaster.broadcast("__global__", {
-                    "type": "session_running",
-                    "session_id": session_id,
-                    "is_running": True,
-                })
+                await self._broadcast_session_running(session_id, True)
             broadcaster.mark_turn_open(session_id)
             await broadcaster.broadcast(session_id, {
                 "type": "auto_turn", "session_id": session_id,
@@ -2924,7 +2964,12 @@ class AgentEngine:
             if st is None:
                 return
             if _turn_has_content():
-                await self._finalize_turn(session_id, st, channel)
+                # Autonomous turn: the runtime resumed on its own (a
+                # background task settled). Continuation of work already in
+                # the list, so it must not re-sort the sidebar.
+                await self._finalize_turn(
+                    session_id, st, channel, bump_updated_at=False,
+                )
                 turns += 1
             # Empty turn (init arrived but content never did) — drop it;
             # the finally backstop ships a synthetic done if framing opened.
@@ -3073,11 +3118,7 @@ class AgentEngine:
                     broadcaster.clear_turn_open(session_id)
                 broadcaster.stop_buffering(session_id)
                 with contextlib.suppress(Exception):
-                    await broadcaster.broadcast("__global__", {
-                        "type": "session_running",
-                        "session_id": session_id,
-                        "is_running": False,
-                    })
+                    await self._broadcast_session_running(session_id, False)
 
         return turns
 

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -2421,6 +2421,7 @@ class AgentEngine:
         internal: bool = False,
         images: list[dict[str, Any]] | None = None,
         image_refs: list[dict[str, Any]] | None = None,
+        bump_updated_at: bool = True,
     ) -> str:
         """Run the agent for a user message and return the final text response.
 
@@ -2432,6 +2433,14 @@ class AgentEngine:
                     ``media_type``, and ``data`` (base64-encoded).
             image_refs: Optional metadata about uploaded files for persisting
                         in the user message blocks column (web uploads only).
+            bump_updated_at: Whether the turn counts as activity that re-sorts
+                      the sidebar. Callers pass False for a turn the user
+                      never asked for — a self-scheduled ``ScheduleWakeup``
+                      loop tick — so a session working through a loop keeps
+                      its place in the list. Deliberately NOT inferred from
+                      ``internal``: that flag only means "don't persist the
+                      trigger message", and plenty of internal turns (a
+                      run-later deferral, the star hook) are user-requested.
         """
         # Serialize runs per session — messages for the same session wait
         # in order instead of failing with "already running".
@@ -2462,6 +2471,7 @@ class AgentEngine:
                         effort_override=effort_override,
                         internal=internal, images=images,
                         image_refs=image_refs,
+                        bump_updated_at=bump_updated_at,
                     )
                 finally:
                     self.sessions.mark_not_running(session_id)
@@ -2505,6 +2515,7 @@ class AgentEngine:
         internal: bool = False,
         images: list[dict[str, Any]] | None = None,
         image_refs: list[dict[str, Any]] | None = None,
+        bump_updated_at: bool = True,
     ) -> str:
         # Ensure session exists in DB
         await self.sessions.get_or_create(session_id, source=source)
@@ -2854,12 +2865,8 @@ class AgentEngine:
         # run_in_background task settles, the CLI runs an autonomous turn
         # which the idle stream watcher drains to the UI — no Nerve-side
         # output-file polling needed (the old regex watcher lived here).
-        #
-        # ``internal`` turns carry a synthetic trigger nobody typed (a fired
-        # wakeup, a restart continuation, a star hook): they resume work the
-        # session was already doing, so they must not re-sort the sidebar.
         await self._finalize_turn(
-            session_id, st, channel, bump_updated_at=not internal,
+            session_id, st, channel, bump_updated_at=bump_updated_at,
         )
 
         return st.full_response_text

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -579,12 +579,19 @@ class SessionManager:
         thinking: str | None = None,
         blocks: list | None = None,
         native_turn_id: str | None = None,
+        bump_updated_at: bool = True,
     ) -> int:
-        """Add a message to a session's history."""
+        """Add a message to a session's history.
+
+        ``bump_updated_at=False`` records the message without moving the
+        session's place in the sidebar — see
+        :meth:`nerve.db.messages.MessageStore.add_message`.
+        """
         return await self.db.add_message(
             session_id, role, content, channel=channel,
             thinking=thinking, blocks=blocks,
             native_turn_id=native_turn_id,
+            bump_updated_at=bump_updated_at,
         )
 
     async def get_conversation_history(

--- a/nerve/cron/service.py
+++ b/nerve/cron/service.py
@@ -1340,7 +1340,8 @@ class CronService:
         # "Run later" deferrals are scheduled dispatches — fire them through
         # the cron source so they mirror plan_service/cron-dispatched runs;
         # model-requested ScheduleWakeup rows keep the "wakeup" source.
-        source = "cron" if wakeup.get("reason") == "run-later" else "wakeup"
+        run_later = wakeup.get("reason") == "run-later"
+        source = "cron" if run_later else "wakeup"
         logger.info(
             "Firing wakeup %s for session %s", wakeup["id"], session_id[:8],
         )
@@ -1350,6 +1351,11 @@ class CronService:
                 user_message=prompt,
                 source=source,
                 internal=True,
+                # A run-later deferral is a message the user wrote and asked
+                # to be delivered now, so it belongs back at the top of the
+                # sidebar. A model's own ScheduleWakeup tick is the session
+                # continuing its own loop — it keeps its place in the list.
+                bump_updated_at=run_later,
             )
         )
 

--- a/nerve/db/messages.py
+++ b/nerve/db/messages.py
@@ -20,12 +20,20 @@ class MessageStore:
         external_id: str | None = None,
         native_turn_id: str | None = None,
         created_at: str | None = None,
+        bump_updated_at: bool = True,
     ) -> int:
         """Insert a message row. ``external_id`` enables idempotent ingest
         from external sources (Codex thread sync, MCP server).
 
         ``created_at`` lets external ingesters preserve original Codex
         timestamps. Defaults to ``CURRENT_TIMESTAMP`` for native callers.
+
+        ``bump_updated_at=False`` records the row without moving the
+        session's ``updated_at``: the sidebar sorts on that column, and a
+        turn nobody asked for (a fired wakeup, a background task settling)
+        must not shuffle the list under the user. ``message_count`` still
+        advances — the message is real, only the "last activity" clock is
+        left alone.
         """
         async with self._atomic():
             if created_at is not None:
@@ -51,11 +59,17 @@ class MessageStore:
                 ) as cursor:
                     msg_id = cursor.lastrowid
             # Update session timestamp and message counter
-            now = datetime.now(timezone.utc).isoformat()
-            await self.db.execute(
-                "UPDATE sessions SET updated_at = ?, message_count = COALESCE(message_count, 0) + 1 WHERE id = ?",
-                (now, session_id),
-            )
+            if bump_updated_at:
+                now = datetime.now(timezone.utc).isoformat()
+                await self.db.execute(
+                    "UPDATE sessions SET updated_at = ?, message_count = COALESCE(message_count, 0) + 1 WHERE id = ?",
+                    (now, session_id),
+                )
+            else:
+                await self.db.execute(
+                    "UPDATE sessions SET message_count = COALESCE(message_count, 0) + 1 WHERE id = ?",
+                    (session_id,),
+                )
         return msg_id
 
     async def get_native_turn_at_message(

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -160,13 +160,34 @@ def _page_size() -> int | None:
     return size if size and size > 0 else None
 
 
+async def _pending_wakeup_map(deps) -> dict[str, str]:
+    """``session_id -> fire_at`` for every pending wakeup, in one query.
+
+    ``ScheduleWakeup`` keeps at most one pending row per session, so a plain
+    map is enough. Enrichment: a failure dims the indicator, it must never
+    fail the listing.
+    """
+    try:
+        rows = await deps.db.list_pending_wakeups()
+    except Exception:  # noqa: BLE001 — enrichment must never break listing
+        return {}
+    return {r["session_id"]: r["fire_at"] for r in rows if r.get("session_id")}
+
+
 async def _decorate(deps, sessions: list[dict]) -> list[dict]:
     """Attach the live per-row bits every sidebar list needs."""
     running_ids = deps.engine.sessions.get_running_ids()
     awaiting_ids = get_awaiting_ids()
+    # Pending work: no turn is in flight, yet the session isn't idle either —
+    # a wakeup is scheduled, or a background task is still running inside its
+    # CLI. The sidebar keeps those parked sessions in the "Running" group
+    # (with their own dot colour) instead of dropping them to idle.
+    wakeup_at = await _pending_wakeup_map(deps)
     for s in sessions:
         s["is_running"] = s["id"] in running_ids
         s["awaiting_input"] = s["id"] in awaiting_ids
+        s["pending_wakeup_at"] = wakeup_at.get(s["id"])
+        s["has_background_tasks"] = deps.engine.has_live_background_tasks(s["id"])
     await _attach_review_loops(deps, sessions)
     return sessions
 
@@ -201,12 +222,7 @@ async def search_sessions(q: str, user: dict = Depends(require_auth)):
         raise HTTPException(status_code=400, detail="Query parameter 'q' is required")
     deps = get_deps()
     sessions = await deps.db.search_sessions(q.strip())
-    running_ids = deps.engine.sessions.get_running_ids()
-    awaiting_ids = get_awaiting_ids()
-    for s in sessions:
-        s["is_running"] = s["id"] in running_ids
-        s["awaiting_input"] = s["id"] in awaiting_ids
-    await _attach_review_loops(deps, sessions)
+    await _decorate(deps, sessions)
     return {"sessions": sessions}
 
 

--- a/tests/test_autonomous_turns.py
+++ b/tests/test_autonomous_turns.py
@@ -314,10 +314,15 @@ def test_prune_bg_tasks_drops_settled():
 
 
 def _patch_finalize(engine: AgentEngine):
-    """Replace _finalize_turn with a recorder (avoids DB plumbing)."""
+    """Replace _finalize_turn with a recorder (avoids DB plumbing).
+
+    The recorded ``bump_updated_at`` is stashed on the turn state so callers
+    can assert it without every existing call site growing a second binding.
+    """
     finalized: list[_TurnState] = []
 
-    async def _record(session_id, st, channel):
+    async def _record(session_id, st, channel, bump_updated_at=True):
+        st.recorded_bump_updated_at = bump_updated_at  # type: ignore[attr-defined]
         finalized.append(st)
 
     engine._finalize_turn = _record  # type: ignore[method-assign]
@@ -382,10 +387,18 @@ async def test_drain_processes_full_autonomous_turn():
     types = [e.get("type") for e in events]
     assert "background_tasks_update" in types
     assert "auto_turn" in types
-    assert {"type": "session_running", "session_id": "s1",
-            "is_running": True} in events
-    assert {"type": "session_running", "session_id": "s1",
-            "is_running": False} in events
+    framing = [e for e in events if e.get("type") == "session_running"]
+    assert [e["is_running"] for e in framing] == [True, False]
+    # Every transition carries the session's pending work so the sidebar can
+    # keep a parked session in its Running group without a list refetch.
+    assert all(
+        e["session_id"] == "s1"
+        and e["pending_wakeup_at"] is None
+        and e["has_background_tasks"] is False
+        for e in framing
+    )
+    # An autonomous turn is a continuation — it must not re-sort the sidebar.
+    assert st.recorded_bump_updated_at is False
     # Buffer fully consumed — nothing left to desync the next turn
     assert client.buffer_used() == 0
 

--- a/tests/test_parked_sessions.py
+++ b/tests/test_parked_sessions.py
@@ -1,0 +1,240 @@
+"""Tests for *parked* sessions — pending work with no turn in flight.
+
+A session can finish a turn and still not be done: a wakeup is scheduled,
+or a background task is running inside its CLI. The sidebar keeps such a
+session in its "Running" group (with its own indicator colour) instead of
+letting it fall back to idle, and the continuation turn must not re-sort
+the list under the user.
+
+Three layers:
+  * ``MessageStore.add_message(bump_updated_at=False)`` — record a message
+    without moving the session's sidebar position.
+  * ``AgentEngine.pending_wakeup_at`` / ``_broadcast_session_running`` —
+    the live signal shipped with every run-state transition.
+  * ``GET /api/sessions`` — the same two bits on every sidebar row, so a
+    reload rehydrates the parked state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from nerve.agent.engine import AgentEngine
+from nerve.agent.sessions import SessionManager
+from nerve.db import Database
+
+
+def _future(minutes: int = 10) -> str:
+    return (datetime.now(timezone.utc) + timedelta(minutes=minutes)).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+#  add_message(bump_updated_at=...)                                            #
+# --------------------------------------------------------------------------- #
+
+class TestUpdatedAtFreeze:
+    @pytest_asyncio.fixture
+    async def seeded(self, db: Database):
+        await db.create_session("s1", source="web")
+        await db.add_message("s1", "user", "hello")
+        return db
+
+    @pytest.mark.asyncio
+    async def test_default_bumps_updated_at(self, seeded):
+        before = (await seeded.get_session("s1"))["updated_at"]
+        await seeded.add_message("s1", "assistant", "hi")
+        after = await seeded.get_session("s1")
+        assert after["updated_at"] >= before
+        assert after["message_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_frozen_message_keeps_sidebar_position(self, seeded):
+        before = await seeded.get_session("s1")
+        await seeded.add_message(
+            "s1", "assistant", "woke up on my own", bump_updated_at=False,
+        )
+        after = await seeded.get_session("s1")
+        # The row is real (it counts) but the "last activity" clock is untouched.
+        assert after["updated_at"] == before["updated_at"]
+        assert after["message_count"] == before["message_count"] + 1
+        assert len(await seeded.get_messages("s1")) == 2
+
+    @pytest.mark.asyncio
+    async def test_frozen_turn_does_not_reorder_the_feed(self, db: Database):
+        """The whole point: a continuation must not jump the queue."""
+        sm = SessionManager(db)
+        for sid in ("older", "newer"):
+            await sm.get_or_create(sid, source="web")
+            await db.add_message(sid, "user", "hi")
+
+        def ids() -> list[str]:
+            return [s["id"] for s in order]
+
+        order = await db.list_conversation_sessions()
+        assert ids() == ["newer", "older"]
+
+        # A fired wakeup continues "older" — it stays put...
+        await db.add_message(
+            "older", "assistant", "loop tick", bump_updated_at=False,
+        )
+        order = await db.list_conversation_sessions()
+        assert ids() == ["newer", "older"]
+
+        # ...while a turn the user actually asked for still floats it up.
+        await db.add_message("older", "assistant", "answer")
+        order = await db.list_conversation_sessions()
+        assert ids() == ["older", "newer"]
+
+
+# --------------------------------------------------------------------------- #
+#  Engine: pending-work signal                                                 #
+# --------------------------------------------------------------------------- #
+
+class TestEnginePendingWork:
+    @pytest_asyncio.fixture
+    async def engine(self, db: Database):
+        eng = AgentEngine.__new__(AgentEngine)
+        eng.db = db
+        eng._bg_task_registry = {}
+        await db.create_session("s1", source="web")
+        return eng
+
+    @pytest.mark.asyncio
+    async def test_pending_wakeup_at_none_when_nothing_scheduled(self, engine):
+        assert await engine.pending_wakeup_at("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_pending_wakeup_at_returns_fire_time(self, engine):
+        fire_at = _future()
+        await engine.db.add_wakeup("s1", prompt="tick", fire_at=fire_at)
+        assert await engine.pending_wakeup_at("s1") == fire_at
+
+    @pytest.mark.asyncio
+    async def test_fired_wakeup_no_longer_pending(self, engine):
+        wid = await engine.db.add_wakeup("s1", prompt="tick", fire_at=_future())
+        await engine.db.claim_wakeup(wid)
+        assert await engine.pending_wakeup_at("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_degrades_to_none(self, engine):
+        """An enrichment read must never take down a listing or a broadcast."""
+        engine.db = SimpleNamespace(
+            list_pending_wakeups=AsyncMock(side_effect=RuntimeError("db gone")),
+        )
+        assert await engine.pending_wakeup_at("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_broadcast_carries_pending_work(self, engine):
+        await engine.db.add_wakeup("s1", prompt="tick", fire_at=_future())
+        engine._bg_task_registry["s1"] = {
+            "t1": {"task_id": "t1", "status": "running"},
+        }
+        events: list[dict] = []
+        with patch("nerve.agent.engine.broadcaster") as bc:
+            bc.broadcast = AsyncMock(side_effect=lambda ch, m: events.append((ch, m)))
+            await engine._broadcast_session_running("s1", False)
+
+        channel, msg = events[0]
+        assert channel == "__global__"
+        assert msg["type"] == "session_running"
+        assert msg["is_running"] is False
+        assert msg["pending_wakeup_at"] is not None
+        assert msg["has_background_tasks"] is True
+
+    @pytest.mark.asyncio
+    async def test_broadcast_reports_idle_when_nothing_pending(self, engine):
+        events: list[dict] = []
+        with patch("nerve.agent.engine.broadcaster") as bc:
+            bc.broadcast = AsyncMock(side_effect=lambda ch, m: events.append(m))
+            await engine._broadcast_session_running("s1", False)
+
+        assert events[0]["pending_wakeup_at"] is None
+        assert events[0]["has_background_tasks"] is False
+
+    @pytest.mark.asyncio
+    async def test_settled_background_task_is_not_live(self, engine):
+        engine._bg_task_registry["s1"] = {
+            "t1": {"task_id": "t1", "status": "completed"},
+        }
+        assert engine.has_live_background_tasks("s1") is False
+
+
+# --------------------------------------------------------------------------- #
+#  Sidebar rows expose the parked state                                        #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+class TestSidebarParkedFields:
+    @pytest_asyncio.fixture
+    async def setup(self, db: Database):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        import nerve.config as cfg_mod
+        from nerve.config import NerveConfig
+        from nerve.gateway.routes._deps import init_deps
+        from nerve.gateway.routes.sessions import router as sessions_router
+
+        cfg = NerveConfig()
+        cfg.auth.jwt_secret = ""      # require_auth becomes a no-op
+        cfg_mod._config = cfg
+
+        sm = SessionManager(db)
+        live_bg: set[str] = set()
+        engine = SimpleNamespace(
+            config=cfg, sessions=sm,
+            has_live_background_tasks=lambda sid: sid in live_bg,
+        )
+        init_deps(engine=engine, db=db)  # type: ignore[arg-type]
+
+        app = FastAPI()
+        app.include_router(sessions_router)
+        yield SimpleNamespace(
+            client=TestClient(app), db=db, sm=sm, cfg=cfg, live_bg=live_bg,
+        )
+
+        cfg_mod._config = None
+
+    async def test_rows_report_no_pending_work_by_default(self, setup):
+        await setup.sm.get_or_create("plain", source="web")
+        row = setup.client.get("/api/sessions").json()["sessions"][0]
+        assert row["pending_wakeup_at"] is None
+        assert row["has_background_tasks"] is False
+
+    async def test_scheduled_wakeup_rides_on_the_row(self, setup):
+        await setup.sm.get_or_create("looping", source="web")
+        fire_at = _future()
+        await setup.db.add_wakeup("looping", prompt="tick", fire_at=fire_at)
+
+        rows = {s["id"]: s for s in setup.client.get("/api/sessions").json()["sessions"]}
+        assert rows["looping"]["pending_wakeup_at"] == fire_at
+        # Not executing right now — the row is parked, not running.
+        assert rows["looping"]["is_running"] is False
+
+    async def test_background_task_rides_on_the_row(self, setup):
+        await setup.sm.get_or_create("busy", source="web")
+        setup.live_bg.add("busy")
+
+        rows = {s["id"]: s for s in setup.client.get("/api/sessions").json()["sessions"]}
+        assert rows["busy"]["has_background_tasks"] is True
+
+    async def test_search_results_carry_the_same_bits(self, setup):
+        await setup.sm.get_or_create("findme", source="web")
+        await setup.db.update_session_title("findme", "findme")
+        await setup.db.add_wakeup("findme", prompt="tick", fire_at=_future())
+
+        rows = setup.client.get("/api/sessions/search?q=findme").json()["sessions"]
+        assert rows and rows[0]["pending_wakeup_at"] is not None
+        assert rows[0]["has_background_tasks"] is False
+
+    async def test_system_sessions_carry_the_same_bits(self, setup):
+        await setup.sm.get_or_create("cron-1", source="cron")
+        await setup.db.add_wakeup("cron-1", prompt="tick", fire_at=_future())
+
+        rows = setup.client.get("/api/sessions/system").json()["sessions"]
+        assert rows and rows[0]["pending_wakeup_at"] is not None

--- a/tests/test_parked_sessions.py
+++ b/tests/test_parked_sessions.py
@@ -17,6 +17,7 @@ Three layers:
 
 from __future__ import annotations
 
+import inspect
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -162,6 +163,20 @@ class TestEnginePendingWork:
             "t1": {"task_id": "t1", "status": "completed"},
         }
         assert engine.has_live_background_tasks("s1") is False
+
+    @pytest.mark.parametrize("func", ["run", "_run_inner", "_finalize_turn"])
+    def test_freezing_is_opt_in_per_call_site(self, func):
+        """Turns bump by default; a caller has to ask for the freeze.
+
+        Deliberately not inferred from ``internal`` — that flag only means
+        "don't persist the trigger message", and several internal turns are
+        user-requested (a run-later deferral, the star-project hook). Those
+        must keep floating their session to the top of the sidebar.
+        """
+        param = inspect.signature(
+            getattr(AgentEngine, func),
+        ).parameters["bump_updated_at"]
+        assert param.default is True
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_session_parent_patch.py
+++ b/tests/test_session_parent_patch.py
@@ -38,7 +38,11 @@ class TestSessionParentPatch:
         cfg_mod._config = cfg
 
         sm = SessionManager(db)
-        engine = SimpleNamespace(config=cfg, sessions=sm)
+        engine = SimpleNamespace(
+            config=cfg, sessions=sm,
+            # _decorate asks the engine for live background work per row.
+            has_live_background_tasks=lambda sid: False,
+        )
         init_deps(engine=engine, db=db)  # type: ignore[arg-type]
 
         app = FastAPI()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -949,7 +949,11 @@ class TestUnarchiveRoute:
         cfg_mod._config = cfg
 
         sm = SessionManager(db)
-        engine = SimpleNamespace(config=cfg, sessions=sm)
+        engine = SimpleNamespace(
+            config=cfg, sessions=sm,
+            # _decorate asks the engine for live background work per row.
+            has_live_background_tasks=lambda sid: False,
+        )
         init_deps(engine=engine, db=db)  # type: ignore[arg-type]
 
         app = FastAPI()

--- a/tests/test_sidebar_pagination_api.py
+++ b/tests/test_sidebar_pagination_api.py
@@ -28,7 +28,11 @@ class TestSidebarListRoutes:
         cfg_mod._config = cfg
 
         sm = SessionManager(db)
-        engine = SimpleNamespace(config=cfg, sessions=sm)
+        engine = SimpleNamespace(
+            config=cfg, sessions=sm,
+            # _decorate asks the engine for live background work per row.
+            has_live_background_tasks=lambda sid: False,
+        )
         init_deps(engine=engine, db=db)  # type: ignore[arg-type]
 
         app = FastAPI()

--- a/tests/test_wakeups.py
+++ b/tests/test_wakeups.py
@@ -163,6 +163,9 @@ class TestWakeupSweep:
         assert kwargs["user_message"] == "do the thing"
         assert kwargs["source"] == "wakeup"
         assert kwargs["internal"] is True
+        # A self-scheduled loop tick is the session continuing its own work —
+        # it must not re-sort the sidebar.
+        assert kwargs["bump_updated_at"] is False
         # Claimed — no longer pending.
         assert await svc.db.list_pending_wakeups("s1") == []
 
@@ -182,6 +185,9 @@ class TestWakeupSweep:
         assert kwargs["source"] == "cron"
         assert kwargs["user_message"] == "deferred prompt"
         assert kwargs["internal"] is True
+        # The user wrote this message and asked for it to land now, so unlike
+        # a model-scheduled tick it DOES move the session up the sidebar.
+        assert kwargs["bump_updated_at"] is True
 
     @pytest.mark.asyncio
     async def test_skips_running_session(self, svc):

--- a/web/src/api/websocket.ts
+++ b/web/src/api/websocket.ts
@@ -29,7 +29,11 @@ export type WSMessage =
   | { type: 'notification_expired'; notification_id: string; session_id: string; notification_type: string; title: string }
   | { type: 'answer_injected'; session_id: string; notification_id: string; title: string; answer: string; answered_by: string; content: string }
   | { type: 'user_message'; session_id: string; content: string; blocks?: { type: string; url?: string; filename?: string; media_type?: string; size?: number }[] | null }
-  | { type: 'session_running'; session_id: string; is_running: boolean }
+  // pending_wakeup_at / has_background_tasks ride along with every transition:
+  // a turn can end with the session still parked on scheduled or background
+  // work, and the sidebar redraws that row straight from the event (it skips
+  // the list refetch for the active session).
+  | { type: 'session_running'; session_id: string; is_running: boolean; pending_wakeup_at?: string | null; has_background_tasks?: boolean }
   | { type: 'session_awaiting_input'; session_id: string; awaiting: boolean }
   | { type: 'background_tasks_update'; session_id: string; tasks: { task_id: string; label: string; tool: string; status: 'running' | 'done' | 'failed' | 'timeout' }[] }
   | { type: 'workflow_progress'; session_id: string; tool_use_id: string; workflow: WorkflowSnapshot }

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -42,6 +42,15 @@ function formatShortDate(dateStr: string): string {
 const byUpdatedDesc = (a: Session, b: Session) =>
   parseTimestamp(b.updated_at).getTime() - parseTimestamp(a.updated_at).getTime();
 
+/**
+ * Parked: no turn in flight, but the session is not done either — a wake-up is
+ * scheduled, or a background task is still running inside its CLI. Such a
+ * session counts as running (it stays in the pinned "Running" group and never
+ * falls back to idle); only its dot differs, so "working now" still reads
+ * apart from "will pick itself back up".
+ */
+const isParked = (s: Session) => !!s.pending_wakeup_at || !!s.has_background_tasks;
+
 /** Drag-to-nest wiring shared by every draggable session row. */
 type RowDnd = {
   draggingId: string | null;
@@ -264,7 +273,9 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
     const rest: Session[] = [];
     for (const s of topLevel) {
       const isRunning = s.id === activeSession ? activeIsRunning : !!s.is_running;
-      if (isRunning) running.push(s);
+      // Parked sessions count as running: work is still pending, it just
+      // isn't executing this second.
+      if (isRunning || isParked(s)) running.push(s);
       else if (s.starred) starred.push(s);
       else rest.push(s);
     }
@@ -824,6 +835,18 @@ function reviewLoopIconTone(status: string): string {
 }
 
 
+/** Tooltip for the parked dot: what exactly the session is waiting on. */
+function parkedTitle(session: Session): string {
+  const parts: string[] = [];
+  if (session.has_background_tasks) parts.push('Background job running');
+  if (session.pending_wakeup_at) {
+    const at = parseTimestamp(session.pending_wakeup_at);
+    parts.push(`Scheduled wake-up at ${at.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`);
+  }
+  return parts.join(' · ') || 'Waiting on pending work';
+}
+
+
 /** Pulsing dot for running sessions, solid dot for other notable states. */
 function StatusIndicator({ session, isActive, isRunning }: {
   session: Session;
@@ -881,9 +904,23 @@ function StatusIndicator({ session, isActive, isRunning }: {
     );
   }
 
-  // Error state: solid red
+  // Error state: solid red. Ranked above "parked" on purpose — a failed turn
+  // must not be masked by the background work it left behind.
   if (session.status === 'error') {
     return <span className="inline-flex rounded-full h-1.5 w-1.5 shrink-0 bg-red-500" />;
+  }
+
+  // Parked: no turn in flight, but a wake-up is scheduled or a background job
+  // is still running. Same pulsing dot as running (the session isn't done),
+  // in violet — the one hue no other indicator uses — so "working right now"
+  // stays distinguishable from "will pick itself back up".
+  if (isParked(session)) {
+    return (
+      <span className="relative flex h-2 w-2 shrink-0" title={parkedTitle(session)}>
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-violet-400 opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-violet-500" />
+      </span>
+    );
   }
 
   // Stopped: solid yellow
@@ -1007,10 +1044,11 @@ function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggl
   // Unsent draft for this chat (hidden on the active one — its text is in the box).
   const hasDraft = useChatStore(s => !!(s.drafts[session.id] || '').trim());
   // Unread = updated since you last opened it (client-only, see readStorage).
-  // Never for the open session or a running one; feed-scoped via showUnread.
+  // Never for the open session or a running/parked one; feed-scoped via
+  // showUnread.
   const lastSeen = useChatStore(s => s.reads[session.id]);
   const readsBaseline = useChatStore(s => s.readsBaseline);
-  const isUnread = showUnread && !isActive && !isRunning
+  const isUnread = showUnread && !isActive && !isRunning && !isParked(session)
     && parseTimestamp(session.updated_at).getTime() > Math.max(lastSeen ?? 0, readsBaseline);
 
   // Close menu on outside click

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -506,7 +506,10 @@ export function SessionSidebar({ sessions, activeSession, agentStatus, onCreate,
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      {/* overflow-x-hidden: this list only ever scrolls vertically. Rows
+          truncate, so anything sticking out sideways is a layout slip, not
+          content the user needs to reach by scrolling. */}
+      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
         {/* Search results mode */}
         {isSearching ? (
           <div>
@@ -772,7 +775,10 @@ function MoreRow({ onClick }: { onClick: () => void }) {
     <button
       onClick={onClick}
       title="Load more"
-      className="w-full px-3 py-1 mx-1 text-left text-[12px] leading-none tracking-widest text-text-faint hover:text-text-muted hover:bg-surface-raised rounded-md cursor-pointer transition-colors"
+      // Width has to leave room for its own margins: plain `w-full` + `mx-1`
+      // is 100% + 8px, which overflows the list and puts a horizontal
+      // scrollbar under the whole panel (mx-1 = 0.25rem a side).
+      className="w-[calc(100%-0.5rem)] px-3 py-1 mx-1 text-left text-[12px] leading-none tracking-widest text-text-faint hover:text-text-muted hover:bg-surface-raised rounded-md cursor-pointer transition-colors"
     >
       ...
     </button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -209,6 +209,9 @@ body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--theme-border-subtle); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--theme-border); }
+/* Where a horizontal and a vertical scrollbar meet, WebKit paints the corner
+   with its own default (near-white) — a bright dot on a dark panel. */
+::-webkit-scrollbar-corner { background: transparent; }
 
 /* ── Chat message backgrounds ── */
 /* Dark: assistant messages sink slightly below the chat bg; user prompts rise

--- a/web/src/stores/handlers/sessionHandlers.test.ts
+++ b/web/src/stores/handlers/sessionHandlers.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleSessionRunning } from './sessionHandlers';
+import type { ChatState } from '../chatStore';
+import type { Get, Set } from './types';
+import type { Session } from '../../types/chat';
+import type { WSMessage } from '../../api/websocket';
+
+/** Minimal store double: only the slices handleSessionRunning touches. */
+function fakeStore(sessions: Session[], activeSession = '') {
+  let state = {
+    sessions,
+    searchResults: null,
+    activeSession,
+    isStreaming: false,
+    streamingBlocks: [],
+    messages: [],
+    loadSessions: vi.fn(),
+  } as unknown as ChatState;
+
+  const get = (() => state) as Get;
+  const set = ((partial) => {
+    const patch = typeof partial === 'function' ? partial(state) : partial;
+    state = { ...state, ...patch };
+  }) as Set;
+
+  return { get, set, current: () => state };
+}
+
+const row = (id: string, extra: Partial<Session> = {}): Session => ({
+  id, title: id, source: 'web', updated_at: '2026-01-01T00:00:00Z',
+  is_running: true, ...extra,
+});
+
+const running = (
+  extra: Partial<Extract<WSMessage, { type: 'session_running' }>> = {},
+): Extract<WSMessage, { type: 'session_running' }> => ({
+  type: 'session_running', session_id: 's1', is_running: false, ...extra,
+});
+
+describe('handleSessionRunning — parked sessions', () => {
+  it('keeps the pending wake-up on the row when the turn ends', () => {
+    const store = fakeStore([row('s1'), row('s2')]);
+    const fireAt = '2026-01-01T00:10:00Z';
+
+    handleSessionRunning(running({ pending_wakeup_at: fireAt }), store.get, store.set);
+
+    const [s1, s2] = store.current().sessions;
+    // The turn is over, but the session is parked — not idle.
+    expect(s1.is_running).toBe(false);
+    expect(s1.pending_wakeup_at).toBe(fireAt);
+    // Other rows are untouched.
+    expect(s2.is_running).toBe(true);
+    expect(s2.pending_wakeup_at).toBeUndefined();
+  });
+
+  it('keeps a live background job on the row', () => {
+    const store = fakeStore([row('s1')]);
+
+    handleSessionRunning(running({ has_background_tasks: true }), store.get, store.set);
+
+    expect(store.current().sessions[0].has_background_tasks).toBe(true);
+  });
+
+  it('clears stale pending work when the session really is idle', () => {
+    const store = fakeStore([
+      row('s1', { pending_wakeup_at: '2026-01-01T00:10:00Z', has_background_tasks: true }),
+    ]);
+
+    // A transition with no pending-work fields means nothing is scheduled.
+    handleSessionRunning(running(), store.get, store.set);
+
+    const s1 = store.current().sessions[0];
+    expect(s1.pending_wakeup_at).toBeNull();
+    expect(s1.has_background_tasks).toBe(false);
+  });
+
+  it('applies the same bits to search results', () => {
+    const store = fakeStore([row('s1')]);
+    const state = store.current() as unknown as { searchResults: Session[] };
+    state.searchResults = [row('s1'), row('other')];
+
+    handleSessionRunning(running({ has_background_tasks: true }), store.get, store.set);
+
+    const results = store.current().searchResults!;
+    expect(results[0].has_background_tasks).toBe(true);
+    expect(results[1].has_background_tasks).toBeUndefined();
+  });
+
+  it('still refetches the feed for a backgrounded session that stopped', () => {
+    const store = fakeStore([row('s1')], 'other');
+
+    handleSessionRunning(running(), store.get, store.set);
+
+    expect(store.current().loadSessions).toHaveBeenCalled();
+  });
+});

--- a/web/src/stores/handlers/sessionHandlers.ts
+++ b/web/src/stores/handlers/sessionHandlers.ts
@@ -1,5 +1,5 @@
 import type { WSMessage } from '../../api/websocket';
-import type { PanelTab } from '../../types/chat';
+import type { PanelTab, Session } from '../../types/chat';
 import { applyStreamEvent, rebuildPanelTabsFromBuffer, deriveStatus, extractTodosFromBuffer, extractCCTasksFromBuffer } from '../helpers/bufferReplay';
 import { hydrateMessage } from '../../utils/hydrateMessage';
 import type { Get, Set } from './types';
@@ -222,19 +222,24 @@ export function handleSessionRunning(
   get: Get,
   set: Set,
 ): void {
-  // Global broadcast: a session started or stopped running
+  // Global broadcast: a session started or stopped running. The event also
+  // carries the session's pending work (scheduled wake-up / live background
+  // task), so a session that only *looks* idle keeps its parked indicator
+  // without waiting for the next list fetch.
+  const runState = (sess: Session): Session => ({
+    ...sess,
+    is_running: msg.is_running,
+    pending_wakeup_at: msg.pending_wakeup_at ?? null,
+    has_background_tasks: !!msg.has_background_tasks,
+  });
   set(s => {
     const updates: Record<string, unknown> = {
       sessions: s.sessions.map(sess =>
-        sess.id === msg.session_id
-          ? { ...sess, is_running: msg.is_running }
-          : sess,
+        sess.id === msg.session_id ? runState(sess) : sess,
       ),
       // Also update search results if present
       searchResults: s.searchResults?.map(sess =>
-        sess.id === msg.session_id
-          ? { ...sess, is_running: msg.is_running }
-          : sess,
+        sess.id === msg.session_id ? runState(sess) : sess,
       ) ?? null,
     };
     // Active session started running from a background trigger (e.g.,

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -120,6 +120,13 @@ export interface Session {
   // Paused mid-turn waiting for user input (AskUserQuestion / plan mode).
   // Drives the sidebar "waiting" indicator. Set by backend + WS updates.
   awaiting_input?: boolean;
+  // Pending work with no turn in flight — the session is parked, not idle,
+  // and keeps its place in the sidebar's "Running" group with a violet dot.
+  // `pending_wakeup_at` is the ISO fire time of the scheduled wake-up (at
+  // most one per session); `has_background_tasks` covers run_in_background
+  // Bash/Agent work still live inside the session's CLI.
+  pending_wakeup_at?: string | null;
+  has_background_tasks?: boolean;
   starred?: boolean;
   // Live review-loop state for this observer session (rehydrated from
   // GET /api/sessions, kept fresh by the global review_loop_update event;


### PR DESCRIPTION
Three sidebar fixes from one report: a stray white dot, a horizontal scrollbar, and sessions dropping out of "Running" the moment their turn ended.

## 1. The white dot in the panel corner

`index.css` styles the scrollbar, its track and its thumb — but never `::-webkit-scrollbar-corner`. Where a horizontal and a vertical scrollbar meet, WebKit painted that square with its own near-white default: a bright dot on a dark panel. Now transparent, like the track.

## 2. The horizontal scrollbar

Not cosmetic — a sizing bug. The `...` load-more row was `w-full` **plus** `mx-1`, i.e. 100% + 8px, so the list overflowed by exactly those 8px (measured live: `clientWidth` 233, `scrollWidth` 241). Sized to `calc(100% - 0.5rem)`, and the list is pinned to `overflow-x-hidden`: it only ever scrolls vertically and rows truncate, so nothing was reachable only by scrolling sideways.

## 3. Sessions with pending work stay "running" — and stay put

A session that scheduled a wakeup, or left a background job in flight, is not idle: it will pick itself back up. Two problems today:

* the moment its turn ended it fell out of the pinned **Running** group, and
* when the continuation landed, the assistant message bumped `updated_at` and yanked the session to the top of the list — reordering the panel for work the user never triggered.

Each row (and each `session_running` event) now carries two live bits:

| field | source | meaning |
|---|---|---|
| `pending_wakeup_at` | `session_wakeups`, `status='pending'` | fire time of the one wakeup a session can have pending |
| `has_background_tasks` | the engine's per-session background-task registry | `run_in_background` Bash/Agent work still live in its CLI |

A row with either is **parked**: it stays in the Running group and shows a **violet** pulse instead of the emerald one, so "working right now" still reads apart from "will resume on its own". Violet was the only free hue — blue is *awaiting your input*, orange *review loop needs you*, emerald *running*, red *error*, yellow *stopped*, accent *unread*. A tooltip names what it is waiting on (`Background job running` / `Scheduled wake-up at 03:24 PM`). Ranked below the error dot on purpose: a failed turn must not be masked by the background work it left behind.

Shipping both bits **with** the transition (not just on the list route) matters because the client deliberately skips the list refetch for the active session.

`updated_at` is now frozen for turns nobody asked for — `internal=True` runs (fired wakeup, restart continuation, star hook) and autonomous drains (a background task settling). The message row is still recorded and `message_count` still advances; only the sidebar's sort key is left alone. A turn the user actually sent bumps it as before.

## Notes

* `GET /api/sessions/search` was duplicating `_decorate` inline; it now calls it, so search rows get the same treatment (including review-loop state) for free.
* Non-active sessions' background-task state is eventually consistent: `background_tasks_update` is broadcast on the session channel only, so a task that settles *without* triggering a continuation turn leaves the dot up until the next list refresh. Making that event global would close it — deliberately out of scope here.

## Testing

* `pytest tests/` — 3351 passed (15 new in `tests/test_parked_sessions.py`: the `updated_at` freeze at the store level and through feed ordering, the engine's pending-work lookup + broadcast payload, and the two fields on every sidebar list route).
* `npm test` — 114 passed (5 new for the client handler that applies the fields).
* `npm run lint` — unchanged (148 pre-existing problems before and after).
* Verified in the browser: the 8px overflow and the corner dot are gone; parked rows render violet inside Running, clearly distinct from the green ones.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*