### PR TITLE
xmemory: raise recall answer budget 4KB -> 16KB

### DIFF
--- a/nerve/agent/tools/handlers/memory.py
+++ b/nerve/agent/tools/handlers/memory.py
@@ -45,9 +45,11 @@ def _resolve_memu_db_path(ctx: ToolContext) -> str:
 # inline-output limit (which would silently persist it to a file).
 _MAX_RECALL_BYTES = 10_000
 
-# Sub-budget for xmemory's synthesized answer so it can never crowd out the
-# memU items it's shown alongside.
-_MAX_XMEM_ANSWER_BYTES = 4_000
+# Sub-budget for xmemory's read result. Structured read modes (raw-tables /
+# xresponse) and multi-sub-query answers routinely exceed the old 4KB budget,
+# so give xmemory its own 16KB. Combined with the memU budget above the worst
+# case stays ~26KB — comfortably under the harness's ~55KB inline-output limit.
+_MAX_XMEM_ANSWER_BYTES = 16_000
 
 
 def _clip_to_budget(text: str, max_bytes: int = _MAX_RECALL_BYTES) -> str:


### PR DESCRIPTION
The recall handler clips xmemory's read result to `_MAX_XMEM_ANSWER_BYTES = 4_000` before appending it to the memU block. 4KB is tight for the structured read modes (`raw-tables` / `xresponse`) and for decomposed multi-sub-query answers (`reader_results`), which get truncated mid-payload.

This bumps the sub-budget to 16KB. Sizing: memU part is capped at 10KB (`_MAX_RECALL_BYTES`), so the combined worst case is ~26KB — still well under the ~55KB harness inline-output limit that these budgets exist to stay clear of (see #95).

One-line constant change + comment; no behavior change below 4KB. Full test suite passes (3360).

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*