### PR TITLE
imap: process backlog oldest-first

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -78,7 +78,8 @@ A persistent cron job (`inbox-processor`) runs every 15 minutes:
 - **Instances:** One source per configured account (`imap:<label>`), each with an independent cursor
 - **Cursor:** `<UIDVALIDITY>:<max_uid>` — UIDs are only stable within a UIDVALIDITY, so a server-side reset is detected and re-baselined instead of trusted
 - **First run:** `SINCE` window of `initial_lookback_days` (default 1)
-- **Subsequent runs:** `UID SEARCH <last+1>:*`, filtered client-side (the `N:*` range always returns at least the highest UID)
+- **Subsequent runs:** `UID SEARCH <last+1>:*`, filtered client-side (the `N:*` range always returns at least the highest UID); oldest UIDs are processed first when a batch is full
+- **Failure policy:** A search or message fetch/parse failure fails the batch and leaves the cursor unchanged. `SourceRunner` reports the error and applies its health/backoff policy. Fix or remove a permanently malformed message, then the next run retries it; manually advancing the cursor is an operator recovery action when skipping that UID is confirmed safe
 - **Blocking I/O:** the whole IMAP conversation runs in a worker thread via `asyncio.to_thread`
 - **Credentials:** passwords live in `sync.imap.passwords` keyed by username (put them in `config.local.yaml`); an account with no password is skipped with a warning instead of failing the sync
 - **Optional image pass:** see below

--- a/nerve/sources/imap.py
+++ b/nerve/sources/imap.py
@@ -88,9 +88,12 @@ class ImapSource(Source):
             parsed, next_cursor = await asyncio.to_thread(
                 self._imap_fetch_blocking, cursor, limit,
             )
-        except Exception as e:
-            logger.error("IMAP error for %s: %s", self.source_name, e)
-            return FetchResult(records=[], next_cursor=cursor, has_more=False)
+        except Exception:
+            # Let SourceRunner record the failure and apply its health/backoff
+            # policy. Returning an empty successful fetch would retry the same
+            # UID forever without telling the caller why the cursor is stuck.
+            logger.exception("IMAP error for %s", self.source_name)
+            raise
 
         records: list[SourceRecord] = []
         for msg in parsed:
@@ -139,6 +142,9 @@ class ImapSource(Source):
         Returns (parsed_messages, next_cursor). Runs entirely in a worker
         thread — no async here.
         """
+        if limit <= 0:
+            return [], cursor
+
         M = imaplib.IMAP4_SSL(self.host, self.port)
         try:
             M.login(self.username, self._password)
@@ -182,8 +188,6 @@ class ImapSource(Source):
             # Process the oldest next batch. Advancing to the newest UID here
             # would skip the unprocessed backlog when there are more messages
             # than the per-run limit.
-            if limit <= 0:
-                return [], cursor
             uids = uids[:limit]
             next_uid = uids[-1]
 

--- a/nerve/sources/imap.py
+++ b/nerve/sources/imap.py
@@ -162,7 +162,9 @@ class ImapSource(Source):
                 ).strftime("%d-%b-%Y")
                 typ, data = M.uid("search", None, "SINCE", since)
 
-            if typ != "OK" or not data or not data[0]:
+            if typ != "OK":
+                raise RuntimeError(f"IMAP SEARCH failed for {self.mailbox}: {typ}")
+            if not data or not data[0]:
                 # Nothing matched. Baseline the cursor so we don't re-scan.
                 baseline = last_uid if incremental else (uidnext - 1 if uidnext else 0)
                 return [], f"{uidvalidity}:{max(0, baseline)}"
@@ -177,23 +179,28 @@ class ImapSource(Source):
                 return [], f"{uidvalidity}:{last_uid}" if last_uid is not None else \
                     f"{uidvalidity}:{max(0, (uidnext - 1) if uidnext else 0)}"
 
-            # Cap to the newest `limit` messages, but track the true max UID so
-            # the cursor advances past everything we saw.
-            max_uid = uids[-1]
-            if len(uids) > limit:
-                uids = uids[-limit:]
+            # Process the oldest next batch. Advancing to the newest UID here
+            # would skip the unprocessed backlog when there are more messages
+            # than the per-run limit.
+            if limit <= 0:
+                return [], cursor
+            uids = uids[:limit]
+            next_uid = uids[-1]
 
             parsed: list[dict] = []
             for uid in uids:
                 try:
                     parsed.append(self._fetch_one(M, uid, uidvalidity))
-                except Exception as e:
-                    logger.warning(
-                        "IMAP %s: failed to parse uid %d: %s",
-                        self.source_name, uid, e,
+                except Exception:
+                    logger.exception(
+                        "IMAP %s: failed to parse uid %d",
+                        self.source_name, uid,
                     )
+                    # Do not advance past a UID that was not successfully
+                    # fetched. The next run must retry this batch.
+                    raise
 
-            return parsed, f"{uidvalidity}:{max_uid}"
+            return parsed, f"{uidvalidity}:{next_uid}"
         finally:
             try:
                 M.logout()

--- a/tests/test_imap_source.py
+++ b/tests/test_imap_source.py
@@ -179,6 +179,32 @@ class _FakeIMAP:
         return "OK", [(b"1 (RFC822 {n}", self._raw)]
 
 
+class _FakeMailbox:
+    """Minimal mailbox for exercising the blocking cursor flow."""
+
+    def __init__(self, uids: list[int], *, search_status: str = "OK"):
+        self.uids = uids
+        self.search_status = search_status
+
+    def login(self, username, password):
+        return "OK", [b"logged in"]
+
+    def select(self, mailbox, readonly=True):
+        return "OK", [b"selected"]
+
+    def status(self, mailbox, query):
+        return "OK", [b"INBOX (UIDVALIDITY 9 UIDNEXT 200)"]
+
+    def uid(self, command, *args):
+        assert command == "search"
+        if self.search_status != "OK":
+            return self.search_status, [b"search failed"]
+        return "OK", [" ".join(str(uid) for uid in self.uids).encode()]
+
+    def logout(self):
+        return "BYE", [b"logged out"]
+
+
 def _parse(src: ImapSource, message: EmailMessage) -> dict:
     return src._fetch_one(_FakeIMAP(message), 7, 99)
 
@@ -262,6 +288,93 @@ def _src(**kw) -> ImapSource:
     return ImapSource(
         host="h", username="u@x", password="p", label="scans", **kw,
     )
+
+
+def _stub_parsed_message(uid: int, uidvalidity: int) -> dict:
+    return {
+        "id": f"{uidvalidity}-{uid}",
+        "subject": f"Message {uid}",
+        "from": "sender@example.com",
+        "date": "",
+        "timestamp": "2026-06-20T00:00:00+00:00",
+        "body": "body",
+        "matched": False,
+        "image": None,
+        "media_type": None,
+    }
+
+
+def test_blocking_fetch_processes_oldest_batch(monkeypatch):
+    """A backlog is drained from the oldest UID instead of skipping ahead."""
+    src = _src()
+    mailbox = _FakeMailbox([101, 102, 103, 104, 105])
+    fetched: list[int] = []
+
+    monkeypatch.setattr(
+        "nerve.sources.imap.imaplib.IMAP4_SSL",
+        lambda host, port: mailbox,
+    )
+
+    def _fetch_one(_mailbox, uid, uidvalidity):
+        fetched.append(uid)
+        return _stub_parsed_message(uid, uidvalidity)
+
+    monkeypatch.setattr(src, "_fetch_one", _fetch_one)
+
+    cursor = "9:100"
+    parsed, cursor = src._imap_fetch_blocking(cursor, limit=2)
+    assert [message["id"] for message in parsed] == ["9-101", "9-102"]
+    assert fetched == [101, 102]
+    assert cursor == "9:102"
+
+    parsed, cursor = src._imap_fetch_blocking(cursor, limit=2)
+    assert [message["id"] for message in parsed] == ["9-103", "9-104"]
+    assert cursor == "9:104"
+
+    parsed, cursor = src._imap_fetch_blocking(cursor, limit=2)
+    assert [message["id"] for message in parsed] == ["9-105"]
+    assert cursor == "9:105"
+
+
+@pytest.mark.asyncio
+async def test_fetch_preserves_cursor_when_a_uid_fails(monkeypatch):
+    """A failed UID must be retried instead of being skipped permanently."""
+    src = _src()
+    mailbox = _FakeMailbox([101, 102, 103])
+    fetched: list[int] = []
+
+    monkeypatch.setattr(
+        "nerve.sources.imap.imaplib.IMAP4_SSL",
+        lambda host, port: mailbox,
+    )
+
+    def _fetch_one(_mailbox, uid, uidvalidity):
+        fetched.append(uid)
+        if uid == 102:
+            raise RuntimeError("temporary parse failure")
+        return _stub_parsed_message(uid, uidvalidity)
+
+    monkeypatch.setattr(src, "_fetch_one", _fetch_one)
+
+    result = await src.fetch(cursor="9:100", limit=2)
+    assert result.records == []
+    assert result.next_cursor == "9:100"
+    assert fetched == [101, 102]
+
+
+@pytest.mark.asyncio
+async def test_fetch_preserves_cursor_when_search_fails(monkeypatch):
+    """A failed search must not be treated as an empty mailbox."""
+    src = _src()
+    mailbox = _FakeMailbox([101, 102], search_status="NO")
+    monkeypatch.setattr(
+        "nerve.sources.imap.imaplib.IMAP4_SSL",
+        lambda host, port: mailbox,
+    )
+
+    result = await src.fetch(cursor="9:100", limit=2)
+    assert result.records == []
+    assert result.next_cursor == "9:100"
 
 
 def _matched_msg(**over) -> dict:

--- a/tests/test_imap_source.py
+++ b/tests/test_imap_source.py
@@ -37,6 +37,7 @@ from nerve.sources.imap import (
     _parse_cursor,
 )
 from nerve.sources.registry import build_source_runners
+from nerve.sources.runner import SourceRunner
 
 # 1x1 transparent PNG (valid, tiny) for the image tests.
 _PNG_BYTES = base64.b64decode(
@@ -185,6 +186,7 @@ class _FakeMailbox:
     def __init__(self, uids: list[int], *, search_status: str = "OK"):
         self.uids = uids
         self.search_status = search_status
+        self.search_args: list[tuple] = []
 
     def login(self, username, password):
         return "OK", [b"logged in"]
@@ -197,9 +199,15 @@ class _FakeMailbox:
 
     def uid(self, command, *args):
         assert command == "search"
+        self.search_args.append(args)
         if self.search_status != "OK":
             return self.search_status, [b"search failed"]
-        return "OK", [" ".join(str(uid) for uid in self.uids).encode()]
+        if len(args) > 1 and isinstance(args[1], str) and args[1].endswith(":*"):
+            lower_bound = int(args[1][:-2])
+            uids = [uid for uid in self.uids if uid >= lower_bound]
+        else:
+            uids = self.uids
+        return "OK", [" ".join(str(uid) for uid in uids).encode()]
 
     def logout(self):
         return "BYE", [b"logged out"]
@@ -326,19 +334,24 @@ def test_blocking_fetch_processes_oldest_batch(monkeypatch):
     assert [message["id"] for message in parsed] == ["9-101", "9-102"]
     assert fetched == [101, 102]
     assert cursor == "9:102"
+    assert mailbox.search_args == [(None, "101:*")]
 
     parsed, cursor = src._imap_fetch_blocking(cursor, limit=2)
     assert [message["id"] for message in parsed] == ["9-103", "9-104"]
     assert cursor == "9:104"
+    assert mailbox.search_args == [(None, "101:*"), (None, "103:*")]
 
     parsed, cursor = src._imap_fetch_blocking(cursor, limit=2)
     assert [message["id"] for message in parsed] == ["9-105"]
     assert cursor == "9:105"
+    assert mailbox.search_args == [
+        (None, "101:*"), (None, "103:*"), (None, "105:*")
+    ]
 
 
 @pytest.mark.asyncio
-async def test_fetch_preserves_cursor_when_a_uid_fails(monkeypatch):
-    """A failed UID must be retried instead of being skipped permanently."""
+async def test_fetch_propagates_uid_failure(monkeypatch):
+    """A failed UID must be visible to SourceRunner instead of being hidden."""
     src = _src()
     mailbox = _FakeMailbox([101, 102, 103])
     fetched: list[int] = []
@@ -356,14 +369,13 @@ async def test_fetch_preserves_cursor_when_a_uid_fails(monkeypatch):
 
     monkeypatch.setattr(src, "_fetch_one", _fetch_one)
 
-    result = await src.fetch(cursor="9:100", limit=2)
-    assert result.records == []
-    assert result.next_cursor == "9:100"
+    with pytest.raises(RuntimeError, match="temporary parse failure"):
+        await src.fetch(cursor="9:100", limit=2)
     assert fetched == [101, 102]
 
 
 @pytest.mark.asyncio
-async def test_fetch_preserves_cursor_when_search_fails(monkeypatch):
+async def test_fetch_propagates_search_failure(monkeypatch):
     """A failed search must not be treated as an empty mailbox."""
     src = _src()
     mailbox = _FakeMailbox([101, 102], search_status="NO")
@@ -372,9 +384,39 @@ async def test_fetch_preserves_cursor_when_search_fails(monkeypatch):
         lambda host, port: mailbox,
     )
 
-    result = await src.fetch(cursor="9:100", limit=2)
-    assert result.records == []
-    assert result.next_cursor == "9:100"
+    with pytest.raises(RuntimeError, match="IMAP SEARCH failed"):
+        await src.fetch(cursor="9:100", limit=2)
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_blocking_fetch_rejects_non_positive_limit_before_connect(monkeypatch, limit):
+    src = _src()
+
+    def _unexpected_connect(*args):
+        raise AssertionError("non-positive limit should not connect to IMAP")
+
+    monkeypatch.setattr(
+        "nerve.sources.imap.imaplib.IMAP4_SSL", _unexpected_connect,
+    )
+
+    assert src._imap_fetch_blocking(None, limit) == ([], None)
+
+
+@pytest.mark.asyncio
+async def test_runner_reports_imap_fetch_failure(db, monkeypatch):
+    src = _src()
+
+    def _boom(cursor, limit):
+        raise RuntimeError("temporary parse failure")
+
+    monkeypatch.setattr(src, "_imap_fetch_blocking", _boom)
+    runner = SourceRunner(source=src, db=db, batch_size=2)
+
+    result = await runner.run()
+
+    assert result.records_ingested == 0
+    assert result.error == "temporary parse failure"
+    assert await db.get_sync_cursor(src.source_name) is None
 
 
 def _matched_msg(**over) -> dict:
@@ -498,16 +540,15 @@ async def test_only_matched_drops_the_rest(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_swallows_blocking_errors(monkeypatch):
+async def test_fetch_propagates_blocking_errors(monkeypatch):
     src = _src(vision_client_factory=lambda: _FakeVisionClient(text="x"))
 
     def _boom(cursor, limit):
         raise RuntimeError("imap down")
 
     monkeypatch.setattr(src, "_imap_fetch_blocking", _boom)
-    result = await src.fetch(cursor="5:5", limit=10)
-    assert result.records == []
-    assert result.next_cursor == "5:5"  # cursor preserved on error
+    with pytest.raises(RuntimeError, match="imap down"):
+        await src.fetch(cursor="5:5", limit=10)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Process IMAP UIDs oldest-first** when the backlog is larger than `batch_size`.
- **Advance the cursor only to the last UID in the processed batch.**
- **Keep the cursor unchanged on search or message-fetch failures** so unprocessed mail is not skipped.

## Bug

With UIDs `101..200` and `batch_size=50`, the old code fetched `151..200` and saved cursor `200`. UIDs `101..150` were then skipped permanently.

## Fix

- Select `uids[:limit]` instead of the newest UIDs.
- Save the cursor from the selected batch, not from the full search result.
- Stop silently skipping a UID when parsing or fetching fails.
- Treat an unsuccessful IMAP search as an error instead of an empty mailbox.
- Return before connecting when `limit <= 0`.

## Failure policy

A failed search or message fetch/parse fails the whole batch and leaves the cursor unchanged. The error now reaches `SourceRunner`, which can report the failure and apply its health/backoff policy. This is intentionally fail-closed. A permanently malformed message must be fixed or removed before the mailbox can continue; manually advancing the cursor is only safe after confirming that skipping the UID is acceptable.

## Tests

- `uv run --extra test pytest tests/test_imap_source.py tests/test_source_filters.py -q`
- **58 tests passed**

Coverage includes backlog draining across multiple runs, exact search ranges, failed UID fetches, failed searches, non-positive limits, and runner error propagation.