### PR TITLE
Diagnostics: fix the empty daily-cost chart

### DIFF
--- a/web/src/pages/DiagnosticsPage.tsx
+++ b/web/src/pages/DiagnosticsPage.tsx
@@ -176,14 +176,20 @@ export function DiagnosticsPage() {
                     const heightPct = maxCost > 0 ? Math.max(2, (cost / maxCost) * 100) : 2;
                     const dateLabel = day.date?.slice(5) || ''; // MM-DD
                     return (
-                      <div key={day.date} className="flex-1 flex flex-col items-center gap-0.5 min-w-0">
-                        <div
-                          className="w-full bg-accent/30 rounded-t-sm hover:bg-accent/50 transition-colors relative group"
-                          style={{ height: `${heightPct}%` }}
-                        >
-                          <div className="absolute -top-6 left-1/2 -translate-x-1/2 hidden group-hover:block z-10
-                            bg-surface-raised border border-border-subtle rounded px-1.5 py-0.5 text-[10px] text-text-secondary whitespace-nowrap shadow-lg">
-                            {formatTokens((day.input_tokens || 0) + (day.output_tokens || 0))} &middot; ${cost.toFixed(2)}
+                      <div key={day.date} className="flex-1 flex flex-col items-center gap-0.5 min-w-0 h-full">
+                        {/* Bar track. The bar's percentage height needs a parent
+                            with a definite height to resolve against, so the
+                            column is h-full and the track takes the space left
+                            over after the date label. */}
+                        <div className="flex-1 w-full flex items-end min-h-0">
+                          <div
+                            className="w-full bg-accent/30 rounded-t-sm hover:bg-accent/50 transition-colors relative group"
+                            style={{ height: `${heightPct}%` }}
+                          >
+                            <div className="absolute -top-6 left-1/2 -translate-x-1/2 hidden group-hover:block z-10
+                              bg-surface-raised border border-border-subtle rounded px-1.5 py-0.5 text-[10px] text-text-secondary whitespace-nowrap shadow-lg">
+                              {formatTokens((day.input_tokens || 0) + (day.output_tokens || 0))} &middot; ${cost.toFixed(2)}
+                            </div>
                           </div>
                         </div>
                         <span className="text-[9px] text-text-faint tabular-nums">{dateLabel}</span>


### PR DESCRIPTION
The Diagnostics page renders "Daily cost" as a row of bare date labels with no bars. Flagged as known-but-unexplained in #411; this is the explanation and the fix.

## Root cause

Frontend only. The backend is healthy — `/api/diagnostics` returns 8 daily rows with real `cost_usd`, and `get_usage_by_period` already emits exactly the `date` / `cost_usd` shape the chart reads.

Each bar carries ``style={{ height: `${heightPct}%` }}``. Its parent column was a flex item in an `items-end` row, so the column's cross size is content-based — it measured 15.5px, the height of the date label alone. A percentage height against an auto-height containing block resolves to `auto`, and the bar has no content of its own, so **every bar computed to 0px** — including the tallest, which asks for `100%`.

Measured in Chromium against the built app and the real API response:

| day | declared | rendered (before) | rendered (after) |
|---|---|---|---|
| 08-18 | 2.71% | **0px** | 1.7px |
| 08-19 | 100% | **0px** | 64.5px |
| 08-20 | 5.65% | **0px** | 3.6px |
| 08-21 | 4.30% | **0px** | 2.8px |
| 08-22 | 2.45% | **0px** | 1.6px |
| 08-23 | 15.91% | **0px** | 10.3px |
| 08-24 | 4.90% | **0px** | 3.2px |
| 08-25 | 70.96% | **0px** | 45.8px |

## Fix

The column gets `h-full`, and the bar moves into a `flex-1 w-full flex items-end min-h-0` track that takes the space left over after the date label. The percentage now resolves against that track.

The chart keeps its 80px total height, the labels stay where they were, and a 100% bar exactly fills the track rather than overflowing — verified as 0px overflow, top and bottom.

## Verification

- **Real app, not a mock**: served the built `dist/` with `/api/*` reverse-proxied to a live Nerve instance, so the numbers above come from the actual component against the actual endpoint.
- The same measurement was run against the **current `main` build** to produce the before column.
- Hover tooltip still works — shows `744.9K · $128.63` on the 08-19 bar, matching that DB row exactly.
- `npm run build` (tsc + vite) passes.
- Frontend: **114 tests pass**.
- Backend: `25 failed, 3256 passed, 25 errors` — **byte-identical with and without this change** (verified by stashing). All of it is a local env gap: 49 × `ModuleNotFoundError: No module named 'mcp.server.context'`, unrelated to this diff.
- eslint on the touched file: **9 problems before, 9 after** — all pre-existing `no-explicit-any` on lines this PR does not touch.

## Notes

- Independent of #411 — that PR does not touch `DiagnosticsPage.tsx`, so this branches off `main` and the two do not conflict. The change uses stock layout utilities only, so it holds under either token set.
- This is the only percentage-height bar chart in the app (`rg items-end` finds three hits; the other two are `flex-wrap` toolbars), so there is no sibling instance of the bug to fix.
- No unit test added, deliberately: `vite.config.ts` sets `test.css: false` and jsdom does not do layout, so this class of bug is invisible to the unit suite. A class-list assertion would pin the markup without testing the behaviour. The browser measurement above is the regression evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
