### PR TITLE
Fork this chat — branch conversations on both backends, with full UI

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -97,11 +97,21 @@ Response: {
 ```
 
 #### `POST /api/sessions/fork`
-Fork a session, optionally from a specific message point.
+Fork a session, optionally from a specific message point (`at_message_id` is
+a numeric message row id as a string). The fork branches the source's
+*native* conversation on its first turn (Claude `--fork-session` +
+`--resume-session-at`; Codex `thread/fork` + `lastTurnId`) and is created
+pre-populated with the source's messages up to the fork point, so the new
+chat displays exactly the history the agent remembers.
+
+Errors: `404` unknown source; `409` not forkable — the source has no native
+conversation yet (no completed turn), or the anchor message has no native
+turn mapping (sessions predating per-turn recording can only be forked
+whole).
 
 ```json
-Request:  { "source_session_id": "main", "at_message_id": "msg-42", "title": "My Fork" }
-Response: { "id": "fork-a1b2c3d4", "title": "My Fork", "source": "web", "status": "created", "parent_session_id": "main" }
+Request:  { "source_session_id": "main", "at_message_id": "42", "title": "My Fork" }
+Response: { "id": "fork-a1b2c3d4", "title": "My Fork", "source": "web", "status": "created", "parent_session_id": "main", "message_count": 12 }
 ```
 
 #### `POST /api/sessions/{id}/resume`

--- a/docs/sdk-sessions.md
+++ b/docs/sdk-sessions.md
@@ -59,12 +59,31 @@ When you want a new session that starts with the parent's full context:
 options = ClaudeAgentOptions(
     resume=parent.sdk_session_id,   # Branch FROM this point
     fork_session=True,              # Create independent branch
+    resume_session_at=turn_uuid,    # Optional: truncate at a mid-point turn
 )
 ```
 
 The fork inherits all parent context but diverges from that point. New messages don't affect the parent.
 
-**Nerve's implementation:** `engine.run()` detects `parent_session_id` on first message (status=CREATED) and sets `fork_from`. See `engine.py:556-567`.
+**Mid-point forks.** Both backends can branch at an earlier turn, not just
+the end: Claude via `resume_session_at` (a transcript-entry UUID), Codex via
+`thread/fork` + `lastTurnId`. To make that possible, each backend records a
+per-turn anchor as `messages.native_turn_id` on the completed assistant row —
+Codex reports the turn id natively; the Claude client tracks the last
+main-chain transcript-entry uuid streamed during the turn
+(`ClaudeClient._translate_and_capture`). `db.get_native_turn_at_message()`
+maps a UI message id to that anchor. Message forks on rows with no anchor
+(history predating this recording) are refused rather than silently forking
+the full context.
+
+**Display parity.** `SessionManager.fork_session()` copies the source's
+message rows up to the fork boundary into the fork
+(`db.copy_messages_to_session`), so the forked chat shows the history the
+agent actually remembers. Copies keep `native_turn_id` (forks are
+re-forkable) and get `external_id = "forkcopy:<source row id>"` for
+provenance.
+
+**Nerve's implementation:** `engine.run()` detects `parent_session_id` on first message (status=CREATED) and sets `fork_from` (+ `fork_last_turn_id` for message-anchored forks). See `_get_or_create_client` / `_run_inner` in `engine.py`.
 
 ## Session ID Lifecycle
 

--- a/nerve/agent/backends/claude.py
+++ b/nerve/agent/backends/claude.py
@@ -544,6 +544,14 @@ class ClaudeBackend:
             betas=betas,
             resume=spec.resume_native_id,
             fork_session=spec.fork,
+            # Mid-conversation fork: truncate the resumed transcript at the
+            # kept turn's last entry (we record it per turn as
+            # native_turn_id — see ClaudeClient._translate_and_capture).
+            # Guarded on spec.fork: without fork_session this flag would
+            # truncate the ORIGINAL session in place.
+            resume_session_at=(
+                spec.fork_last_turn_id if spec.fork else None
+            ),
             hooks=hooks,
             stderr=_cli_stderr,
             extra_args=extra_args,
@@ -963,6 +971,10 @@ class ClaudeBackend:
 class ClaudeClient(AgentClient):
     """One live Claude Code CLI subprocess for one nerve session."""
 
+    # Class-level default so test doubles built via ``__new__`` (and any
+    # partially-initialized instance) read None instead of raising.
+    _last_entry_uuid: str | None = None
+
     def __init__(self, spec: SessionSpec, options: ClaudeAgentOptions):
         self._spec = spec
         self._options = options
@@ -971,6 +983,11 @@ class ClaudeClient(AgentClient):
         # The resolved model this client was built with (engine reads it
         # to detect mid-session model switches).
         self.model: str = options.model or ""
+        # Last main-chain transcript-entry uuid observed this turn — the
+        # fork anchor (``resume_session_at`` wants "the last transcript
+        # entry of the turn you are keeping"). Reset per turn; attached to
+        # TurnCompleted as native_turn_id (codex parity).
+        self._last_entry_uuid: str | None = None
 
     # -- protocol ------------------------------------------------------- #
 
@@ -982,6 +999,10 @@ class ClaudeClient(AgentClient):
         await self._sdk.connect()
 
     async def start_turn(self, turn: TurnInput) -> None:
+        # Per-turn fork anchor: a turn that yields no transcript entries
+        # (errors out early) must not inherit the previous turn's uuid —
+        # a stale anchor would fork at the WRONG turn.
+        self._last_entry_uuid = None
         try:
             if turn.images or turn.documents:
                 blocks = self._build_content_blocks(turn)
@@ -1115,7 +1136,22 @@ class ClaudeClient(AgentClient):
         msg_sid = getattr(message, "session_id", None)
         if msg_sid:
             self._native_session_id = msg_sid
-        return translate_message(message)
+        # Track the last MAIN-CHAIN transcript entry uuid (assistant text /
+        # tool_use and user tool_result rows both count — a turn ending on
+        # an end-turn tool closes on a user entry). Sidechain (subagent)
+        # entries are skipped: they interleave mid-turn and are not valid
+        # truncation points for ``resume_session_at``.
+        if isinstance(message, (AssistantMessage, UserMessage)):
+            if getattr(message, "parent_tool_use_id", None) is None:
+                entry_uuid = getattr(message, "uuid", None)
+                if entry_uuid:
+                    self._last_entry_uuid = str(entry_uuid)
+        events = translate_message(message)
+        if self._last_entry_uuid:
+            for event in events:
+                if isinstance(event, ev.TurnCompleted):
+                    event.native_turn_id = self._last_entry_uuid
+        return events
 
     async def interrupt(self) -> None:
         await self._sdk.interrupt()

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -2586,9 +2586,14 @@ class AgentEngine:
                             fork_last_turn_id = await self.db.get_native_turn_at_message(
                                 parent_id, fork_msg,
                             )
-                            if parent.get("backend") == "codex" and not fork_last_turn_id:
+                            # Both backends truncate by native turn id now
+                            # (codex: thread/fork lastTurnId; claude:
+                            # --resume-session-at). A message fork without a
+                            # mapping would silently carry the FULL context —
+                            # the opposite of what was asked — so refuse.
+                            if not fork_last_turn_id:
                                 raise ValueError(
-                                    "Cannot fork this Codex session at the selected "
+                                    "Cannot fork this session at the selected "
                                     "message: no native turn mapping is available."
                                 )
 

--- a/nerve/agent/sessions.py
+++ b/nerve/agent/sessions.py
@@ -500,8 +500,15 @@ class SessionManager:
     ) -> dict:
         """Create a forked session from an existing one.
 
-        The fork is a new session that can optionally be linked back to a
-        specific message point in the source session.
+        The fork is a new session that branches the source's *native*
+        conversation (Claude ``--fork-session``, Codex ``thread/fork``) on
+        its first turn — optionally truncated at a specific message point.
+        The source's messages up to that point are copied into the fork so
+        the new chat displays exactly the history the agent remembers.
+
+        Raises ``ValueError`` when the source doesn't exist, has no native
+        conversation yet, or ``at_message_id`` can't be mapped to a native
+        turn (pre-mapping history — see ``get_native_turn_at_message``).
 
         Args:
             source: Override the source field (default: inherit from parent).
@@ -509,6 +516,26 @@ class SessionManager:
         parent = await self.db.get_session(source_session_id)
         if not parent:
             raise ValueError(f"Source session not found: {source_session_id}")
+        if not parent.get("sdk_session_id"):
+            raise ValueError(
+                "Nothing to fork yet — this chat has no agent conversation."
+            )
+
+        # Resolve the fork point up front so a bad anchor fails the API
+        # call, not the fork's first message. The engine re-resolves the
+        # same mapping when it builds the client (source history is
+        # immutable, so both resolutions agree).
+        fork_turn_id: str | None = None
+        if at_message_id is not None:
+            fork_turn_id = await self.db.get_native_turn_at_message(
+                source_session_id, at_message_id,
+            )
+            if not fork_turn_id:
+                raise ValueError(
+                    "Cannot fork at that message: it has no native turn "
+                    "mapping (recorded per turn since this feature shipped). "
+                    "Fork the whole chat instead."
+                )
 
         fork_id = f"fork-{str(uuid.uuid4())[:8]}"
         fork_title = title or f"Fork of {parent.get('title', source_session_id)}"
@@ -522,6 +549,15 @@ class SessionManager:
             backend=parent.get("backend") or "claude",
             model=parent.get("model"),
             cwd=parent.get("cwd"),
+        )
+        copied = await self.db.copy_messages_to_session(
+            source_session_id, fork_id, up_to_native_turn_id=fork_turn_id,
+        )
+        session["message_count"] = copied
+        logger.info(
+            "Forked session %s from %s (%d messages copied%s)",
+            fork_id, source_session_id, copied,
+            f", at turn {fork_turn_id[:12]}" if fork_turn_id else "",
         )
         return session
 

--- a/nerve/db/messages.py
+++ b/nerve/db/messages.py
@@ -107,6 +107,67 @@ class MessageStore:
             row = await cursor.fetchone()
         return str(row[0]) if row else None
 
+    async def copy_messages_to_session(
+        self,
+        source_session_id: str,
+        dest_session_id: str,
+        up_to_native_turn_id: str | None = None,
+    ) -> int:
+        """Copy message rows into a freshly forked session.
+
+        The fork's *native* context is carried by the backend (Claude
+        ``--fork-session`` / Codex ``thread/fork``); these copies exist so
+        the forked chat *displays* the conversation it remembers. Copies
+        keep ``created_at`` (history reads chronologically), ``native_turn_id``
+        (so a fork can itself be forked at a copied message — both backends
+        preserve entry/turn ids across a fork), and get a synthetic
+        ``external_id`` (``forkcopy:<source row id>``) for provenance.
+
+        ``up_to_native_turn_id`` bounds the copy at the assistant row that
+        completed that native turn — the same boundary the backend truncates
+        the native context at, so display and context never disagree.
+        Returns the number of rows copied.
+        """
+        boundary_id: int | None = None
+        if up_to_native_turn_id is not None:
+            async with self.db.execute(
+                """SELECT id FROM messages
+                   WHERE session_id = ? AND native_turn_id = ?
+                   ORDER BY id DESC LIMIT 1""",
+                (source_session_id, up_to_native_turn_id),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if not row:
+                raise ValueError(
+                    f"native turn {up_to_native_turn_id!r} not found in "
+                    f"session {source_session_id}"
+                )
+            boundary_id = int(row[0])
+
+        where = "session_id = ?"
+        params: list = [dest_session_id, source_session_id]
+        if boundary_id is not None:
+            where += " AND id <= ?"
+            params.append(boundary_id)
+
+        async with self._atomic():
+            async with self.db.execute(
+                f"""INSERT INTO messages
+                      (session_id, role, content, thinking, blocks, channel,
+                       external_id, native_turn_id, created_at)
+                    SELECT ?, role, content, thinking, blocks, channel,
+                           'forkcopy:' || id, native_turn_id, created_at
+                    FROM messages WHERE {where} ORDER BY id ASC""",
+                params,
+            ) as cursor:
+                copied = cursor.rowcount or 0
+            if copied:
+                await self.db.execute(
+                    "UPDATE sessions SET message_count = ? WHERE id = ?",
+                    (copied, dest_session_id),
+                )
+        return copied
+
     async def add_message_idempotent(
         self,
         session_id: str,

--- a/nerve/gateway/routes/sessions.py
+++ b/nerve/gateway/routes/sessions.py
@@ -464,6 +464,18 @@ async def update_session(session_id: str, req: dict, user: dict = Depends(requir
                 )
             if await _would_create_cycle(deps.db, session_id, new_parent):
                 raise HTTPException(status_code=400, detail="That drop would create a cycle")
+        elif (
+            session.get("status") == "created"
+            and session.get("parent_session_id")
+        ):
+            # Symmetric fork-window guard: clearing the parent of a
+            # not-yet-started fork would silently discard the fork context
+            # its first turn is about to branch from.
+            raise HTTPException(
+                status_code=409,
+                detail="This fork hasn't started yet — send its first "
+                       "message before un-nesting it",
+            )
         fields["parent_session_id"] = new_parent
     if not fields:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -573,7 +585,13 @@ async def session_status(session_id: str, user: dict = Depends(require_auth)):
 
 @router.post("/api/sessions/fork")
 async def fork_session(req: ForkRequest, user: dict = Depends(require_auth)):
-    """Fork a session, optionally from a specific message."""
+    """Fork a session, optionally from a specific message.
+
+    The fork branches the source's native conversation on its first turn
+    and starts pre-populated with the source's messages up to the fork
+    point. 404 = unknown source; 409 = source not forkable (no native
+    conversation yet, or the anchor message has no native turn mapping).
+    """
     deps = get_deps()
     try:
         fork = await deps.engine.fork_session(
@@ -581,7 +599,8 @@ async def fork_session(req: ForkRequest, user: dict = Depends(require_auth)):
         )
         return fork
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        status = 404 if "not found" in str(e).lower() else 409
+        raise HTTPException(status_code=status, detail=str(e))
 
 
 # "Run later" — defer a prompt without spending tokens now. The three timed

--- a/tests/test_codex_integrity.py
+++ b/tests/test_codex_integrity.py
@@ -41,12 +41,17 @@ async def test_fork_inherits_backend_model_and_cwd(db, tmp_path):
     await db.create_session(
         "parent", backend="codex", model="gpt-test", cwd=str(tmp_path),
     )
-    fork = await manager.fork_session("parent", at_message_id="7")
+    await db.update_session_fields("parent", {"sdk_session_id": "thread-p"})
+    await db.add_message("parent", "user", "q")
+    anchor = await db.add_message(
+        "parent", "assistant", "a", native_turn_id="turn-1",
+    )
+    fork = await manager.fork_session("parent", at_message_id=str(anchor))
     row = await db.get_session(fork["id"])
     assert row["backend"] == "codex"
     assert row["model"] == "gpt-test"
     assert row["cwd"] == str(tmp_path)
-    assert row["forked_from_message"] == "7"
+    assert row["forked_from_message"] == str(anchor)
 
 
 async def test_native_turn_lookup_and_thread_mapping(db):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, UserMessage
 
 from nerve.agent.backends import events as ev
 from nerve.agent.backends.base import SessionSpec, TransportDiedError
@@ -245,6 +245,71 @@ async def test_receive_turn_raises_on_idle_timeout():
     assert seen == _translated(messages)
     # The underlying iterator was closed before the exception propagated.
     assert sdk.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_receive_turn_captures_fork_anchor_uuid():
+    """The turn's TurnCompleted carries the last MAIN-CHAIN transcript-entry
+    uuid as native_turn_id — the ``resume_session_at`` fork anchor. Sidechain
+    (subagent) entries and uuid-less messages must not win."""
+    messages = [
+        AssistantMessage(content=[TextBlock(text="a")], model="m", uuid="uuid-1"),
+        # Sidechain entry arrives later but is not a valid truncation point.
+        AssistantMessage(
+            content=[TextBlock(text="sub")], model="m",
+            uuid="uuid-side", parent_tool_use_id="tool-1",
+        ),
+        AssistantMessage(content=[TextBlock(text="b")], model="m", uuid="uuid-2"),
+        # End-turn tool shape: the kept turn can close on a user entry.
+        UserMessage(content=[], uuid="uuid-3"),
+        _result_msg(),
+    ]
+    sdk = _StubClient(messages)
+    client = _turn_client(sdk, "sess-fork", idle_timeout=5.0)
+    completed = [
+        e async for e in client.receive_turn()
+        if isinstance(e, ev.TurnCompleted)
+    ]
+    assert len(completed) == 1
+    assert completed[0].native_turn_id == "uuid-3"
+
+
+@pytest.mark.asyncio
+async def test_start_turn_resets_fork_anchor():
+    """A new turn must not inherit the previous turn's anchor uuid."""
+
+    class _QueryStub:
+        async def query(self, *_a, **_k):
+            return None
+
+    client = _turn_client(_StubClient([]), "sess-reset", idle_timeout=5.0)
+    client._last_entry_uuid = "stale-uuid"
+    client._sdk = _QueryStub()
+    from nerve.agent.backends.base import TurnInput
+    await client.start_turn(TurnInput(text="hi"))
+    assert client._last_entry_uuid is None
+
+
+def test_claude_options_pass_resume_session_at_only_for_forks(tmp_path):
+    """fork_last_turn_id maps to resume_session_at, gated on spec.fork —
+    without fork_session the flag would truncate the ORIGINAL session."""
+    cfg = NerveConfig.from_dict({"workspace": str(tmp_path)})
+    backend = ClaudeBackend(SimpleNamespace(
+        config=lambda: cfg,
+        claude_plugins=lambda: [],
+    ))
+    base = dict(
+        session_id="fork-opts", source="web", model=cfg.agent.model,
+        effort="high", system_prompt="p", cwd=str(tmp_path),
+        resume_native_id="native-1", fork_last_turn_id="uuid-9",
+    )
+    with patch.object(backend, "_build_mcp_servers", return_value={}), \
+         patch.object(backend, "_build_hooks", return_value={}):
+        forked = backend._build_options(SessionSpec(**base, fork=True))
+        plain = backend._build_options(SessionSpec(**base, fork=False))
+    assert forked.fork_session is True
+    assert forked.resume_session_at == "uuid-9"
+    assert plain.resume_session_at is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -341,26 +341,91 @@ class TestRunningState:
 class TestFork:
     """Test session forking."""
 
+    @staticmethod
+    async def _seed_turns(db: Database, session_id: str, turns: int = 2) -> list[dict]:
+        """Write `turns` user/assistant pairs; assistant rows carry a
+        native_turn_id (like a real completed turn). Returns row info."""
+        rows = []
+        for n in range(1, turns + 1):
+            uid = await db.add_message(session_id, "user", f"prompt {n}")
+            aid = await db.add_message(
+                session_id, "assistant", f"answer {n}",
+                native_turn_id=f"turn-{n}",
+            )
+            rows.append({"user_id": uid, "assistant_id": aid, "turn": f"turn-{n}"})
+        return rows
+
     async def test_fork_session(self, sm: SessionManager, db: Database):
         await sm.get_or_create("source-1", title="Source")
+        await sm.mark_active("source-1", sdk_session_id="sdk-src-1")
         fork = await sm.fork_session("source-1", title="My Fork")
         assert fork["id"].startswith("fork-")
         assert fork["parent_session_id"] == "source-1"
         assert fork["title"] == "My Fork"
 
-    async def test_fork_with_message_id(self, sm: SessionManager, db: Database):
+    async def test_fork_copies_all_messages(self, sm: SessionManager, db: Database):
         await sm.get_or_create("source-2")
-        fork = await sm.fork_session("source-2", at_message_id="msg-42")
+        await sm.mark_active("source-2", sdk_session_id="sdk-src-2")
+        await self._seed_turns(db, "source-2", turns=2)
+        fork = await sm.fork_session("source-2")
+        assert fork["message_count"] == 4
+        msgs = await db.get_messages(fork["id"])
+        assert [m["content"] for m in msgs] == [
+            "prompt 1", "answer 1", "prompt 2", "answer 2",
+        ]
+        # Provenance + native anchors survive the copy (re-forkable).
+        assert all(m["external_id"].startswith("forkcopy:") for m in msgs)
+        assert msgs[1]["native_turn_id"] == "turn-1"
+        assert msgs[3]["native_turn_id"] == "turn-2"
+
+    async def test_fork_at_message_truncates_copy(self, sm: SessionManager, db: Database):
+        await sm.get_or_create("source-3")
+        await sm.mark_active("source-3", sdk_session_id="sdk-src-3")
+        rows = await self._seed_turns(db, "source-3", turns=3)
+        # Anchor at turn 2's assistant row: keep turns 1-2, drop turn 3.
+        anchor = rows[1]["assistant_id"]
+        fork = await sm.fork_session("source-3", at_message_id=str(anchor))
         session = await db.get_session(fork["id"])
-        assert session["forked_from_message"] == "msg-42"
+        assert session["forked_from_message"] == str(anchor)
+        msgs = await db.get_messages(fork["id"])
+        assert [m["content"] for m in msgs] == [
+            "prompt 1", "answer 1", "prompt 2", "answer 2",
+        ]
+
+    async def test_fork_at_user_message_keeps_its_turn(self, sm: SessionManager, db: Database):
+        """Anchoring at a user prompt keeps that prompt's full turn (the
+        native fork points are turn boundaries)."""
+        await sm.get_or_create("source-4")
+        await sm.mark_active("source-4", sdk_session_id="sdk-src-4")
+        rows = await self._seed_turns(db, "source-4", turns=2)
+        fork = await sm.fork_session(
+            "source-4", at_message_id=str(rows[0]["user_id"]),
+        )
+        msgs = await db.get_messages(fork["id"])
+        assert [m["content"] for m in msgs] == ["prompt 1", "answer 1"]
+
+    async def test_fork_at_unmapped_message_raises(self, sm: SessionManager, db: Database):
+        """A source with no native turn mappings can't be message-forked."""
+        await sm.get_or_create("source-5")
+        await sm.mark_active("source-5", sdk_session_id="sdk-src-5")
+        mid = await db.add_message("source-5", "user", "hello")
+        await db.add_message("source-5", "assistant", "hi")  # no native_turn_id
+        with pytest.raises(ValueError, match="native turn mapping"):
+            await sm.fork_session("source-5", at_message_id=str(mid))
+
+    async def test_fork_without_native_conversation_raises(self, sm: SessionManager):
+        await sm.get_or_create("source-6", title="Fresh")
+        with pytest.raises(ValueError, match="[Nn]othing to fork"):
+            await sm.fork_session("source-6")
 
     async def test_fork_nonexistent_raises(self, sm: SessionManager):
         with pytest.raises(ValueError, match="not found"):
             await sm.fork_session("nonexistent")
 
     async def test_fork_auto_title(self, sm: SessionManager):
-        await sm.get_or_create("source-3", title="Original")
-        fork = await sm.fork_session("source-3")
+        await sm.get_or_create("source-7", title="Original")
+        await sm.mark_active("source-7", sdk_session_id="sdk-src-7")
+        fork = await sm.fork_session("source-7")
         assert "Fork of Original" in fork["title"]
 
 

--- a/web/src/components/Chat/AssistantMessage.tsx
+++ b/web/src/components/Chat/AssistantMessage.tsx
@@ -1,9 +1,14 @@
+import type { ReactNode } from 'react';
 import { Repeat } from '../ui/icons';
 import type { ChatMessage } from '../../types/chat';
 import { BlockRenderer } from './BlockRenderer';
 import { formatMessageTime } from '../../utils/messageTime';
 
-export function AssistantMessage({ message }: { message: ChatMessage }) {
+export function AssistantMessage({ message, actions }: {
+  message: ChatMessage;
+  /** Hover toolbar (MessageActions) — anchored to the reading column. */
+  actions?: ReactNode;
+}) {
   // Review-loop milestones are controller-written system entries, not the
   // session's assistant speaking — render them as compact tagged cards.
   if (message.channel === 'review-loop') {
@@ -21,8 +26,9 @@ export function AssistantMessage({ message }: { message: ChatMessage }) {
     );
   }
   return (
-    <div className="py-4 px-5 msg-assistant" data-role="assistant">
-      <div className="max-w-[var(--chat-width)] mx-auto">
+    <div className="py-4 px-5 msg-assistant group/msg" data-role="assistant">
+      <div className="max-w-[var(--chat-width)] mx-auto relative">
+        {actions}
         <div className="flex gap-3">
           <div className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium shrink-0 mt-0.5 bg-accent/20 text-accent">
             N

--- a/web/src/components/Chat/MessageActions.tsx
+++ b/web/src/components/Chat/MessageActions.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, Copy, GitBranch } from '../ui/icons';
+import { copyToClipboard } from '../../utils/clipboard';
+import { messageText } from '../../utils/messageText';
+import type { ChatMessage } from '../../types/chat';
+
+/**
+ * Hover-revealed per-message toolbar (Slack-style: floats at the message's
+ * top-right, so it never shifts the transcript layout).
+ *
+ * Revealed by the `group/msg` on the message root — `opacity-0` at rest,
+ * visible on row hover and while focused (keyboard users tab into it).
+ * Hidden below `md`: there is no hover on touch, and a persistent toolbar
+ * per message would be noise.
+ */
+export function MessageActions({ message, onFork }: {
+  message: ChatMessage;
+  /** Present only when this message is a valid fork anchor. */
+  onFork?: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+  }, []);
+
+  const text = messageText(message);
+
+  const handleCopy = async () => {
+    if (!text) return;
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
+    setCopied(true);
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => setCopied(false), 1500);
+  };
+
+  if (!text && !onFork) return null;
+
+  return (
+    <div
+      className="absolute -top-2.5 right-0 z-10 hidden md:flex items-center gap-0.5
+                 rounded-lg border border-border-subtle bg-surface-raised shadow-md p-0.5
+                 opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100 transition-opacity"
+    >
+      {text && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          title="Copy message"
+          aria-label="Copy message"
+          className="p-1.5 rounded-md text-text-faint hover:text-text-secondary hover:bg-surface-hover cursor-pointer transition-colors"
+        >
+          {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+        </button>
+      )}
+      {onFork && (
+        <button
+          type="button"
+          onClick={onFork}
+          title="Fork chat from here — branch a new chat that remembers the conversation up to this point"
+          aria-label="Fork chat from here"
+          className="p-1.5 rounded-md text-text-faint hover:text-hue-violet hover:bg-surface-hover cursor-pointer transition-colors"
+        >
+          <GitBranch size={13} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Chat/MessageList.tsx
+++ b/web/src/components/Chat/MessageList.tsx
@@ -1,19 +1,32 @@
 import { useEffect, useRef, useCallback, memo } from 'react';
+import { Link } from 'react-router-dom';
 import type { ChatMessage, MessageBlock } from '../../types/chat';
 import { UserMessage } from './UserMessage';
 import { AssistantMessage } from './AssistantMessage';
 import { StreamingMessage } from './StreamingMessage';
 import { SelectionToolbar } from './SelectionToolbar';
+import { MessageActions } from './MessageActions';
+import { GitBranch } from '../ui/icons';
 
-function MessageListImpl({ messages, streamingBlocks, isStreaming }: {
+function MessageListImpl({ messages, streamingBlocks, isStreaming, onForkMessage, messageForks }: {
   messages: ChatMessage[];
   streamingBlocks: MessageBlock[];
   isStreaming: boolean;
+  /** Fork the chat from a specific message (undefined = feature unavailable
+      for this session, e.g. a virtual chat). */
+  onForkMessage?: (messageId: number) => void;
+  /** Existing forks of this session keyed by their anchor message id —
+      renders a "branched here" pill under those messages. */
+  messageForks?: Map<string, { id: string; title: string }[]>;
 }) {
   const endRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const isNearBottom = useRef(true);
   const prevMessageCount = useRef(0);
+
+  // A message-anchored fork resolves to a backend-native turn; sessions
+  // predating turn recording can only be forked whole (header action).
+  const hasForkAnchors = messages.some(m => m.native_turn_id != null);
 
   const handleScroll = useCallback(() => {
     const el = containerRef.current;
@@ -42,14 +55,47 @@ function MessageListImpl({ messages, streamingBlocks, isStreaming }: {
         </div>
       )}
 
-      {messages.map((msg, i) => (
-        <div key={msg.id ?? i}>
-          {msg.role === 'user'
-            ? <UserMessage message={msg} />
-            : <AssistantMessage message={msg} />
-          }
-        </div>
-      ))}
+      {messages.map((msg, i) => {
+        // "Fork from here" needs a persisted row id (live-streamed messages
+        // gain one on the next reload) and at least one native turn mapping
+        // in the transcript to anchor the branch to.
+        const canFork = !!onForkMessage && msg.id != null && hasForkAnchors
+          && msg.channel !== 'review-loop';
+        const actions = msg.channel === 'review-loop' ? undefined : (
+          <MessageActions
+            message={msg}
+            onFork={canFork ? () => onForkMessage!(msg.id!) : undefined}
+          />
+        );
+        const forks = msg.id != null ? messageForks?.get(String(msg.id)) : undefined;
+        return (
+          <div key={msg.id ?? i}>
+            {msg.role === 'user'
+              ? <UserMessage message={msg} actions={actions} />
+              : <AssistantMessage message={msg} actions={actions} />
+            }
+            {forks && forks.length > 0 && (
+              <div className="px-5 -mt-2 pb-2">
+                <div className="max-w-[var(--chat-width)] mx-auto pl-10 flex flex-wrap gap-1.5">
+                  {forks.map(f => (
+                    <Link
+                      key={f.id}
+                      to={`/chat/${f.id}`}
+                      title={`Open fork: ${f.title}`}
+                      className="inline-flex items-center gap-1 max-w-[280px] px-2 py-0.5 rounded-full
+                                 border border-hue-violet/25 bg-hue-violet/10 text-2xs text-hue-violet
+                                 no-underline hover:bg-hue-violet/20 transition-colors"
+                    >
+                      <GitBranch size={10} className="shrink-0" />
+                      <span className="truncate">{f.title}</span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
 
       {isStreaming && <StreamingMessage blocks={streamingBlocks} />}
 

--- a/web/src/components/Chat/SessionSidebar.tsx
+++ b/web/src/components/Chat/SessionSidebar.tsx
@@ -1,12 +1,13 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
-import { Plus, X, MessageSquare, ChevronRight, ChevronDown, Bot, Loader2, Search, Hammer, MoreHorizontal, Star, StarFilled, Pencil, Trash2, Archive, ArchiveRestore, Repeat, Unlink } from '../ui/icons';
+import { Link, useNavigate } from 'react-router-dom';
+import { Plus, X, MessageSquare, ChevronRight, ChevronDown, Bot, Loader2, Search, Hammer, MoreHorizontal, Star, StarFilled, Pencil, Trash2, Archive, ArchiveRestore, Repeat, Unlink, GitBranch } from '../ui/icons';
 import { Button, IconButton, TextField } from '../ui';
 import type { Session, AgentStatus } from '../../types/chat';
 import { groupByDate, parseTimestamp, loadCollapsedGroups, saveCollapsedGroups, loadExpandedParents, saveExpandedParents } from '../../utils/dateGroups';
 import { useChatStore } from '../../stores/chatStore';
 import { useModalSurface } from '../../hooks/useModalSurface';
 import { safeAreaInsets } from '../../utils/safeArea';
+import { forkChat } from '../../utils/forkChat';
 
 /** Strip leading '#' and 'Implement: ' prefixes from generated titles. */
 function cleanTitle(session: Session): string {
@@ -1062,6 +1063,7 @@ function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggl
   const [renameValue, setRenameValue] = useState('');
   const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
   // Unsent draft for this chat (hidden on the active one — its text is in the box).
   const hasDraft = useChatStore(s => !!(s.drafts[session.id] || '').trim());
   // Unread = updated since you last opened it (client-only, see readStorage).
@@ -1163,6 +1165,8 @@ function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggl
         <Repeat size={13} className={`shrink-0 ${reviewLoopIconTone(session.review_loop.status)}`} />
       ) : isImplementSession(session) ? (
         <Hammer size={13} className="shrink-0 text-hue-cyan/70" />
+      ) : session.id.startsWith('fork-') ? (
+        <GitBranch size={13} className="shrink-0 text-hue-violet/70" />
       ) : (
         <MessageSquare size={13} className="shrink-0 opacity-50" />
       )}
@@ -1316,6 +1320,28 @@ function SessionItem({ session, isActive, isRunning, onDelete, onRename, onToggl
               >
                 <Unlink size={14} />
                 Remove from parent
+              </Button>
+            )}
+            {/* Forkable = has a native conversation to branch (materializes
+                after the first completed turn). Self-contained: fork, then
+                jump into the new chat. */}
+            {session.sdk_session_id && (
+              <Button
+                variant="subtle"
+                size="sm"
+                fullWidth
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setMenuOpen(false);
+                  void forkChat(session.id).then((forkId) => {
+                    if (forkId) navigate(`/chat/${forkId}`);
+                  });
+                }}
+                className="justify-start gap-2.5 px-3 py-1.5 rounded-none text-left"
+              >
+                <GitBranch size={14} />
+                Fork
               </Button>
             )}
             <div className="border-t border-border my-1" />

--- a/web/src/components/Chat/UserMessage.tsx
+++ b/web/src/components/Chat/UserMessage.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { ChatMessage, ImageBlockData, FileBlockData } from '../../types/chat';
 import { Download, FileText } from '../ui/icons';
 import { getToken } from '../../api/client';
@@ -9,14 +10,19 @@ function authUrl(url: string): string {
   return `${url}${url.includes('?') ? '&' : '?'}token=${token}`;
 }
 
-export function UserMessage({ message }: { message: ChatMessage }) {
+export function UserMessage({ message, actions }: {
+  message: ChatMessage;
+  /** Hover toolbar (MessageActions) — anchored to the reading column. */
+  actions?: ReactNode;
+}) {
   const text = message.blocks.find(b => b.type === 'text')?.content || '';
   const images = message.blocks.filter(b => b.type === 'image') as ImageBlockData[];
   const files = message.blocks.filter(b => b.type === 'file') as FileBlockData[];
 
   return (
-    <div className="py-4 px-5 msg-user" data-role="user">
-      <div className="max-w-[var(--chat-width)] mx-auto">
+    <div className="py-4 px-5 msg-user group/msg" data-role="user">
+      <div className="max-w-[var(--chat-width)] mx-auto relative">
+        {actions}
         <div className="flex gap-3">
           <div className="w-7 h-7 rounded-full bg-surface-raised flex items-center justify-center text-xs font-medium text-text-muted shrink-0 mt-0.5">
             U

--- a/web/src/components/ShortcutsModal.tsx
+++ b/web/src/components/ShortcutsModal.tsx
@@ -41,6 +41,7 @@ const SECTIONS: Section[] = [
       { combo: { mod: true, shift: true, key: 's' }, description: 'Toggle session sidebar' },
       { combo: { mod: true, shift: true, key: ';' }, description: 'Focus message input' },
       { combo: { mod: true, shift: true, key: 'c' }, description: 'Copy last response' },
+      { combo: { mod: true, shift: true, key: 'f' }, description: 'Fork this chat' },
       { combo: { mod: true, shift: true, key: 'Backspace' }, description: 'Delete current conversation' },
       { combo: { mod: true, key: '\\' }, description: 'Toggle side panel' },
     ],

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { useChatStore } from '../stores/chatStore';
 import { SessionSidebar } from '../components/Chat/SessionSidebar';
 import { MessageList } from '../components/Chat/MessageList';
@@ -12,13 +12,14 @@ import { SidePanel } from '../components/Chat/SidePanel';
 import { ChatWidthHandle } from '../components/Chat/ChatWidthHandle';
 import { BackgroundJobs } from '../components/Chat/BackgroundJobs';
 import { ReviewLoopCard } from '../components/Chat/ReviewLoopCard';
-import { Loader2, Files, ExternalLink } from '../components/ui/icons';
+import { Loader2, Files, ExternalLink, GitBranch } from '../components/ui/icons';
 import { Button, PaneToggle } from '../components/ui';
 import { api } from '../api/client';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { useIsMobile } from '../hooks/useMediaQuery';
 import type { ShortcutDef } from '../utils/keyboard';
 import { copyToClipboard } from '../utils/clipboard';
+import { forkChat } from '../utils/forkChat';
 import { findSessionById } from '../utils/findSession';
 import type { ChatMessage, TextBlockData } from '../types/chat';
 
@@ -55,6 +56,24 @@ export function ChatPage() {
   // The active session row may live in the feed or a lazy archived/system group.
   const activeSessionRow = findSessionById(activeSession, sessions, archivedSessions, systemSessions);
 
+  // Forks of THIS chat keyed by their anchor message — MessageList marks the
+  // divergence points with a pill. Memoized so the memo'd list doesn't
+  // re-render on unrelated store churn.
+  const messageForks = useMemo(() => {
+    const map = new Map<string, { id: string; title: string }[]>();
+    for (const s of sessions) {
+      if (s.parent_session_id !== activeSession) continue;
+      if (!s.forked_from_message || !s.id.startsWith('fork-')) continue;
+      const arr = map.get(s.forked_from_message) ?? [];
+      arr.push({ id: s.id, title: s.title || s.id });
+      map.set(s.forked_from_message, arr);
+    }
+    return map.size > 0 ? map : undefined;
+  }, [sessions, activeSession]);
+
+  // Forkable = a real session with a native conversation to branch from.
+  const canForkSession = !!activeSessionRow?.sdk_session_id;
+
   // Below `md` the session list becomes an off-canvas drawer. Its open state is
   // deliberately NOT `sidebarCollapsed`: that one is a persisted desktop
   // preference (default: expanded), and reusing it would both pop the drawer
@@ -83,6 +102,20 @@ export function ChatPage() {
     previousSession.current = activeSession;
     if (switched) setMobileSidebarOpen(false);
   }, [activeSession, setMobileSidebarOpen]);
+
+  // Fork the active chat — optionally from a specific message. The fork is
+  // a real server session immediately; jump into it (push, not replace, so
+  // Back returns to the source chat).
+  const handleFork = useCallback(async (atMessageId?: number) => {
+    const { activeSession: source, virtualSession: virt } = useChatStore.getState();
+    if (!source || virt?.id === source) return; // nothing to fork in a new chat
+    const forkId = await forkChat(source, atMessageId);
+    if (forkId) navigate(`/chat/${forkId}`);
+  }, [navigate]);
+
+  const handleForkMessage = useCallback((messageId: number) => {
+    void handleFork(messageId);
+  }, [handleFork]);
 
   // Chat-scoped keyboard shortcuts. Global ones (new chat, search, modal,
   // Esc cascade) live in <GlobalShortcuts /> in App.tsx.
@@ -125,6 +158,13 @@ export function ChatPage() {
       },
     },
     {
+      id: 'chat-fork',
+      combo: { mod: true, shift: true, key: 'f' },
+      description: 'Fork this chat',
+      section: 'chat',
+      action: () => { void handleFork(); },
+    },
+    {
       id: 'chat-delete-current',
       combo: { mod: true, shift: true, key: 'Backspace' },
       description: 'Delete current conversation',
@@ -137,7 +177,7 @@ export function ChatPage() {
         }
       },
     },
-  ], []);
+  ], [handleFork]);
 
   useKeyboardShortcuts(chatShortcuts);
 
@@ -342,6 +382,17 @@ export function ChatPage() {
                 activeSession={activeSession}
                 onSelect={switchSession}
               />
+              {canForkSession && (
+                <Button
+                  variant="subtle"
+                  size="xs"
+                  onClick={() => void handleFork()}
+                  title="Fork this chat — branch a new chat that shares this conversation (⌘⇧F)"
+                >
+                  <GitBranch size={14} />
+                  <span className="hidden lg:inline">Fork</span>
+                </Button>
+              )}
               {/* House convention for a tinted action: the identity hue rides
                   the icon and the label stays neutral, so nothing competes
                   with `subtle`'s own text colour. */}
@@ -371,6 +422,36 @@ export function ChatPage() {
             </div>
           </div>
 
+          {/* Fork provenance strip — orients a freshly opened fork: where it
+              branched from, one click back to the source. */}
+          {activeSessionRow?.id.startsWith('fork-') && (() => {
+            const parentId = activeSessionRow.parent_session_id;
+            const parentRow = parentId
+              ? findSessionById(parentId, sessions, archivedSessions, systemSessions)
+              : undefined;
+            return (
+              <div className="border-b border-border-subtle bg-hue-violet/[0.06] px-3 md:px-5 py-1.5 flex items-center gap-1.5 text-xs text-text-muted shrink-0">
+                <GitBranch size={12} className="text-hue-violet shrink-0" />
+                {parentRow ? (
+                  <>
+                    <span className="shrink-0">Forked from</span>
+                    <Link
+                      to={`/chat/${parentRow.id}`}
+                      className="truncate text-text-secondary hover:text-text underline-offset-2 hover:underline"
+                    >
+                      {parentRow.title || parentRow.id}
+                    </Link>
+                  </>
+                ) : (
+                  <span>Forked from another chat</span>
+                )}
+                {activeSessionRow.forked_from_message && (
+                  <span className="shrink-0 text-text-faint">· branched mid-conversation</span>
+                )}
+              </div>
+            );
+          })()}
+
           {/* Review-loop dashboard — sticky above the transcript for
               observer sessions: live criteria, attempt timeline with
               watch-the-leg jumps, inline decisions when parked. */}
@@ -390,6 +471,8 @@ export function ChatPage() {
                 messages={messages}
                 streamingBlocks={streamingBlocks}
                 isStreaming={isStreaming}
+                onForkMessage={canForkSession ? handleForkMessage : undefined}
+                messageForks={messageForks}
               />
             )}
             <ChatWidthHandle />

--- a/web/src/types/chat.ts
+++ b/web/src/types/chat.ts
@@ -98,6 +98,9 @@ export interface ChatMessage {
   blocks: MessageBlock[];
   channel?: string;
   created_at?: string;
+  /** Backend-native turn id recorded on completed assistant rows — the
+      anchor that makes "fork from here" possible at this point. */
+  native_turn_id?: string | null;
 }
 
 export interface Session {
@@ -109,6 +112,9 @@ export interface Session {
   status?: string;
   sdk_session_id?: string;
   parent_session_id?: string;
+  /** Set on message-anchored forks: the source-session message id the
+      fork branched at (whole-chat forks leave it null). */
+  forked_from_message?: string | null;
   connected_at?: string;
   message_count?: number;
   total_cost_usd?: number;

--- a/web/src/utils/forkChat.ts
+++ b/web/src/utils/forkChat.ts
@@ -1,0 +1,38 @@
+import { api } from '../api/client';
+import { useChatStore } from '../stores/chatStore';
+
+/**
+ * Fork a chat (optionally from a specific message) and return the new
+ * session id, or null on failure (after surfacing the reason).
+ *
+ * The fork is a real server session immediately — it branches the source's
+ * native conversation on its first turn and starts pre-populated with the
+ * source's messages up to the fork point. Callers navigate to the returned
+ * id themselves (navigation is router-owned, see ChatPage's URL contract).
+ */
+export async function forkChat(
+  sourceSessionId: string,
+  atMessageId?: number,
+): Promise<string | null> {
+  try {
+    const fork = await api.forkSession(
+      sourceSessionId,
+      atMessageId != null ? String(atMessageId) : undefined,
+    );
+    await useChatStore.getState().loadSessions();
+    return (fork?.id as string) ?? null;
+  } catch (e) {
+    // request() throws Error("<status>: <json body>") — surface the
+    // server's human-readable detail when present.
+    let reason = e instanceof Error ? e.message : String(e);
+    const jsonStart = reason.indexOf('{');
+    if (jsonStart >= 0) {
+      try {
+        const parsed = JSON.parse(reason.slice(jsonStart));
+        if (typeof parsed?.detail === 'string') reason = parsed.detail;
+      } catch { /* keep raw message */ }
+    }
+    window.alert(`Could not fork this chat: ${reason}`);
+    return null;
+  }
+}

--- a/web/src/utils/hydrateMessage.ts
+++ b/web/src/utils/hydrateMessage.ts
@@ -19,6 +19,7 @@ export function hydrateMessage(raw: any): ChatMessage {
       blocks: userBlocks,
       channel: raw.channel,
       created_at: raw.created_at,
+      native_turn_id: raw.native_turn_id,
     };
   }
 
@@ -76,5 +77,6 @@ export function hydrateMessage(raw: any): ChatMessage {
     blocks,
     channel: raw.channel,
     created_at: raw.created_at,
+    native_turn_id: raw.native_turn_id,
   };
 }

--- a/web/src/utils/messageText.ts
+++ b/web/src/utils/messageText.ts
@@ -1,0 +1,9 @@
+import type { ChatMessage, TextBlockData } from '../types/chat';
+
+/** Joined text content of a message (copy action, previews). */
+export function messageText(msg: ChatMessage): string {
+  return msg.blocks
+    .filter((b): b is TextBlockData => b.type === 'text')
+    .map(b => b.content)
+    .join('\n');
+}


### PR DESCRIPTION
## What

A complete **"fork this chat"** feature: branch any conversation into a new independent chat — from its end or from any earlier message — on **both agent backends** (Claude and Codex).

The backend already had fork scaffolding (`POST /api/sessions/fork`, WS `fork`, codex `thread/fork` + `lastTurnId`), but Claude couldn't fork mid-conversation, forks started visually empty, invalid forks failed only on their first message, and **nothing in the UI exposed any of it**.

## Backend

- **Claude mid-point forks**: `ClaudeClient` now records each turn's last main-chain transcript-entry uuid and emits it as `TurnCompleted.native_turn_id` (exact codex parity — same column, same mapping helper). Message-anchored forks pass it as `resume_session_at` alongside `fork_session` (gated on `spec.fork` so it can never truncate the original in place).
- **Display parity**: `fork_session()` copies the source's message rows up to the fork boundary into the fork (`db.copy_messages_to_session`) — the forked chat opens showing exactly the history the agent remembers. Copies keep `created_at` and `native_turn_id` (forks are re-forkable) and get `external_id="forkcopy:<src id>"` for provenance.
- **Fail fast, honestly**: fork requests are validated at the API call (404 unknown source; 409 no native conversation yet / no turn mapping at the anchor) instead of erroring on the fork's first message. The engine-side missing-mapping refusal is now backend-agnostic — a message fork must never silently carry the full context.
- Symmetric fork-window guard in `PATCH /api/sessions/{id}`: un-nesting a not-yet-started fork is refused (it would silently discard the pending fork context).

## UI/UX

- **Hover toolbar on every message** (Slack-style, floats top-right of the reading column, zero layout shift): copy message + **"fork from here"**. The fork action appears only where an anchor exists (`native_turn_id` present in the transcript), so it never promises a branch it can't make.
- **Header "⑂ Fork" button** + `⌘⇧F` — fork the whole chat; shown once the session has a native conversation.
- **Sidebar kebab → Fork** on any loaded session row.
- **Fork provenance banner** in a forked chat — "Forked from _{parent}_", one click back to the source; forks also get a violet branch icon in the sidebar and nest under their source (existing `parent_session_id` nesting).
- **Branch pills at divergence points**: messages that have forks hanging off them show `⑂ <fork title>` pills linking to each branch.
- Post-fork flow: instant fork → navigate into the new chat (push, so Back returns to the source) → copied history + banner orient you immediately.

## Verified

- `pytest tests/` — 3367 passed (new coverage: copy boundaries incl. user-message anchors, unmapped-anchor refusal, no-conversation refusal, claude uuid capture incl. sidechain exclusion, per-turn anchor reset, `resume_session_at` gating).
- `npm run build` + vitest (229 passed; the one failing suite is a pre-existing collection failure on main), eslint clean on touched files.
- **Live E2E probe** of the risky seam with the real Claude CLI: seeded two turns, forked at turn 1's live-captured uuid — the fork recalled turn 1's content and had genuinely dropped turn 2's, in a new session id, source untouched.
- Visual pass in the running UI (header button, hover toolbars, gating on sessions without anchors).

## Notes

- Sessions predating per-turn anchor recording (all existing Claude chats) can be forked **whole**; per-message forks light up as new turns complete. Codex rows have carried `native_turn_id` since v039.
- No schema change — uses the existing `native_turn_id` column and v039 indexes.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*