### PR TITLE
Fail open in consumer_has_unread when a consumer has no cursor rows

### DIFF
--- a/nerve/cron/gates.py
+++ b/nerve/cron/gates.py
@@ -145,6 +145,9 @@ class MessagesGate(CronGate):
         # unread messages. Read-only and expiry-agnostic — it never
         # initializes or advances a cursor (unlike get_consumer_cursor) and
         # still sees a backlog after a quiet inbox's cursors pass their TTL.
+        # With zero cursor rows (fresh install, or cursor cleanup after a
+        # quiet stretch) it fails open when any messages exist, so the gated
+        # job can run once and seed the cursors its next evaluations need.
         return await ctx.db.consumer_has_unread(self.consumer)
 
     def describe(self) -> str:

--- a/nerve/db/sources.py
+++ b/nerve/db/sources.py
@@ -407,6 +407,16 @@ class SourceStore:
         Unlike list_consumer_cursors, which hides expired cursors, this keeps
         a run gate from wedging shut when an inbox goes quiet long enough for
         its cursors to expire and then receives new mail.
+
+        Bootstrap fail-open: with *zero* cursor rows, "tracks nothing" would
+        make this permanently False — yet the job a gate blocks on it is the
+        very job whose poll creates the first cursor row, so the gate could
+        never open. A consumer reaches that state two ways: a fresh install,
+        and cleanup_expired_consumer_cursors physically deleting every row
+        after a quiet stretch longer than the cursor TTL. In both cases report
+        unread whenever any messages exist at all, letting the job run once;
+        its poll then seeds cursors at MAX(rowid) (backlog still skipped —
+        delivery semantics unchanged) and the check reverts to cursor-based.
         """
         async with self.db.execute(
             """SELECT 1 FROM consumer_cursors cc
@@ -415,6 +425,17 @@ class SourceStore:
                       WHERE sm.source = cc.source) > cc.cursor_seq
                LIMIT 1""",
             (consumer,),
+        ) as cursor:
+            if await cursor.fetchone() is not None:
+                return True
+        async with self.db.execute(
+            "SELECT 1 FROM consumer_cursors WHERE consumer = ? LIMIT 1",
+            (consumer,),
+        ) as cursor:
+            if await cursor.fetchone() is not None:
+                return False
+        async with self.db.execute(
+            "SELECT 1 FROM source_messages LIMIT 1"
         ) as cursor:
             return await cursor.fetchone() is not None
 

--- a/tests/test_cron_gates.py
+++ b/tests/test_cron_gates.py
@@ -249,6 +249,65 @@ class TestMessagesGate:
         assert gate.consumer == "inbox"
 
 
+@pytest.mark.asyncio
+class TestMessagesGateBootstrap:
+    """No-sources MessagesGate against a real DB: the cursorless-consumer deadlock.
+
+    The no-sources branch reads consumer_cursors only, and the job the gate
+    blocks is the one whose poll would create those rows. Without a bootstrap
+    path the gate wedges shut in two ways: a fresh install (no rows ever) and
+    a cursor-TTL cleanup after a quiet stretch (rows deleted). Both must fire.
+    """
+
+    async def _ingest(self, db, source: str, count: int, offset: int = 0) -> None:
+        from nerve.sources.models import SourceRecord
+        records = [
+            SourceRecord(
+                id=f"msg-{source}-{offset + i}",
+                source=source,
+                record_type="test",
+                summary=f"message {offset + i}",
+                content=f"content {offset + i}",
+                timestamp=f"2026-08-14T{10 + i:02d}:00:00Z",
+            )
+            for i in range(count)
+        ]
+        await db.insert_source_messages(records, source=source)
+
+    async def test_fresh_install_backlog_opens_gate(self, db):
+        """Fresh DB, telegram messages ingested, no cursor rows → gate fires."""
+        await self._ingest(db, "telegram", 3)
+        gate = MessagesGate(consumer="inbox")
+        assert await gate.is_satisfied(_ctx(db)) is True
+
+    async def test_fresh_install_empty_inbox_keeps_gate_shut(self, db):
+        """Fresh DB with no messages at all → nothing to do, gate stays shut."""
+        gate = MessagesGate(consumer="inbox")
+        assert await gate.is_satisfied(_ctx(db)) is False
+
+    async def test_gate_reopens_after_cursor_cleanup(self, db):
+        """Cursor seeded, then expired and deleted by cleanup, then new mail → fires."""
+        await self._ingest(db, "telegram", 2)
+        max_seq = await db.get_source_max_rowid("telegram")
+        # Caught up, but the TTL has already lapsed (quiet weekend).
+        await db.set_consumer_cursor("inbox", "telegram", max_seq, ttl_days=-1)
+        assert await db.cleanup_expired_consumer_cursors() == 1
+
+        gate = MessagesGate(consumer="inbox")
+        await self._ingest(db, "telegram", 2, offset=2)
+        assert await gate.is_satisfied(_ctx(db)) is True
+
+    async def test_established_consumer_still_ignores_untracked_backlog(self, db):
+        """With at least one live cursor row, untracked sources stay ignored."""
+        await self._ingest(db, "telegram", 2)
+        await self._ingest(db, "gmail", 2)
+        max_seq = await db.get_source_max_rowid("telegram")
+        await db.set_consumer_cursor("inbox", "telegram", max_seq)
+
+        gate = MessagesGate(consumer="inbox")
+        assert await gate.is_satisfied(_ctx(db)) is False
+
+
 # ---------------------------------------------------------------------------
 # build_gate / build_gates
 # ---------------------------------------------------------------------------

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1345,9 +1345,48 @@ class TestConsumerCursors:
         assert await db.consumer_has_unread("inbox") is False
 
     async def test_consumer_has_unread_ignores_untracked_source(self, db: Database):
-        """Messages exist but the consumer has no cursor for the source → not unread."""
-        await self._insert_messages(db, "github", 2)
+        """An established consumer ignores sources it has no cursor row for.
+
+        "New consumers see only future messages": once the consumer tracks at
+        least one source, a backlog in some *other* source it never polled must
+        not count as unread.
+        """
+        gh_rowids = await self._insert_messages(db, "github", 2)
+        await self._insert_messages(db, "gmail", 2)
+        # Tracks github and is caught up; gmail is untracked.
+        await db.set_consumer_cursor("inbox", "github", gh_rowids[-1])
         assert await db.consumer_has_unread("inbox") is False
+
+    async def test_consumer_has_unread_bootstrap_fresh_install(self, db: Database):
+        """Zero cursor rows + a backlog → unread (fail-open bootstrap).
+
+        On a fresh install the consumer has no cursor rows at all, so the
+        tracked-sources check can never fire — and the job that would create
+        the first cursor row is the very job the gate is blocking. With any
+        messages present, report unread so the job runs once and seeds its
+        cursors (at MAX(rowid), so the backlog itself is still skipped).
+        """
+        await self._insert_messages(db, "telegram", 3)
+        assert await db.consumer_has_unread("inbox") is True
+
+    async def test_consumer_has_unread_false_on_empty_db(self, db: Database):
+        """Zero cursor rows and zero messages → nothing to do, gate stays shut."""
+        assert await db.consumer_has_unread("inbox") is False
+
+    async def test_consumer_has_unread_survives_cursor_cleanup(self, db: Database):
+        """Cursor rows deleted by cleanup must not wedge the check shut again.
+
+        cleanup_expired_consumer_cursors physically DELETEs expired rows, so
+        after a quiet stretch longer than the cursor TTL the consumer is back
+        to zero rows — the same state as a fresh install. New messages arriving
+        after that must still count as unread.
+        """
+        rowids = await self._insert_messages(db, "telegram", 2)
+        await db.set_consumer_cursor("inbox", "telegram", rowids[-1], ttl_days=-1)
+        assert await db.cleanup_expired_consumer_cursors() == 1
+
+        await self._insert_messages(db, "telegram", 2)
+        assert await db.consumer_has_unread("inbox") is True
 
     async def test_consumer_has_unread_counts_expired_cursor(self, db: Database):
         """A quiet inbox whose cursor expired must still report a backlog.


### PR DESCRIPTION
### The bug

A `MessagesGate` configured without an explicit source list reads `consumer_cursors` only. The job it gates is the very job whose poll creates the first cursor row — so with zero rows the gate can never open, and the job never runs to create them.

A consumer reaches that state in two ordinary ways:

- a fresh install, before the job has ever run;
- any time `cleanup_expired_consumer_cursors` deletes every row after a quiet stretch longer than the cursor TTL.

The failure is silent: the job is simply skipped forever, and nothing in the logs says why.

### The fix

With **zero** cursor rows, report unread whenever any messages exist at all. The job then runs once, its poll seeds cursors at `MAX(rowid)`, and the check reverts to the normal cursor-based path.

Backlog is still skipped — "new consumers see only future messages" is delivery semantics and is unchanged. Consumers that already have at least one cursor row keep ignoring untracked sources exactly as before, so this only affects the state that was previously unrecoverable.

### Tests

New coverage in `tests/test_cron_gates.py` and `tests/test_db.py` for both the zero-row and the established-consumer paths. Full suite green on top of current `main`.