### PR TITLE
feat(install): unattended installation mode

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -119,6 +119,8 @@ curl -fsSL https://raw.githubusercontent.com/ClickHouse/nerve/main/install.sh \
     bash
 ```
 
+Dependency installation adapts to the environment: as root (a plain `ubuntu:24.04` container, for example) packages are installed directly with no `sudo` needed, and on Debian and Ubuntu `DEBIAN_FRONTEND=noninteractive` is set so `tzdata` and friends cannot open a debconf prompt. As a non-root user, `sudo -n` is used, so a missing password rule fails immediately instead of waiting.
+
 The daemon is not started: unattended installs are normally followed by a service manager that owns the process (see [systemd Service](#systemd-service-optional)). Set `NERVE_START=1` to start it from the installer instead.
 
 Anything the setup wizard would ask comes from the environment. Authentication is required — set `NERVE_PROVIDER=bedrock` (IAM, no key), or `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` or `NERVE_USE_PROXY=1`. Everything else has a default. `NERVE_PASSWORD` is read once here and stored only as a bcrypt hash in `config.local.yaml`, so it does not need to stay in the environment afterwards.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -103,6 +103,40 @@ The container paths are not conventions — the generated Dockerfile sets
 `NERVE_HOME=/root/.nerve` and `NERVE_WORKSPACE=/root/nerve-workspace`
 explicitly. Point them elsewhere and the mounts must follow.
 
+## Unattended installation
+
+For cloud-init, Ansible, image builds and other places with no terminal, run the installer with `--non-interactive` (or `NERVE_NON_INTERACTIVE=1`). It implies `NERVE_YES=1`, never prompts, and finishes with `nerve init --non-interactive`, which reads its configuration from the environment.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ClickHouse/nerve/main/install.sh \
+  | NERVE_NON_INTERACTIVE=1 \
+    NERVE_INSTALL_DIR=/home/agent/nerve \
+    NERVE_MODE=worker \
+    NERVE_WORKSPACE=/home/agent/nerve-workspace \
+    NERVE_TIMEZONE=UTC \
+    NERVE_PROVIDER=bedrock \
+    NERVE_AWS_REGION=eu-central-1 \
+    bash
+```
+
+The daemon is not started: unattended installs are normally followed by a service manager that owns the process (see [systemd Service](#systemd-service-optional)). Set `NERVE_START=1` to start it from the installer instead.
+
+Anything the setup wizard would ask comes from the environment. Authentication is required — set `NERVE_PROVIDER=bedrock` (IAM, no key), or `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` or `NERVE_USE_PROXY=1`. Everything else has a default. `NERVE_PASSWORD` is read once here and stored only as a bcrypt hash in `config.local.yaml`, so it does not need to stay in the environment afterwards.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NERVE_MODE` | `personal` | `personal` or `worker` |
+| `NERVE_WORKSPACE` | `~/nerve-workspace` | Workspace directory |
+| `NERVE_TIMEZONE` | `America/New_York` | Schedule timezone |
+| `NERVE_PROVIDER` | `anthropic` | `anthropic` or `bedrock` |
+| `NERVE_AWS_REGION` | `$AWS_REGION`, else `us-east-1` | Bedrock region; sets the model geo-prefix |
+| `NERVE_PASSWORD` | unset | Web UI password; unset means no authentication |
+| `NERVE_TASK` | unset | Worker mode task description |
+| `NERVE_EXTERNAL_AGENTS` | unset | Personal mode, e.g. `codex,claude-code` |
+| `GH_TOKEN` | unset | GitHub integration |
+
+A re-run over an existing install keeps the configuration and only upgrades the code.
+
 ## Re-running `nerve init`
 
 You can re-run `nerve init` at any time — it's safe on existing installations.

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,13 @@
 #   curl -fsSL https://raw.githubusercontent.com/ClickHouse/nerve/main/install.sh | bash
 #
 # Environment variables:
-#   NERVE_INSTALL_DIR  — Where to clone the repo (default: ~/nerve)
-#   NERVE_BRANCH       — Git branch to install (default: main)
-#   NERVE_YES          — Set to 1 to skip all confirmations
+#   NERVE_INSTALL_DIR      — Where to clone the repo (default: ~/nerve)
+#   NERVE_BRANCH           — Git branch to install (default: main)
+#   NERVE_YES              — Set to 1 to skip all confirmations
+#   NERVE_NON_INTERACTIVE  — Set to 1 for unattended install: implies NERVE_YES,
+#                            configures from env (see docs/setup.md), never prompts
+#   NERVE_START            — Set to 1 to start the daemon after an unattended
+#                            install; leave unset when a service manager owns it
 #
 set -euo pipefail
 
@@ -24,7 +28,9 @@ MIN_PYTHON_MINOR=13
 PREFERRED_PYTHON_MINOR=13
 # Vite 7 (see web/package.json) requires Node 20.19+ or 22.12+.
 MIN_NODE_VERSION="20.19.0"
+NON_INTERACTIVE="${NERVE_NON_INTERACTIVE:-0}"
 AUTO_YES="${NERVE_YES:-0}"
+[ "$NON_INTERACTIVE" = "1" ] && AUTO_YES=1
 IS_UPGRADE=0
 
 # --- Colors ---
@@ -499,6 +505,15 @@ run_init() {
         return
     fi
 
+    if [ "$NON_INTERACTIVE" = "1" ]; then
+        step "Running Nerve setup (non-interactive)"
+        cd "$INSTALL_DIR" || exit 1
+        # Fail loudly: a half-configured unattended install is worse than none.
+        "$nerve_bin" -c "$INSTALL_DIR" init --non-interactive
+        INIT_COMPLETED=1
+        return
+    fi
+
     # Clear boundary between installation and configuration: everything is
     # installed at this point — the wizard is optional and resumable.
     printf "\n"
@@ -535,8 +550,14 @@ offer_start() {
     if [ "$INIT_COMPLETED" != "1" ] || [ "$IS_UPGRADE" = "1" ]; then
         return
     fi
+    # Unattended installs are usually followed by a service manager owning the
+    # process, so starting a stray daemon here is wrong unless asked for.
+    if [ "$NON_INTERACTIVE" = "1" ] && [ "${NERVE_START:-0}" != "1" ]; then
+        info "Not starting Nerve (set NERVE_START=1 to start it here)"
+        return
+    fi
     printf "\n"
-    if ! confirm "Start Nerve now?"; then
+    if [ "$NON_INTERACTIVE" != "1" ] && ! confirm "Start Nerve now?"; then
         return
     fi
     local nerve_bin="$INSTALL_DIR/.venv/bin/nerve"
@@ -605,12 +626,15 @@ Usage:
   curl -fsSL .../install.sh | bash -s -- --yes
 
 Options:
-  --yes, -y       Skip all confirmation prompts
+  --yes, -y             Skip all confirmation prompts
+  --non-interactive     Unattended install; configure from environment
 
 Environment variables:
-  NERVE_INSTALL_DIR   Where to clone (default: ~/nerve)
-  NERVE_BRANCH        Git branch (default: main)
-  NERVE_YES           Set to 1 to skip confirmations
+  NERVE_INSTALL_DIR     Where to clone (default: ~/nerve)
+  NERVE_BRANCH          Git branch (default: main)
+  NERVE_YES             Set to 1 to skip confirmations
+  NERVE_NON_INTERACTIVE Set to 1 for unattended install (implies NERVE_YES)
+  NERVE_START           Set to 1 to start the daemon after unattended install
 
 EOF
 }
@@ -622,13 +646,19 @@ main() {
     for arg in "$@"; do
         case "$arg" in
             --yes|-y) AUTO_YES=1 ;;
+            --non-interactive) NON_INTERACTIVE=1; AUTO_YES=1 ;;
             --help|-h) usage; exit 0 ;;
         esac
     done
 
     # When piped via curl | bash, stdin is the pipe (EOF after script).
-    # Reclaim the terminal for all interactive prompts.
-    if [ ! -t 0 ] && [ -e /dev/tty ]; then
+    # Reclaim the terminal for all interactive prompts. The read test matters:
+    # under cloud-init and other daemons /dev/tty exists but there is no
+    # controlling terminal, so the open fails with ENXIO and set -e ends the
+    # install before it starts.
+    # Probe in a subshell: a failed `exec` redirection ends a non-interactive
+    # shell on POSIX-mode shells, where `||` would not get a chance to run.
+    if [ "$NON_INTERACTIVE" != "1" ] && [ ! -t 0 ] && (exec < /dev/tty) 2>/dev/null; then
         exec < /dev/tty
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 NERVE_REPO="https://github.com/ClickHouse/nerve.git"
 NERVE_BRANCH="${NERVE_BRANCH:-main}"
 INSTALL_DIR="${NERVE_INSTALL_DIR:-$HOME/nerve}"
+# The CLI resolves this itself, so upgrade detection, init, start and the
+# summary must all agree with it or they act on different configurations.
+CONFIG_DIR="${NERVE_CONFIG_DIR:-$INSTALL_DIR}"
 # 13, not 12: pyproject's requires-python is >=3.13 (set by memu-py==1.4.0).
 # Accepting 3.12 here meant the installer would provision a Python that then
 # failed at `uv pip install -e .` with an opaque dependency conflict.
@@ -62,6 +65,32 @@ confirm() {
 
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
+# Root images (ubuntu:24.04 and friends) can install packages with no sudo at
+# all, so elevation is a capability question, not a "is sudo present" one.
+run_as_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif ! command_exists sudo; then
+        error "Root privileges are required, but sudo is not available."
+        return 1
+    elif [ "$NON_INTERACTIVE" = "1" ]; then
+        # -n so automation fails instead of waiting on a password prompt.
+        sudo -n "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+# apt's -y answers apt, not debconf: tzdata still asks for a geographic area.
+# The variable is set past the sudo boundary so sudo cannot strip it.
+run_debian_command() {
+    if [ "$NON_INTERACTIVE" = "1" ]; then
+        run_as_root env DEBIAN_FRONTEND=noninteractive "$@"
+    else
+        run_as_root "$@"
+    fi
+}
+
 # Compare versions: version_ge "3.13" "3.13" → true
 version_ge() {
     local a="$1" b="$2"
@@ -98,10 +127,10 @@ detect_os() {
     DISTRO="unknown"
     PKG_MGR="unknown"
     ARCH="$(uname -m)"
-    HAS_SUDO=0
-
-    if command_exists sudo; then
-        HAS_SUDO=1
+    # "Can we install packages", not "is sudo installed" — root needs neither.
+    CAN_ELEVATE=0
+    if [ "$(id -u)" -eq 0 ] || command_exists sudo; then
+        CAN_ELEVATE=1
     fi
 
     case "$(uname -s)" in
@@ -151,8 +180,8 @@ ensure_git() {
     fi
 
     info "git is not installed"
-    if [ "$HAS_SUDO" = "0" ] && [ "$OS" = "linux" ]; then
-        error "git is required but sudo is not available. Install git manually and re-run."
+    if [ "$CAN_ELEVATE" = "0" ] && [ "$OS" = "linux" ]; then
+        error "git is required but packages cannot be installed (not root, no sudo). Install git manually and re-run."
         exit 1
     fi
 
@@ -163,13 +192,13 @@ ensure_git() {
 
     case "$PKG_MGR" in
         apt)
-            sudo apt-get update -qq && sudo apt-get install -y -qq git ;;
+            run_debian_command apt-get update -qq && run_debian_command apt-get install -y -qq git ;;
         dnf)
-            sudo dnf install -y -q git ;;
+            run_as_root dnf install -y -q git ;;
         pacman)
-            sudo pacman -S --noconfirm git ;;
+            run_as_root pacman -S --noconfirm git ;;
         zypper)
-            sudo zypper install -y git ;;
+            run_as_root zypper install -y git ;;
         brew)
             brew install git ;;
         *)
@@ -241,8 +270,8 @@ ensure_python() {
     # Last resort: system packages
     warn "uv python install failed. Trying system packages..."
 
-    if [ "$HAS_SUDO" = "0" ] && [ "$OS" = "linux" ]; then
-        error "Cannot install Python: no sudo and uv python install failed."
+    if [ "$CAN_ELEVATE" = "0" ] && [ "$OS" = "linux" ]; then
+        error "Cannot install Python: no way to elevate and uv python install failed."
         error "Install Python 3.13+ manually and re-run."
         exit 1
     fi
@@ -251,24 +280,24 @@ ensure_python() {
         apt)
             if ! apt-cache show python3.13 >/dev/null 2>&1; then
                 info "Adding deadsnakes PPA..."
-                sudo apt-get update -qq
-                sudo apt-get install -y -qq software-properties-common
-                sudo add-apt-repository -y ppa:deadsnakes/ppa
-                sudo apt-get update -qq
+                run_debian_command apt-get update -qq
+                run_debian_command apt-get install -y -qq software-properties-common
+                run_debian_command add-apt-repository -y ppa:deadsnakes/ppa
+                run_debian_command apt-get update -qq
             fi
-            sudo apt-get install -y -qq python3.13 python3.13-venv python3.13-dev
+            run_debian_command apt-get install -y -qq python3.13 python3.13-venv python3.13-dev
             PYTHON_CMD="python3.13"
             ;;
         dnf)
-            sudo dnf install -y -q python3.13 || sudo dnf install -y -q python3.12 || sudo dnf install -y -q python3
+            run_as_root dnf install -y -q python3.13 || run_as_root dnf install -y -q python3.12 || run_as_root dnf install -y -q python3
             PYTHON_CMD="$(command -v python3.13 || command -v python3.12 || command -v python3)"
             ;;
         pacman)
-            sudo pacman -S --noconfirm python
+            run_as_root pacman -S --noconfirm python
             PYTHON_CMD="python3"
             ;;
         zypper)
-            sudo zypper install -y python313 || sudo zypper install -y python312 || sudo zypper install -y python3
+            run_as_root zypper install -y python313 || run_as_root zypper install -y python312 || run_as_root zypper install -y python3
             PYTHON_CMD="$(command -v python3.13 || command -v python3.12 || command -v python3)"
             ;;
         brew)
@@ -317,8 +346,8 @@ ensure_node() {
 
     info "Node.js v${MIN_NODE_VERSION}+ is not installed"
 
-    if [ "$HAS_SUDO" = "0" ] && [ "$OS" = "linux" ]; then
-        error "Node.js is required but sudo is not available."
+    if [ "$CAN_ELEVATE" = "0" ] && [ "$OS" = "linux" ]; then
+        error "Node.js is required but packages cannot be installed (not root, no sudo)."
         error "Install Node.js v${MIN_NODE_VERSION}+ manually and re-run."
         exit 1
     fi
@@ -331,19 +360,19 @@ ensure_node() {
     case "$PKG_MGR" in
         apt)
             info "Installing Node.js via nodesource..."
-            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-            sudo apt-get install -y -qq nodejs
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | run_debian_command bash -
+            run_debian_command apt-get install -y -qq nodejs
             ;;
         dnf)
             info "Installing Node.js via nodesource..."
-            curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -
-            sudo dnf install -y -q nodejs
+            curl -fsSL https://rpm.nodesource.com/setup_lts.x | run_as_root bash -
+            run_as_root dnf install -y -q nodejs
             ;;
         pacman)
-            sudo pacman -S --noconfirm nodejs npm
+            run_as_root pacman -S --noconfirm nodejs npm
             ;;
         zypper)
-            sudo zypper install -y nodejs20
+            run_as_root zypper install -y nodejs20
             ;;
         brew)
             brew install node
@@ -496,7 +525,7 @@ INIT_SKIPPED=0
 
 run_init() {
     local nerve_bin="$INSTALL_DIR/.venv/bin/nerve"
-    local config_local="$INSTALL_DIR/config.local.yaml"
+    local config_local="$CONFIG_DIR/config.local.yaml"
 
     if [ "$IS_UPGRADE" = "1" ] && [ -f "$config_local" ]; then
         info "Existing configuration found — skipping setup wizard"
@@ -509,7 +538,7 @@ run_init() {
         step "Running Nerve setup (non-interactive)"
         cd "$INSTALL_DIR" || exit 1
         # Fail loudly: a half-configured unattended install is worse than none.
-        "$nerve_bin" -c "$INSTALL_DIR" init --non-interactive
+        "$nerve_bin" -c "$CONFIG_DIR" init --non-interactive
         INIT_COMPLETED=1
         return
     fi
@@ -533,7 +562,7 @@ run_init() {
     step "Running Nerve setup"
     cd "$INSTALL_DIR" || exit 1
     # Don't let a wizard abort look like a failed installation (set -e).
-    if "$nerve_bin" init; then
+    if "$nerve_bin" -c "$CONFIG_DIR" init; then
         INIT_COMPLETED=1
     else
         printf "\n"
@@ -561,7 +590,7 @@ offer_start() {
         return
     fi
     local nerve_bin="$INSTALL_DIR/.venv/bin/nerve"
-    if "$nerve_bin" start; then
+    if "$nerve_bin" -c "$CONFIG_DIR" start; then
         NERVE_STARTED=1
     else
         warn "Start failed — check logs with: nerve logs"
@@ -602,7 +631,7 @@ print_summary() {
     printf "    ${CYAN}nerve stop${NC}            Stop the daemon\n"
     printf "\n"
     printf "  ${DIM}Install dir : $INSTALL_DIR${NC}\n"
-    printf "  ${DIM}Config      : $INSTALL_DIR/config.local.yaml${NC}\n"
+    printf "  ${DIM}Config      : $CONFIG_DIR/config.local.yaml${NC}\n"
     printf "  ${DIM}Data        : ~/.nerve/${NC}\n"
     printf "\n"
     printf "  ${DIM}To uninstall: rm -rf $INSTALL_DIR ~/.nerve ~/.local/bin/nerve${NC}\n"


### PR DESCRIPTION
## Problem

`install.sh` cannot complete without a terminal, so it can't be used from cloud-init, Ansible, a Dockerfile or an image build. Two separate things block it.

**1. The tty reclaim is fatal without a controlling terminal.**

```bash
if [ ! -t 0 ] && [ -e /dev/tty ]; then
    exec < /dev/tty
fi
```

`/dev/tty` exists on any normal system, but a process started by a daemon has no controlling terminal, so the open fails with ENXIO. Under `set -e` that ends the install before the first dependency check. `-e /dev/tty` tests that the device node is there, which is not the same question.

**2. There is no way to skip the wizard.**

Past the dependency phase `run_init` always runs the interactive `nerve init`. `NERVE_YES=1` does not help — it makes `confirm "Run the setup wizard now?"` return true, so the wizard runs with no one to answer it and the install hangs. `offer_start` then does the same for "Start Nerve now?".

`nerve init --non-interactive` already exists and reads everything from the environment; the installer just had no way to reach it.

## Change

Adds `--non-interactive` / `NERVE_NON_INTERACTIVE=1`:

- implies `NERVE_YES=1` and skips the tty reclaim entirely
- `run_init` calls `nerve init --non-interactive` and fails loudly rather than leaving a half-configured install
- `offer_start` leaves the daemon stopped, since these installs are normally followed by a service manager that owns the process. `NERVE_START=1` starts it from the installer instead.
- an existing install still takes the upgrade path and keeps its configuration

The tty reclaim is now probed in a subshell before it is used, so an interactive run behaves as before and a run without a terminal continues instead of dying.

```bash
curl -fsSL https://raw.githubusercontent.com/ClickHouse/nerve/main/install.sh \
  | NERVE_NON_INTERACTIVE=1 \
    NERVE_INSTALL_DIR=/home/agent/nerve \
    NERVE_MODE=worker \
    NERVE_PROVIDER=bedrock \
    NERVE_AWS_REGION=eu-central-1 \
    bash
```

`docs/setup.md` gets an "Unattended installation" section listing the variables the wizard would otherwise ask for.

## Notes

- No behaviour change for an interactive install: `NON_INTERACTIVE` defaults to 0 and every new branch is behind it.
- `NERVE_PASSWORD` is read once by `nerve init` and stored only as a bcrypt hash, so an unattended caller can pass it in and drop it immediately. Called out in the docs.

## Testing

- `bash -n install.sh`
- Verified `NERVE_NON_INTERACTIVE=1` sets `AUTO_YES=1` and that `confirm` then returns without reading stdin.
- Verified the subshell probe swallows an unopenable path and lets the script continue, where a bare `exec` redirection does not.
- Not yet run as a full unattended install on a clean host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)