### PR TITLE
Codex backend: GPT-6 Astra + codex-cli 0.153 support

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -247,7 +247,7 @@ A reload is always explicit. Two things cause one:
 | `telegram.dm_policy`, `.stream_mode` | ✅ read per update. Tightening `open` to `pairing` takes effect on the next message; `allowed_users` does not follow it (see the restart table) |
 | `workflows.*` and `workflows.review_loop.*` — budget caps, concurrency, the warning fraction, iteration and criteria caps, leg engines/models, the verifier sandbox | ✅ read per use, by loops and runs already in flight as well as new ones. The two `enabled` flags and the two loop cadences are the exceptions; see the restart table |
 | `provider.*` and the API keys it selects (`aws_region`, `aws_profile`, `aws_access_key_id`, and the effective Anthropic key) | ✅ for sessions started **after** the reload. Each client's environment is built from the live reference when the session is created, by the same seam as `agent.*` below |
-| **`agent.*` and `codex.*`**: backend choice and models (`agent.backend`, `agent.cron_model`, `agent.model`, `codex.model`, `codex.cron_model`), `max_turns`, `agent.effort`/`cron_effort` and `codex.effort_map`, `agent.thinking`, `agent.context_1m*`, `agent.background_agent_permissions`, `agent.agent_teams`, idle timeouts, cache TTL, `codex.sandbox`, `.approval_policy`, `.web_search`, `.extra_config`, `.tool_timeout_sec`, `.bin_path`, `.auth`/`.api_key`/`.api_key_env`, `.pricing`, `.min_version`/`.max_version`, `.ultracode.*` | ✅ for sessions and turns **started after** the reload. The engine and both backends resolve these through one live reference, so a key cannot be hot in one and frozen in the other |
+| **`agent.*` and `codex.*`**: backend choice and models (`agent.backend`, `agent.cron_model`, `agent.model`, `codex.model`, `codex.cron_model`, `codex.models`), `max_turns`, `agent.effort`/`cron_effort` and `codex.effort_map`, `agent.thinking`, `agent.context_1m*`, `agent.background_agent_permissions`, `agent.agent_teams`, idle timeouts, cache TTL, `codex.sandbox`, `.approval_policy`, `.web_search`, `.extra_config`, `.tool_timeout_sec`, `.bin_path`, `.auth`/`.api_key`/`.api_key_env`, `.pricing`, `.min_version`/`.max_version`, `.ultracode.*` | ✅ for sessions and turns **started after** the reload. The engine and both backends resolve these through one live reference, so a key cannot be hot in one and frozen in the other |
 
 All of that is reloaded together, and the response says what happened to each
 piece: `POST /api/config/reload` returns `ok`, a per-subsystem `detail`, and an
@@ -932,12 +932,13 @@ agent:
   cron_backend: null       # null → backend; new cron/hook sessions only
 
 codex:                     # active when a codex backend is selected
-  bin_path: codex          # tested: >= 0.144.1 and < 0.145.0
-  min_version: 0.144.1
-  max_version: 0.145.0
+  bin_path: codex          # tested: >= 0.153.1 and < 0.154.0
+  min_version: 0.153.1
+  max_version: 0.154.0
   home_dir: ~/.nerve/codex # isolated CODEX_HOME (auth, config, sessions)
   model: gpt-5.6-sol
   cron_model: null         # null → model
+  models: [gpt-6-astra]    # hidden catalog entries to offer when the account serves them
   auth: chatgpt            # chatgpt | api_key
   api_key: null            # config.local.yaml; or api_key_env: OPENAI_API_KEY
   sandbox: danger-full-access   # read-only | workspace-write | danger-full-access
@@ -947,6 +948,7 @@ codex:                     # active when a codex backend is selected
   turn_idle_timeout_seconds: null  # null → agent.cli_idle_timeout_seconds
   pricing:                      # $/1M tokens — cost is None for unlisted models
     gpt-5.6-sol: {input: 5.0, cached_input: 0.5, output: 30.0}
+    gpt-6-astra: {input: 10.0, cached_input: 1.0, output: 50.0}  # >272K-token requests bill more; not modelled
   extra_config: {}              # arbitrary codex -c key=value passthrough
   ultracode:                    # optional managed third-party orchestrator
     enabled: false

--- a/nerve/agent/backends/codex/appserver.py
+++ b/nerve/agent/backends/codex/appserver.py
@@ -11,7 +11,7 @@ as independent asyncio tasks: the reader never blocks, deltas keep
 flowing while an approval is pending, and interrupts stay responsive.
 
 Protocol shapes verified against the schema exported from codex-cli
-0.144.1 (``codex app-server generate-json-schema``); see
+0.153.3 (``codex app-server generate-json-schema``); see
 ``tests/fixtures/codex_schema_meta.json``. Parsing is defensive:
 unknown notifications are debug-logged, unknown server requests get a
 safe response, missing fields never raise.

--- a/nerve/agent/backends/codex/backend.py
+++ b/nerve/agent/backends/codex/backend.py
@@ -113,6 +113,51 @@ def _toml_str(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
+# Reasoning-effort vocabulary shared by nerve's effort_map values and the
+# app-server catalog, weakest first. Used only to clamp a requested effort
+# down to what the serving model advertises.
+_EFFORT_ORDER = ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra")
+
+
+def _catalog_entries(result: dict) -> list[dict]:
+    """The model entries of a ``model/list`` result (defensive)."""
+    models = result.get("data") or result.get("models") or []
+    return [item for item in models if isinstance(item, dict)]
+
+
+def _model_id(item: dict) -> str:
+    return str(item.get("id") or item.get("model") or item.get("slug") or "")
+
+
+def _supported_efforts(item: dict) -> list[str]:
+    """``supportedReasoningEfforts`` as plain strings (empty = unknown)."""
+    out: list[str] = []
+    for entry in item.get("supportedReasoningEfforts") or []:
+        value = entry.get("reasoningEffort") if isinstance(entry, dict) else entry
+        if isinstance(value, str) and value and value not in out:
+            out.append(value)
+    return out
+
+
+def clamp_effort(effort: str | None, supported: list[str]) -> str | None:
+    """Clamp *effort* to the strongest advertised level at or below it.
+
+    The catalog is advisory: an unknown model, an empty list or an effort
+    outside the shared vocabulary passes through untouched and the
+    app-server decides. An entry that advertises only up to ``high`` gets
+    ``high`` for a ``max``/``ultra`` request instead of a failed turn.
+    """
+    if not effort or not supported or effort in supported:
+        return effort
+    if effort not in _EFFORT_ORDER:
+        return effort
+    rank = {name: i for i, name in enumerate(_EFFORT_ORDER)}
+    lower = [s for s in supported if s in rank and rank[s] <= rank[effort]]
+    if not lower:
+        return effort
+    return max(lower, key=lambda s: rank[s])
+
+
 class CodexBackend:
     """OpenAI Codex app-server backend."""
 
@@ -132,6 +177,37 @@ class CodexBackend:
         self._preflight_lock = asyncio.Lock()
         self._live_models: set[str] = set()
         self._rate_limits: dict[str, Any] | None = None
+
+    def catalog(self, entries: list[dict]) -> dict[str, Any]:
+        """Digest a ``model/list`` (``includeHidden``) result.
+
+        ``offered`` feeds the picker: every visible entry plus the configured
+        ``codex.models`` the live catalog actually serves (hidden entries are
+        hidden upstream for a reason — internal previews, reviewers — so they
+        are opt-in by name). ``allowed`` is what a session may run on: the
+        whole catalog, hidden included, plus the configured models
+        unconditionally. ``efforts`` maps model id → advertised reasoning
+        efforts, for clamping turn requests.
+        """
+        visible: list[str] = []
+        all_ids: list[str] = []
+        efforts: dict[str, list[str]] = {}
+        for item in entries:
+            model_id = _model_id(item)
+            if not model_id:
+                continue
+            all_ids.append(model_id)
+            if not item.get("hidden"):
+                visible.append(model_id)
+            efforts[model_id] = _supported_efforts(item)
+        configured = [m for m in (self.codex.models or []) if m]
+        return {
+            "listed": sorted(set(all_ids)),
+            "offered": sorted({*visible, *(m for m in configured if m in all_ids)}),
+            "allowed": sorted({*all_ids, *configured}),
+            "hidden": sorted(set(all_ids) - set(visible)),
+            "efforts": efforts,
+        }
 
     @property
     def config(self):
@@ -171,6 +247,7 @@ class CodexBackend:
         allowed = {
             self.codex.model,
             self.codex.cron_model or self.codex.model,
+            *(self.codex.models or []),
             *(self.codex.pricing or {}).keys(),
             *self._live_models,
         }
@@ -275,7 +352,12 @@ class CodexBackend:
                         raise BackendError(
                             "Codex is not authenticated. To fix: " + self.auth_hint()
                         )
-                    model_result = await transport.request("model/list", {}, timeout=10)
+                    # includeHidden: the catalog omits API-only entries such
+                    # as GPT-6 Astra from the default picker list; nerve
+                    # decides what to offer (see ``catalog``).
+                    model_result = await transport.request(
+                        "model/list", {"includeHidden": True}, timeout=10,
+                    )
                     try:
                         rate_result = await transport.request(
                             "account/rateLimits/read", {}, timeout=10,
@@ -284,17 +366,15 @@ class CodexBackend:
                         rate_result = {}
                 finally:
                     await transport.close()
-                models = model_result.get("data") or model_result.get("models") or []
-                model_ids = sorted({
-                    str(item.get("id") or item.get("model") or item.get("slug"))
-                    for item in models if isinstance(item, dict)
-                    and (item.get("id") or item.get("model") or item.get("slug"))
-                })
-                if model_ids and self.codex.model not in model_ids:
+                catalog = self.catalog(_catalog_entries(model_result))
+                model_ids = catalog["offered"]
+                # An empty catalog (older/odd app-server) skips the check,
+                # as before; a populated one must allow the default model.
+                if catalog["listed"] and self.codex.model not in catalog["allowed"]:
                     raise BackendError(
                         f"Configured Codex model {self.codex.model!r} is unavailable"
                     )
-                self._live_models = set(model_ids)
+                self._live_models = set(catalog["allowed"])
                 rate_limits = rate_result.get("rateLimits")
                 if isinstance(rate_limits, dict):
                     self._rate_limits = rate_limits
@@ -318,6 +398,7 @@ class CodexBackend:
                     ),
                     "account_type": account_type,
                     "models": model_ids or [self.codex.model],
+                    "hidden_models": catalog["hidden"],
                     "default_model": self.codex.model,
                     "rate_limits": self._rate_limits,
                     "ultracode": plugin,
@@ -634,6 +715,9 @@ class CodexClient(AgentClient):
         self._ultracode_priced_worker_count = 0
         self._ultracode_runs: set[str] = set()
         self._effective_auth = "unknown"
+        # model id -> advertised reasoning efforts (from model/list at
+        # connect); empty until then, which leaves efforts unclamped.
+        self._model_efforts: dict[str, list[str]] = {}
 
     # -- protocol --------------------------------------------------------- #
 
@@ -722,25 +806,40 @@ class CodexClient(AgentClient):
         self._thread_id = str(thread_id)
 
     async def _validate_live_model(self) -> None:
-        """Confirm the selected model against the authenticated app-server."""
+        """Confirm the selected model against the authenticated app-server.
+
+        Hidden catalog entries count (GPT-6 Astra is hidden upstream), as
+        do the configured ``codex.models``; the model's advertised
+        reasoning efforts are kept for :meth:`start_turn` to clamp against.
+        """
         try:
-            response = await self._transport.request("model/list", {})
+            response = await self._transport.request(
+                "model/list", {"includeHidden": True},
+            )
         except CodexRpcError as e:
             raise BackendError(
                 f"Codex model discovery failed; the app-server protocol is "
                 f"not compatible: {e}"
             ) from e
-        models = response.get("data") or response.get("models") or []
-        ids = {
-            str(item.get("id") or item.get("model") or item.get("slug"))
-            for item in models if isinstance(item, dict)
-        }
-        ids.discard("")
-        if ids and self.model not in ids:
+        catalog = self._backend.catalog(_catalog_entries(response))
+        self._model_efforts = catalog["efforts"]
+        allowed = catalog["allowed"]
+        if catalog["listed"] and self.model not in allowed:
             raise BackendError(
                 f"Codex model {self.model!r} is unavailable for the current "
-                f"account (available: {sorted(ids)})"
+                f"account (available: {catalog['offered'] or allowed})"
             )
+
+    def turn_effort(self) -> str | None:
+        """The reasoning effort for the next turn, clamped to the model."""
+        effort = self._backend.map_effort(self._spec.effort)
+        clamped = clamp_effort(effort, self._model_efforts.get(self.model) or [])
+        if clamped != effort:
+            logger.info(
+                "Codex model %s does not advertise effort %r; sending %r",
+                self.model, effort, clamped,
+            )
+        return clamped
 
     async def _ensure_auth(self) -> None:
         """Best-effort auth check with a clear operator hint.
@@ -809,7 +908,7 @@ class CodexClient(AgentClient):
             "threadId": self._thread_id,
             "input": self._build_input_items(turn),
         }
-        effort = self._backend.map_effort(self._spec.effort)
+        effort = self.turn_effort()
         if effort:
             params["effort"] = effort
 

--- a/nerve/cli.py
+++ b/nerve/cli.py
@@ -1674,6 +1674,12 @@ def codex_doctor(ctx: click.Context, json_output: bool) -> None:
         if status.get("available"):
             click.echo(f"[OK] {status.get('version')} ({status.get('auth')})")
             click.echo(f"[OK] Models: {', '.join(status.get('models') or [])}")
+            hidden = status.get("hidden_models") or []
+            if hidden:
+                click.echo(
+                    "[--] Hidden catalog entries (opt in via codex.models): "
+                    + ", ".join(hidden)
+                )
             if status.get("auth_mismatch"):
                 click.echo(
                     "[ERR] Codex auth mismatch: configured "

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -2170,11 +2170,37 @@ _CODEX_SANDBOX_MODES = ("read-only", "workspace-write", "danger-full-access")
 
 # $/1M tokens; cached input bills at the discounted rate. Config values
 # under codex.pricing REPLACE entries per model key (dict deep-merge).
+# GPT-6 Astra's long-context tier (requests above 272K input tokens bill
+# 2x input / 1.5x output) is not modelled: the app-server reports usage
+# per turn, not per request, so the threshold cannot be attributed.
 _DEFAULT_CODEX_PRICING: dict[str, dict[str, float]] = {
+    "gpt-6-astra":    {"input": 10.0, "cached_input": 1.0,  "output": 50.0},
     "gpt-5.6-sol":    {"input": 5.0,  "cached_input": 0.5,  "output": 30.0},
     "gpt-5.6-terra":  {"input": 2.5,  "cached_input": 0.25, "output": 15.0},
     "gpt-5.6-luna":   {"input": 1.0,  "cached_input": 0.1,  "output": 6.0},
 }
+
+# Catalog entries the app-server hides from its default ``model/list``
+# (served only with ``includeHidden``) that Nerve still offers in the
+# picker when the authenticated account can reach them. GPT-6 Astra is
+# hidden upstream on purpose (API-key accounts; codex-cli 0.153.1+).
+_DEFAULT_CODEX_MODELS: tuple[str, ...] = ("gpt-6-astra",)
+
+
+def _codex_models(raw: Any) -> list[str]:
+    """``codex.models``: unset → built-in list; ``[]`` → offer none."""
+    if raw is None:
+        return list(_DEFAULT_CODEX_MODELS)
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return list(_DEFAULT_CODEX_MODELS)
+    out: list[str] = []
+    for item in raw:
+        name = str(item or "").strip()
+        if name and name not in out:
+            out.append(name)
+    return out
 
 
 @dataclass
@@ -2245,11 +2271,16 @@ class CodexConfig:
     """
 
     bin_path: str = "codex"                 # PATH-resolved codex binary
-    min_version: str = "0.144.1"            # inclusive tested protocol range
-    max_version: str = "0.145.0"            # exclusive
+    min_version: str = "0.153.1"            # inclusive tested protocol range
+    max_version: str = "0.154.0"            # exclusive
     home_dir: str = field(default_factory=lambda: str(paths.nerve_path("codex")))  # isolated CODEX_HOME (auth/config/sessions)
     model: str = "gpt-5.6-sol"
     cron_model: str = ""                    # empty → model
+    # Hidden catalog models to offer next to the visible ``model/list``
+    # (only when the live catalog serves them). Any model named here is
+    # also always accepted as a session model — the app-server stays the
+    # authority on whether a turn on it succeeds.
+    models: list[str] = field(default_factory=lambda: list(_DEFAULT_CODEX_MODELS))
     auth: str = "chatgpt"                   # chatgpt | api_key
     api_key: str = ""                       # literal key (config.local.yaml)
     api_key_env: str = "OPENAI_API_KEY"     # env fallback when auth=api_key
@@ -2300,13 +2331,14 @@ class CodexConfig:
             effort_map.update({str(k): str(v) for k, v in raw_effort.items()})
         return cls(
             bin_path=str(d.get("bin_path", "codex")),
-            min_version=str(d.get("min_version", "0.144.1")),
-            max_version=str(d.get("max_version", "0.145.0")),
+            min_version=str(d.get("min_version", "0.153.1")),
+            max_version=str(d.get("max_version", "0.154.0")),
             home_dir=_setting_str(
                 d.get("home_dir"), str(paths.nerve_path("codex"))
             ),
             model=str(d.get("model", "gpt-5.6-sol")),
             cron_model=str(d.get("cron_model") or ""),
+            models=_codex_models(d.get("models")),
             auth=str(d.get("auth", "chatgpt")).strip().lower(),
             api_key=str(d.get("api_key") or ""),
             api_key_env=str(d.get("api_key_env", "OPENAI_API_KEY")),

--- a/scripts/check_codex_schema.py
+++ b/scripts/check_codex_schema.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -22,10 +23,13 @@ def canonical_hash(path: Path) -> str:
 
 
 def main() -> int:
+    # Optional argv[1]: the codex binary to check (default: PATH `codex`),
+    # so a downloaded CLI can be verified before it is installed.
+    codex_bin = sys.argv[1] if len(sys.argv) > 1 else "codex"
     meta = json.loads(META_PATH.read_text(encoding="utf-8"))
     with tempfile.TemporaryDirectory(prefix="nerve-codex-schema-") as tmp:
         subprocess.run(
-            ["codex", "app-server", "generate-json-schema", "--out", tmp],
+            [codex_bin, "app-server", "generate-json-schema", "--out", tmp],
             check=True,
         )
         schema_path = Path(tmp) / "codex_app_server_protocol.v2.schemas.json"

--- a/scripts/codex_smoke.py
+++ b/scripts/codex_smoke.py
@@ -46,6 +46,12 @@ def _rss_mb(pid: int) -> float:
 async def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", default=None)
+    parser.add_argument("--effort", default="low", help="nerve effort (default low)")
+    parser.add_argument(
+        "--bin", default="codex",
+        help="codex binary to drive (default: PATH `codex`); handy for "
+             "verifying a freshly downloaded CLI before installing it",
+    )
     parser.add_argument("--home", default=os.path.expanduser("~/.nerve/codex"))
     parser.add_argument("--auth", choices=["chatgpt", "api_key"], default="chatgpt")
     parser.add_argument(
@@ -74,6 +80,7 @@ async def main() -> int:
     cfg = NerveConfig.from_dict({
         "workspace": str(workspace),
         "codex": {
+            "bin_path": args.bin,
             "home_dir": args.home,
             "auth": args.auth,
             **({"api_key": api_key} if api_key else {}),
@@ -95,21 +102,22 @@ async def main() -> int:
         snapshots.append((path, content))
 
     spec = SessionSpec(
-        session_id="smoke", source="web", model=args.model, effort="low",
+        session_id="smoke", source="web", model=args.model, effort=args.effort,
         system_prompt="You are a smoke test. Be terse.",
         cwd=str(workspace), interactive=None, snapshot=snapshot,
         idle_timeout=120.0,
     )
 
-    print(f"→ spawning codex app-server (home={args.home}, auth={args.auth})")
+    print(f"→ spawning codex app-server (bin={args.bin}, home={args.home}, auth={args.auth})")
     client = await backend.create_client(spec)
     proc = client._transport._proc
     print(f"✓ thread started: {client.native_session_id}")
     print(f"  app-server RSS after connect: {_rss_mb(proc.pid):.1f} MB")
+    print(f"  model: {client.model}, effort sent: {client.turn_effort()!r}")
 
-    # Model catalog — diagnostics for picking codex.model.
+    # Model catalog — diagnostics for picking codex.model (hidden included).
     try:
-        models = await client._transport.request("model/list", {})
+        models = await client._transport.request("model/list", {"includeHidden": True})
         ids = [
             m.get("id") or m.get("model") or str(m)
             for m in (models.get("models") or models.get("data") or [])

--- a/tests/fixtures/codex_schema_meta.json
+++ b/tests/fixtures/codex_schema_meta.json
@@ -1,8 +1,8 @@
 {
-  "codex_cli_version": "0.144.1",
+  "codex_cli_version": "0.153.3",
   "generated_with": "codex app-server generate-json-schema",
-  "verified_date": "2026-07-11",
-  "canonical_v2_schema_sha256": "5d8251e1e2f713a3c567c927386f84f2f94692d4721b90d8ff36d0ff92877621",
+  "verified_date": "2026-09-05",
+  "canonical_v2_schema_sha256": "73f9645eb8531f1caaa31b85c59fdd5c2db12cf79928bfb290a672a654fa9a14",
   "required_methods": [
     "initialize",
     "account/read",
@@ -14,5 +14,5 @@
     "turn/start",
     "turn/interrupt"
   ],
-  "notes": "Canonical JSON hash is stable across generator output ordering. Regenerate with scripts/check_codex_schema.py when changing the tested CLI range."
+  "notes": "Canonical JSON hash is stable across generator output ordering. Regenerate with scripts/check_codex_schema.py when changing the tested CLI range. 0.144.1 -> 0.153.3 was purely additive for every method and notification nerve uses (no removed fields; new: model/list includeHidden + Model.hidden/supportedReasoningEfforts, TokenUsageBreakdown.cacheWriteInputTokens)."
 }

--- a/tests/fixtures/fake_codex_appserver.py
+++ b/tests/fixtures/fake_codex_appserver.py
@@ -2,7 +2,7 @@
 """Fake ``codex app-server`` for offline transport/backend tests.
 
 Speaks newline-delimited JSON-RPC 2.0 on stdio, mimicking the surface
-nerve's CodexAppServerClient uses (schema shapes from codex-cli 0.144.1,
+nerve's CodexAppServerClient uses (schema shapes from codex-cli 0.153.3,
 see tests/fixtures/codex_schema_meta.json). Behavior is selected via the
 FAKE_CODEX_MODE env var:
 
@@ -45,7 +45,7 @@ import threading
 import time
 
 if "--version" in sys.argv:
-    print("codex-cli 0.144.1")
+    print("codex-cli 0.153.3")
     raise SystemExit(0)
 
 MODE = os.environ.get("FAKE_CODEX_MODE", "basic")
@@ -306,7 +306,7 @@ def main() -> None:
 
         if method == "initialize":
             respond(req_id, {
-                "userAgent": "fake-codex/0.144.1",
+                "userAgent": "fake-codex/0.153.3",
                 "_fake": {"configOverrides": _config_overrides(),
                           "env": {"CODEX_HOME": os.environ.get("CODEX_HOME", ""),
                                   "NERVE_MCP_TOKEN_SET": bool(os.environ.get("NERVE_MCP_TOKEN"))}},
@@ -319,7 +319,25 @@ def main() -> None:
         elif method == "account/login/start":
             respond(req_id, {"loginId": "fake-login"})
         elif method == "model/list":
-            respond(req_id, {"data": [{"id": "gpt-5.6-sol"}]})
+            # Mirrors the real codex-cli 0.153 catalog shape: GPT-5.6 Sol
+            # and the hidden, API-only GPT-6 Astra both advertise up to
+            # "ultra"; a hidden internal preview stops at "high". Hidden
+            # entries appear only with includeHidden.
+            def _efforts(*names):
+                return [{"reasoningEffort": n} for n in names]
+            full = _efforts("low", "medium", "high", "xhigh", "max", "ultra")
+            catalog = [
+                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "hidden": False,
+                 "supportedReasoningEfforts": full},
+                {"id": "gpt-6-astra", "model": "gpt-6-astra", "hidden": True,
+                 "supportedReasoningEfforts": full},
+                {"id": "fake-internal-preview", "model": "fake-internal-preview",
+                 "hidden": True,
+                 "supportedReasoningEfforts": _efforts("low", "medium", "high")},
+            ]
+            if not (msg.get("params") or {}).get("includeHidden"):
+                catalog = [m for m in catalog if not m["hidden"]]
+            respond(req_id, {"data": catalog})
         elif method == "thread/read":
             if MODE == "resume_auth_fail":
                 respond_error(req_id, 401, "authentication expired")
@@ -343,6 +361,11 @@ def main() -> None:
             thread_id = msg["params"]["threadId"]
             turn_id = f"turn_{threads_started}_1"
             _active_turn.update({"threadId": thread_id, "turnId": turn_id})
+            # Expose the received turn params to tests (effort clamping).
+            home = os.environ.get("CODEX_HOME")
+            if home:
+                with open(os.path.join(home, "last_turn_params.json"), "w") as fh:
+                    json.dump(msg["params"], fh)
             respond(req_id, {"turn": {"id": turn_id, "status": "inProgress",
                                       "items": []}})
             threading.Thread(

--- a/tests/test_codex_appserver.py
+++ b/tests/test_codex_appserver.py
@@ -1,7 +1,7 @@
 """CodexBackend / CodexAppServerClient integration tests.
 
 Driven against ``tests/fixtures/fake_codex_appserver.py`` — a scripted
-stdio JSON-RPC subprocess mimicking codex-cli 0.144.1's app-server
+stdio JSON-RPC subprocess mimicking codex-cli 0.153.3's app-server
 surface. Everything runs offline.
 
 The crown-jewel test is ``test_approval_does_not_block_stream``: the
@@ -14,6 +14,7 @@ synchronously); nerve's asyncio client must not.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from pathlib import Path
 
@@ -129,6 +130,70 @@ async def test_basic_turn_streams_and_completes(tmp_path, monkeypatch):
         assert shaped["input_tokens"] == 200
         assert shaped["cache_read_input_tokens"] == 1000
         assert shaped["cache_creation_input_tokens"] == 0
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_hidden_catalog_models_are_opt_in(tmp_path, monkeypatch):
+    """GPT-6 Astra is hidden upstream (``model/list`` needs includeHidden):
+    it is offered only through ``codex.models`` (the default names it),
+    while every catalog entry — hidden or not — stays a legal session
+    model. The picker never sees the other hidden entries."""
+    _mode(monkeypatch, "account_api_key")
+    cfg = _config(tmp_path, auth="api_key", api_key="sk-fake")
+    backend = CodexBackend(_deps(cfg))
+    status = await backend.preflight(force=True)
+    assert status["available"] is True
+    assert status["models"] == ["gpt-5.6-sol", "gpt-6-astra"]
+    assert status["hidden_models"] == ["fake-internal-preview", "gpt-6-astra"]
+    await backend.validate_model("gpt-6-astra")
+    await backend.validate_model("fake-internal-preview")   # allowed, not offered
+    with pytest.raises(Exception, match="not available"):
+        await backend.validate_model("claude-opus-5")
+
+    client = await backend.create_client(
+        _spec(cfg, model="gpt-6-astra", effort="max"),
+    )
+    try:
+        assert client.model == "gpt-6-astra"
+        await client.start_turn(TurnInput(text="hello"))
+        done = (await _collect_turn(client))[-1]
+        assert isinstance(done, ev.TurnCompleted)
+        assert done.status == "completed"
+        # Astra advertises "ultra" like the 5.6 family — nothing to clamp.
+        sent = json.loads(
+            (tmp_path / "codex-home" / "last_turn_params.json").read_text(),
+        )
+        assert sent["effort"] == "ultra"
+        # API-billed at Astra's rate: 200*10 + 1000*1 + 50*50 = 5500 per 1M
+        assert done.total_cost_usd == pytest.approx(0.0055)
+        assert done.cost_basis == "api_billed"
+    finally:
+        await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_effort_is_clamped_to_the_models_catalog(tmp_path, monkeypatch):
+    _mode(monkeypatch, "basic")
+    cfg = _config(tmp_path, models=[])       # offer no hidden entries ...
+    backend = CodexBackend(_deps(cfg))
+    status = await backend.preflight(force=True)
+    assert status["models"] == ["gpt-5.6-sol"]
+    # ... yet the catalog still allows them, and an entry that only
+    # advertises up to "high" caps the request: nerve "max" → codex
+    # "ultra" → "high", instead of a turn the app-server would reject.
+    client = await backend.create_client(
+        _spec(cfg, model="fake-internal-preview", effort="max"),
+    )
+    try:
+        assert client.turn_effort() == "high"
+        await client.start_turn(TurnInput(text="hello"))
+        await _collect_turn(client)
+        sent = json.loads(
+            (tmp_path / "codex-home" / "last_turn_params.json").read_text(),
+        )
+        assert sent["effort"] == "high"
     finally:
         await client.disconnect()
 

--- a/tests/test_codex_protocol.py
+++ b/tests/test_codex_protocol.py
@@ -8,9 +8,13 @@ import pytest
 
 from nerve.agent.backends import events as ev
 from nerve.agent.backends.base import SessionSpec
-from nerve.agent.backends.codex.backend import CodexBackend, CodexClient
+from nerve.agent.backends.codex.backend import (
+    CodexBackend,
+    CodexClient,
+    clamp_effort,
+)
 from nerve.agent.backends.codex.pricing import compute_cost, match_pricing
-from nerve.config import NerveConfig
+from nerve.config import _DEFAULT_CODEX_PRICING, CodexConfig, NerveConfig
 
 
 def _client(tmp_path, **codex_overrides) -> CodexClient:
@@ -159,6 +163,75 @@ def test_effort_mapping_and_defaults(tmp_path):
     assert backend.map_effort("low") == "minimal"
     assert backend.map_effort("high") == "high"     # default map preserved
     assert backend.map_effort("unknown") is None    # omitted from turn/start
+
+
+def test_default_pricing_covers_gpt_6_astra():
+    assert _DEFAULT_CODEX_PRICING["gpt-6-astra"] == {
+        "input": 10.0, "cached_input": 1.0, "output": 50.0,
+    }
+    usage = ev.NormalizedUsage(
+        input_tokens=1_000_000, output_tokens=1_000_000,
+        cache_read_tokens=1_000_000,
+    )
+    assert compute_cost("gpt-6-astra", usage, _DEFAULT_CODEX_PRICING) == (
+        pytest.approx(10.0 + 1.0 + 50.0)
+    )
+
+
+def test_clamp_effort_uses_the_catalog_as_a_ceiling():
+    full = ["low", "medium", "high", "xhigh", "max", "ultra"]
+    assert clamp_effort("ultra", full) == "ultra"
+    assert clamp_effort("ultra", ["low", "medium", "high"]) == "high"
+    assert clamp_effort("max", ["low", "medium", "high"]) == "high"
+    assert clamp_effort("medium", ["low", "high"]) == "low"
+    assert clamp_effort("low", ["medium", "high"]) == "low"   # nothing lower: as asked
+    assert clamp_effort("ultra", []) == "ultra"               # unknown catalog: advisory
+    assert clamp_effort("turbo", ["low"]) == "turbo"          # outside the vocabulary
+    assert clamp_effort(None, full) is None
+
+
+def test_catalog_offers_visible_plus_configured_hidden(tmp_path):
+    entries = [
+        {"id": "gpt-5.6-sol", "hidden": False, "supportedReasoningEfforts": [
+            {"reasoningEffort": "low"}, {"reasoningEffort": "ultra"},
+        ]},
+        {"id": "gpt-6-astra", "hidden": True, "supportedReasoningEfforts": [
+            {"reasoningEffort": "max"},
+        ]},
+        {"id": "internal-preview", "hidden": True},
+        {"model": "legacy-shape"},          # id-less shape still identifies
+        {"garbage": True},                  # no identifier: ignored
+    ]
+    backend = _client(tmp_path)._backend    # default codex.models: gpt-6-astra
+    cat = backend.catalog(entries)
+    assert cat["listed"] == [
+        "gpt-5.6-sol", "gpt-6-astra", "internal-preview", "legacy-shape",
+    ]
+    assert cat["offered"] == ["gpt-5.6-sol", "gpt-6-astra", "legacy-shape"]
+    assert cat["hidden"] == ["gpt-6-astra", "internal-preview"]
+    assert cat["allowed"] == cat["listed"]
+    assert cat["efforts"]["gpt-5.6-sol"] == ["low", "ultra"]
+    assert cat["efforts"]["internal-preview"] == []
+
+    # A configured model the catalog does not serve is allowed, never offered.
+    backend = _client(tmp_path, models=["gpt-6-astra", "gpt-7-preview"])._backend
+    cat = backend.catalog(entries[:1])
+    assert cat["offered"] == ["gpt-5.6-sol"]
+    assert cat["allowed"] == ["gpt-5.6-sol", "gpt-6-astra", "gpt-7-preview"]
+    # models: [] opts out of every hidden entry.
+    cat = _client(tmp_path, models=[])._backend.catalog(entries)
+    assert cat["offered"] == ["gpt-5.6-sol", "legacy-shape"]
+    # An empty catalog lists nothing — callers then skip model validation.
+    assert backend.catalog([])["listed"] == []
+
+
+def test_codex_models_config_parsing():
+    assert CodexConfig.from_dict({}).models == ["gpt-6-astra"]
+    assert CodexConfig.from_dict({"models": None}).models == ["gpt-6-astra"]
+    assert CodexConfig.from_dict({"models": []}).models == []
+    assert CodexConfig.from_dict({"models": "gpt-6-astra"}).models == ["gpt-6-astra"]
+    assert CodexConfig.from_dict({"models": ["a", "a", " b ", ""]}).models == ["a", "b"]
+    assert CodexConfig.from_dict({"models": 42}).models == ["gpt-6-astra"]
 
 
 def test_backend_notes_appended_to_developer_instructions(tmp_path):


### PR DESCRIPTION
## What
- Re-pin the Codex app-server contract to codex-cli **0.153.3** (tested range `>=0.153.1,<0.154.0`). The schema diff vs 0.144.1 is purely additive for every method/notification nerve uses (0 removed fields); new canonical hash in `tests/fixtures/codex_schema_meta.json`.
- `model/list` is now requested with `includeHidden: true`. Codex deliberately hides API-only entries such as **gpt-6-astra** from its default picker list; nerve digests the catalog into `offered` (visible entries + the configured `codex.models` the account actually serves), `allowed` (whole catalog + configured models) and per-model advertised reasoning efforts.
- New `codex.models` setting (default `[gpt-6-astra]`; `[]` opts out). Hidden entries are opt-in by name, so internal previews / reviewer models never reach the picker while any catalog entry stays a legal session model.
- Default pricing for `gpt-6-astra` ($10 / $1 cached / $50 per 1M tokens). The >272K-token long-context tier is not modelled (usage arrives per turn, not per request) — documented in code and docs.
- Reasoning effort is clamped to what the serving model's catalog entry advertises: an entry that stops at `high` gets `high` for a `max`/`ultra` request instead of a rejected turn. GPT-5.6 and GPT-6 Astra both advertise up to `ultra`, so nothing changes for them.
- `nerve codex doctor` lists hidden catalog entries; `scripts/check_codex_schema.py [codex-bin]` and `scripts/codex_smoke.py --bin/--effort` can verify a downloaded CLI before it is installed.

## Verification
- `pytest tests/` — 3383 passed.
- `scripts/check_codex_schema.py` → contract OK against 0.153.3 (fails against 0.144.1, as intended).
- `scripts/codex_smoke.py --bin <codex 0.153.3> --auth api_key --model gpt-6-astra --effort max` → real turn completed on `gpt-6-astra`, cost computed from the new pricing entry, clean disconnect.

## Rollout
`min_version` moves to 0.153.1, so upgrade the CLI **before** restarting: `npm i -g @openai/codex@0.153.3`, then `nerve restart`, then `nerve codex doctor` (expect `gpt-6-astra` under Models). Frontend untouched — the picker reads `/api/models`.

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*
