### PR TITLE
Fix test_distinct_titles_keep_unsuffixed_ids failing on the 20th-29th

### DIFF
--- a/tests/test_task_id_collision.py
+++ b/tests/test_task_id_collision.py
@@ -419,9 +419,15 @@ class TestSlugCollision:
     async def test_distinct_titles_keep_unsuffixed_ids(self, db: Database, tmp_path):
         """Unchanged behaviour: no collision, no suffix."""
         ctx = _ctx(db, tmp_path)
-        first = await _create(ctx, "Rotate the staging credentials", "x")
-        second = await _create(ctx, "Backfill the audit table", "y")
+        titles = ("Rotate the staging credentials", "Backfill the audit table")
+        ids = [task_handlers._make_task_id(t, ctx) for t in titles]
+        assert len(set(ids)) == 2, f"harness: titles no longer distinct ({ids})"
 
-        assert "-2" not in first.splitlines()[0]
-        assert "-2" not in second.splitlines()[0]
-        assert len(_ids(tmp_path, "active")) == 2
+        # Assert the id is reported verbatim rather than searching the line for
+        # "-2": ids carry a date prefix, so that substring matches 2026-08-20
+        # and every other day from the 20th on. A collision suffix would put a
+        # "-2" where this expects the space before "(status: ...)".
+        for title, task_id in zip(titles, ids):
+            assert f"Task created: {task_id} " in await _create(ctx, title, "x")
+
+        assert _ids(tmp_path, "active") == sorted(ids)


### PR DESCRIPTION
`tests/test_task_id_collision.py::TestSlugCollision::test_distinct_titles_keep_unsuffixed_ids` fails on `main` today, and on 119 days a year, with nothing wrong with the code it covers.

## Why

The test means "two distinct titles get ids with no `-2` collision suffix", but it checks that by searching the response line for the substring `-2`:

```python
assert "-2" not in first.splitlines()[0]
```

Task ids are date-prefixed, so from the 20th of any month the date supplies that substring itself:

```
Task created: 2026-08-20-rotate-the-staging-credentials (status: pending)
                       ^^
```

Days 20-29 of every month — 119 days in 2026. (The 1st-19th are safe: a `-` is only ever followed by a `2` in the day field, months being 01-12.)

## Fix

Assert on the id rather than hunting for a substring: build the expected unsuffixed ids with `_make_task_id` (the helper this file already uses to pin collisions) and require each response to name its id verbatim.

```python
assert f"Task created: {task_id} " in await _create(ctx, title, "x")
```

This keeps the test's teeth — a collision suffix would put a `-2` exactly where the assertion expects the space before `(status: …)`, so `...-credentials-2 (status: …)` still fails. Verified against clean and suffixed strings across dates on both sides of the boundary, plus a harness guard that the two titles remain distinct.

## Testing

`pytest tests/` — 3336 passed, run today (2026-08-20), the exact date that breaks the current assertion.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*