### PR TITLE
fix: preserve Claude terminal outcomes

### DIFF
--- a/nerve/agent/backends/claude.py
+++ b/nerve/agent/backends/claude.py
@@ -208,6 +208,7 @@ def translate_message(message: Any) -> list[ev.AgentEvent]:
             ev.NormalizedUsage.from_anthropic(message.usage)
             if message.usage else None
         )
+        status, error = _result_outcome(message)
         out.append(ev.TurnCompleted(
             native_session_id=message.session_id,
             model=None,  # claude reports the model per AssistantMessage
@@ -218,10 +219,33 @@ def translate_message(message: Any) -> list[ev.AgentEvent]:
             duration_ms=getattr(message, "duration_ms", None),
             duration_api_ms=getattr(message, "duration_api_ms", None),
             num_turns=getattr(message, "num_turns", None),
-            status="completed",
+            status=status,
+            error=error,
         ))
 
     return out
+
+
+def _result_outcome(message: ResultMessage) -> tuple[ev.TurnStatus, str | None]:
+    reason = getattr(message, "terminal_reason", None)
+    if reason in {"aborted_streaming", "aborted_tools"}:
+        return "interrupted", reason.replace("_", " ")
+
+    subtype = getattr(message, "subtype", "")
+    if not getattr(message, "is_error", False) and subtype == "success":
+        return "completed", None
+
+    errors = getattr(message, "errors", None)
+    if errors:
+        detail = "; ".join(errors)
+    elif reason == "max_turns":
+        turns = getattr(message, "num_turns", None)
+        detail = f"max turns ({turns}) exhausted" if turns is not None else "max turns exhausted"
+    elif status := getattr(message, "api_error_status", None):
+        detail = f"API error (HTTP {status})"
+    else:
+        detail = (reason or subtype or "Claude turn failed").replace("_", " ")
+    return "failed", detail
 
 
 def _translate_tool_result(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -202,13 +202,15 @@ def _translated(messages: list) -> list:
     return [event for m in messages for event in translate_message(m)]
 
 
-def _result_msg(session_id: str = "sdk-1") -> ResultMessage:
+def _result_msg(session_id: str = "sdk-1", **overrides) -> ResultMessage:
     """A terminal ResultMessage: translates to one TurnCompleted."""
-    return ResultMessage(
-        subtype="success", duration_ms=1, duration_api_ms=1,
-        is_error=False, num_turns=1, session_id=session_id,
-        total_cost_usd=0.5, usage={"input_tokens": 1},
-    )
+    values = {
+        "subtype": "success", "duration_ms": 1, "duration_api_ms": 1,
+        "is_error": False, "num_turns": 1, "session_id": session_id,
+        "total_cost_usd": 0.5, "usage": {"input_tokens": 1},
+    }
+    values.update(overrides)
+    return ResultMessage(**values)
 
 
 @pytest.mark.asyncio
@@ -410,6 +412,36 @@ async def test_receive_turn_completes_on_result_without_raising():
     assert len(terminal) == 1
     assert terminal[0].status == "completed"
     assert sdk.aclose_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("message", "status", "error"),
+    [
+        (
+            _result_msg(
+                subtype="error_max_turns", is_error=True,
+                terminal_reason="max_turns", num_turns=50,
+            ),
+            "failed",
+            "max turns (50) exhausted",
+        ),
+        (
+            _result_msg(is_error=True, api_error_status=529),
+            "failed",
+            "API error (HTTP 529)",
+        ),
+        (
+            _result_msg(is_error=True, terminal_reason="aborted_streaming"),
+            "interrupted",
+            "aborted streaming",
+        ),
+    ],
+)
+def test_result_message_preserves_abnormal_terminal_state(message, status, error):
+    event = translate_message(message)[0]
+
+    assert isinstance(event, ev.TurnCompleted)
+    assert (event.status, event.error) == (status, error)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #292.

The Claude backend now maps `ResultMessage` terminal signals onto the existing normalized turn states instead of hardcoding every result to `completed`:

- aborted streaming or tool execution becomes `interrupted`
- max-turn, API, and other error results become `failed` with an actionable error
- successful results remain unchanged

This keeps the fix at the translator seam already shared by interactive and autonomous turns.

## Validation

- `tests/test_engine.py`: 91 passed
- Python compile check passed
- Full suite: 3380 passed; 6 existing MemU date tests failed under Asia/Shanghai because a timezone conversion produced the prior UTC date
- The same MemU date group passes under UTC: 11 passed

No engine or persistence changes were needed.