### PR TITLE
fix: reconcile stale background-task registry entries (phantom parked dot)

### DIFF
--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -1081,12 +1081,9 @@ class AgentEngine:
                         "Client process for session %s is dead, recreating",
                         session_id,
                     )
-                    self._stop_idle_watcher(session_id)
-                    self.sessions.remove_client(session_id)
-                    self._session_backends.pop(session_id, None)
-                    self._session_models.pop(session_id, None)
-                    unregister_handler(session_id)
-                    await self._safe_disconnect(client)
+                    await self._teardown_live_client(
+                        session_id, client, drop_bindings=True,
+                    )
                     client = None
                 elif bound_model is not None and bound_model != requested_model:
                     # Model switched mid-session (e.g. the composer's picker
@@ -1096,12 +1093,9 @@ class AgentEngine:
                         "Session %s model changed (%s → %s), recreating client",
                         session_id, bound_model, requested_model,
                     )
-                    self._stop_idle_watcher(session_id)
-                    self.sessions.remove_client(session_id)
-                    self._session_backends.pop(session_id, None)
-                    self._session_models.pop(session_id, None)
-                    unregister_handler(session_id)
-                    await self._safe_disconnect(client)
+                    await self._teardown_live_client(
+                        session_id, client, drop_bindings=True,
+                    )
                     client = None
                     # Deliberate switch — drop the observed-model baseline so
                     # the first message on the new model doesn't fire a
@@ -1381,29 +1375,39 @@ class AgentEngine:
         The registry models background tasks from the CLI's event stream. Once
         the delivering client (and its idle-stream watcher) is gone, a terminal
         event for those tasks can never arrive — so any entry still "running"
-        here is orphaned. Mark such entries stopped, prune them, and broadcast
+        here is orphaned. Mark such entries done, prune them, and broadcast
         so the sidebar's "parked" dot clears at once instead of lingering until
         the next daemon restart (the registry is in-memory).
 
-        Called from ``_discard_client`` — the client-teardown path the idle
-        sweep, the idle-stream watcher, and one-shot runs all funnel through.
+        "done" (not "stopped") matches the bg registry's existing terminal
+        vocabulary — the task_notification handler already maps a CLI "stopped"
+        outcome to "done", and the frontend background_tasks_update contract
+        only knows running/done/failed/timeout.
+
+        Also settles any orphaned Workflow snapshots (the parallel
+        ``_workflows`` registry) so a workflow panel's spinner clears too.
+
+        Called from ``_discard_client`` and the client-replacement/error paths
+        (``_teardown_live_client``) — every path that removes a client.
         """
         registry = self._bg_task_registry.get(session_id)
-        if not registry:
+        bg_changed = False
+        if registry:
+            for entry in registry.values():
+                if entry.get("status") == "running":
+                    entry["status"] = "done"
+                    entry["last_event_at"] = time.monotonic()
+                    bg_changed = True
+        wf_changed = await self._settle_orphaned_workflows(session_id)
+        if not (bg_changed or wf_changed):
             return
-        changed = False
-        for entry in registry.values():
-            if entry.get("status") == "running":
-                entry["status"] = "stopped"
-                entry["last_event_at"] = time.monotonic()
-                changed = True
-        if not changed:
-            return
-        await broadcaster.broadcast(session_id, {
-            "type": "background_tasks_update",
-            "session_id": session_id,
-            "tasks": list(registry.values()),
-        })
+        if bg_changed:
+            await broadcaster.broadcast(session_id, {
+                "type": "background_tasks_update",
+                "session_id": session_id,
+                "tasks": list(registry.values()),
+            })
+        # Prunes settled bg entries AND settled workflow snapshots.
         self._prune_bg_tasks(session_id)
         # background_tasks_update only refreshes the active session's task
         # panel; the sidebar's parked dot is driven by has_background_tasks on
@@ -1412,13 +1416,62 @@ class AgentEngine:
             session_id, self.is_session_running(session_id),
         )
         logger.info(
-            "Reconciled orphaned background tasks on teardown for session %s",
-            session_id,
+            "Reconciled orphaned background tasks/workflows on teardown for "
+            "session %s", session_id,
         )
+
+    async def _settle_orphaned_workflows(self, session_id: str) -> bool:
+        """Mark still-running Workflow snapshots terminal when the client is
+        torn down, so the workflow panel spinner settles instead of spinning
+        forever (``_workflows`` is the finer-grained sibling of
+        ``_bg_task_registry``). Persists each settled snapshot so a reload
+        reconstructs it. Returns whether anything was settled — the caller
+        prunes and broadcasts.
+        """
+        wf_reg = self._workflows.get(session_id)
+        if not wf_reg:
+            return False
+        settled = False
+        for tuid, cached in wf_reg.items():
+            snap = cached.get("snapshot")
+            if snap and snap.get("status") not in ("completed", "failed", "stopped"):
+                snap["status"] = "stopped"
+                settled = True
+                await broadcaster.broadcast_workflow_progress(session_id, tuid, snap)
+                try:
+                    await self.db.merge_workflow_into_call(session_id, tuid, snap)
+                except Exception as e:  # persistence is best-effort
+                    logger.debug(
+                        "merge_workflow_into_call on teardown failed for %s: %s",
+                        tuid, e,
+                    )
+        return settled
+
+    async def _teardown_live_client(
+        self, session_id: str, client: Any, *, drop_bindings: bool = False,
+    ) -> None:
+        """Reconcile background tasks, then fully detach a live client that is
+        being replaced on an error/recreate path (dead subprocess, model
+        switch, transport retry). The client's subprocess is going, so its
+        run_in_background entries are orphaned — terminalize them first so they
+        don't pin a phantom "parked" dot after the swap, and so the idle sweep
+        (which can't see a session that has no client) never has to.
+
+        ``drop_bindings`` also clears the cached backend/model for the session,
+        for teardowns not immediately followed by a same-binding recreate.
+        """
+        await self._reconcile_bg_tasks_on_teardown(session_id)
+        self._stop_idle_watcher(session_id)
+        self.sessions.remove_client(session_id)
+        if drop_bindings:
+            self._session_backends.pop(session_id, None)
+            self._session_models.pop(session_id, None)
+        unregister_handler(session_id)
+        await self._safe_disconnect(client)
 
     async def _discard_client(
         self, session_id: str, clear_resume: bool = False,
-        background_memorize: bool = False,
+        background_memorize: bool = False, only_if_idle: bool = False,
     ) -> None:
         """Disconnect and remove a client.
 
@@ -1431,7 +1484,14 @@ class AgentEngine:
                 blocks the caller for the whole queue wait — for cron runs
                 that kept the run log "running" (and APScheduler skipping
                 subsequent fires) long after the agent turn had finished.
+            only_if_idle: If True (the idle sweep), abort the discard when a
+                new turn has started on — or replaced — the client during the
+                teardown's awaits (reconcile + memorize), so the sweep never
+                disconnects a client a freshly-started turn is using.
         """
+        # Capture the client we intend to discard: the awaits below can let a
+        # new turn reuse or replace it before we actually remove it.
+        target_client = self.sessions.get_client(session_id)
         # The client that delivers these tasks' completion is about to go —
         # terminalize any still-"running" entries so they don't pin a phantom
         # "parked" dot on the session forever.
@@ -1441,6 +1501,15 @@ class AgentEngine:
             await self.schedule_memorize(session_id)
         else:
             await self._memorize_session(session_id)
+        if only_if_idle and (
+            self.sessions.is_running(session_id)
+            or self.sessions.get_client(session_id) is not target_client
+        ):
+            logger.info(
+                "Idle discard aborted for session %s — a new turn reused the "
+                "client during teardown", session_id,
+            )
+            return
         client = self.sessions.remove_client(session_id)
         self._session_backends.pop(session_id, None)
         self._session_models.pop(session_id, None)
@@ -2757,10 +2826,7 @@ class AgentEngine:
                             "Agent runtime dead for session %s (query phase): %s — retrying",
                             session_id, _qerr,
                         )
-                        self._stop_idle_watcher(session_id)
-                        self.sessions.remove_client(session_id)
-                        unregister_handler(session_id)
-                        await self._safe_disconnect(client)
+                        await self._teardown_live_client(session_id, client)
                         client = await self._get_or_create_client(
                             session_id, source, model,
                             effort_override=effort_override,
@@ -2794,10 +2860,7 @@ class AgentEngine:
                             "(no content yet): %s — retrying with fresh client",
                             session_id, _recv_err,
                         )
-                        self._stop_idle_watcher(session_id)
-                        self.sessions.remove_client(session_id)
-                        unregister_handler(session_id)
-                        await self._safe_disconnect(client)
+                        await self._teardown_live_client(session_id, client)
                         client = await self._get_or_create_client(
                             session_id, source, model,
                             effort_override=effort_override,
@@ -2832,6 +2895,9 @@ class AgentEngine:
             await self.sessions.mark_stopped(session_id)
             self._stop_idle_watcher(session_id)
             unregister_handler(session_id)
+            # A cancelled turn tears down the client — settle any orphaned
+            # background tasks so the session keeps no phantom parked dot.
+            await self._reconcile_bg_tasks_on_teardown(session_id)
             client = self.sessions.remove_client(session_id)
             if client:
                 await self._safe_disconnect(client)
@@ -2927,6 +2993,9 @@ class AgentEngine:
             # Clear resume — CLI state may be corrupted after error
             self._stop_idle_watcher(session_id)
             unregister_handler(session_id)
+            # An errored turn tears down the client — settle any orphaned
+            # background tasks so the session keeps no phantom parked dot.
+            await self._reconcile_bg_tasks_on_teardown(session_id)
             client = self.sessions.remove_client(session_id)
             await self.sessions.mark_error(session_id, error_msg)
             if client:
@@ -3565,7 +3634,10 @@ class AgentEngine:
             logger.info("Auto-closing idle client for session %s", sid)
             # background_memorize: free the claude subprocess now; indexing
             # follows whenever the memorize queue drains.
-            await self._discard_client(sid, background_memorize=True)
+            # only_if_idle: abort if a new turn reused the client mid-teardown.
+            await self._discard_client(
+                sid, background_memorize=True, only_if_idle=True,
+            )
             discarded += 1
 
         if discarded:

--- a/nerve/agent/engine.py
+++ b/nerve/agent/engine.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -1374,6 +1375,47 @@ class AgentEngine:
                 "Failed to reset cost baseline for %s: %s", session_id, e,
             )
 
+    async def _reconcile_bg_tasks_on_teardown(self, session_id: str) -> None:
+        """Terminalize a torn-down session's still-"running" bg-task entries.
+
+        The registry models background tasks from the CLI's event stream. Once
+        the delivering client (and its idle-stream watcher) is gone, a terminal
+        event for those tasks can never arrive — so any entry still "running"
+        here is orphaned. Mark such entries stopped, prune them, and broadcast
+        so the sidebar's "parked" dot clears at once instead of lingering until
+        the next daemon restart (the registry is in-memory).
+
+        Called from ``_discard_client`` — the client-teardown path the idle
+        sweep, the idle-stream watcher, and one-shot runs all funnel through.
+        """
+        registry = self._bg_task_registry.get(session_id)
+        if not registry:
+            return
+        changed = False
+        for entry in registry.values():
+            if entry.get("status") == "running":
+                entry["status"] = "stopped"
+                entry["last_event_at"] = time.monotonic()
+                changed = True
+        if not changed:
+            return
+        await broadcaster.broadcast(session_id, {
+            "type": "background_tasks_update",
+            "session_id": session_id,
+            "tasks": list(registry.values()),
+        })
+        self._prune_bg_tasks(session_id)
+        # background_tasks_update only refreshes the active session's task
+        # panel; the sidebar's parked dot is driven by has_background_tasks on
+        # the global session_running event, so emit that too to clear it live.
+        await self._broadcast_session_running(
+            session_id, self.is_session_running(session_id),
+        )
+        logger.info(
+            "Reconciled orphaned background tasks on teardown for session %s",
+            session_id,
+        )
+
     async def _discard_client(
         self, session_id: str, clear_resume: bool = False,
         background_memorize: bool = False,
@@ -1390,6 +1432,10 @@ class AgentEngine:
                 that kept the run log "running" (and APScheduler skipping
                 subsequent fires) long after the agent turn had finished.
         """
+        # The client that delivers these tasks' completion is about to go —
+        # terminalize any still-"running" entries so they don't pin a phantom
+        # "parked" dot on the session forever.
+        await self._reconcile_bg_tasks_on_teardown(session_id)
         self._stop_idle_watcher(session_id)
         if background_memorize:
             await self.schedule_memorize(session_id)
@@ -1977,9 +2023,16 @@ class AgentEngine:
         if entry is None:
             entry = {
                 "task_id": task_id, "label": "", "tool": "Bash",
-                "status": "running",
+                "status": "running", "last_event_at": time.monotonic(),
             }
             registry[task_id] = entry
+
+        # Any event for this task is proof of life — refresh the liveness
+        # stamp unconditionally (even for events that don't change the UI
+        # chip, e.g. a workflow's repeated task_progress once its label is
+        # set). _has_live_background_tasks uses this to distinguish a task
+        # that has genuinely gone silent from one still emitting.
+        entry["last_event_at"] = time.monotonic()
 
         changed = True
         if subtype == "task_started":
@@ -3447,11 +3500,42 @@ class AgentEngine:
         discarding tears down the idle-stream watcher (``_idle_stream_watcher``)
         that delivers the task's completion turn, so the session would never
         wake when the task settles.
+
+        A ``"running"`` entry is only trusted while it keeps producing events.
+        The registry is event-driven, so a missed terminal event (a detached
+        ``&`` child the CLI stops observing, a dropped notification, a client
+        torn down before completion) would otherwise pin the entry "running"
+        forever — the session's client is never reaped and the sidebar shows a
+        permanent "parked" dot. An entry silent for longer than the configured
+        staleness window is therefore treated as not-live, which lets the idle
+        sweep proceed and reconcile it (``_reconcile_bg_tasks_on_teardown``).
+
+        The window must stay well above the longest legitimately-silent
+        background task — a from-scratch build or a long test suite can run for
+        an hour or more without emitting a single event — so this never reaps a
+        genuinely-running task. This method is a pure predicate: it does not
+        mutate the registry, so the teardown reconcile still finds the entry to
+        terminalize and broadcast.
         """
         registry = self._bg_task_registry.get(session_id)
-        return bool(registry) and any(
-            entry.get("status") == "running" for entry in registry.values()
-        )
+        if not registry:
+            return False
+        now = time.monotonic()
+        stale_seconds: float | None = None
+        for entry in registry.values():
+            if entry.get("status") != "running":
+                continue
+            if stale_seconds is None:  # resolved lazily — only if something runs
+                stale_seconds = self.config.sessions.bg_task_stale_minutes * 60
+            if stale_seconds <= 0:
+                return True  # staleness check disabled — legacy behaviour
+            # Missing stamp → treat as just-seen (live): fail toward keeping a
+            # possibly-live task, never toward reaping one. Every entry created
+            # by _handle_system_event carries a stamp, so this only guards
+            # entries built by other means.
+            if now - entry.get("last_event_at", now) < stale_seconds:
+                return True
+        return False
 
     async def run_idle_client_sweep(self) -> int:
         """Disconnect clients that have been idle beyond the configured timeout.

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -1869,11 +1869,12 @@ class SessionsConfig:
     client_idle_timeout_minutes: int = 60  # Auto-disconnect clients idle longer than this (0 = disabled)
     # A "running" background-task registry entry silent for longer than this is
     # treated as orphaned (a missed terminal event) so the idle sweep can reap
-    # the session instead of showing a permanent "parked" dot. Keep it well
-    # above the longest legitimately-silent background task (a from-scratch
-    # build or long test suite emits no events for an hour or more) so a real
-    # run_in_background task is never reaped early. 0 = disabled (legacy).
-    bg_task_stale_minutes: int = 360
+    # the session instead of showing a permanent "parked" dot. Kept well above
+    # the longest legitimately-silent background task — a from-scratch build or
+    # a long test/fuzzer run can emit no events for many hours — so a real
+    # run_in_background task is never reaped early (that would kill its
+    # idle-stream watcher and lose the completion turn). 0 = disabled (legacy).
+    bg_task_stale_minutes: int = 1440  # 24h
     star_project_hook: bool = False  # opt-in; fire an internal agent turn on star/unstar transition
     # Rows per sidebar request; caps the conversation feed and sizes one lazy Archived/System page (0 = unlimited, starred exempt).
     sidebar_page_size: int = 50
@@ -1889,7 +1890,7 @@ class SessionsConfig:
             memorize_interval_minutes=d.get("memorize_interval_minutes", 30),
             sticky_period_minutes=d.get("sticky_period_minutes", 120),
             client_idle_timeout_minutes=d.get("client_idle_timeout_minutes", 60),
-            bg_task_stale_minutes=d.get("bg_task_stale_minutes", 360),
+            bg_task_stale_minutes=d.get("bg_task_stale_minutes", 1440),
             star_project_hook=d.get("star_project_hook", False),
             sidebar_page_size=max(0, _lenient_int(d.get("sidebar_page_size"), 50)),
         )

--- a/nerve/config.py
+++ b/nerve/config.py
@@ -1867,6 +1867,13 @@ class SessionsConfig:
     memorize_interval_minutes: int = 30  # Background memorization sweep interval
     sticky_period_minutes: int = 120  # Reuse session if active within this window
     client_idle_timeout_minutes: int = 60  # Auto-disconnect clients idle longer than this (0 = disabled)
+    # A "running" background-task registry entry silent for longer than this is
+    # treated as orphaned (a missed terminal event) so the idle sweep can reap
+    # the session instead of showing a permanent "parked" dot. Keep it well
+    # above the longest legitimately-silent background task (a from-scratch
+    # build or long test suite emits no events for an hour or more) so a real
+    # run_in_background task is never reaped early. 0 = disabled (legacy).
+    bg_task_stale_minutes: int = 360
     star_project_hook: bool = False  # opt-in; fire an internal agent turn on star/unstar transition
     # Rows per sidebar request; caps the conversation feed and sizes one lazy Archived/System page (0 = unlimited, starred exempt).
     sidebar_page_size: int = 50
@@ -1882,6 +1889,7 @@ class SessionsConfig:
             memorize_interval_minutes=d.get("memorize_interval_minutes", 30),
             sticky_period_minutes=d.get("sticky_period_minutes", 120),
             client_idle_timeout_minutes=d.get("client_idle_timeout_minutes", 60),
+            bg_task_stale_minutes=d.get("bg_task_stale_minutes", 360),
             star_project_hook=d.get("star_project_hook", False),
             sidebar_page_size=max(0, _lenient_int(d.get("sidebar_page_size"), 50)),
         )

--- a/tests/test_autonomous_turns.py
+++ b/tests/test_autonomous_turns.py
@@ -39,6 +39,10 @@ def _make_engine() -> AgentEngine:
             cli_idle_timeout_seconds=2,
             context_1m=False,
         ),
+        sessions=SimpleNamespace(
+            client_idle_timeout_minutes=60,
+            bg_task_stale_minutes=360,
+        ),
     )
     engine._bg_task_registry = {}
     engine._workflows = {}
@@ -620,7 +624,9 @@ async def test_idle_sweep_skips_sessions_with_live_background_tasks():
     idle sweep — discarding its client would tear down the idle-stream watcher
     that delivers the task's completion turn (the lost-wakeup bug)."""
     engine = _make_engine()
-    engine.config.sessions = SimpleNamespace(client_idle_timeout_minutes=60)
+    engine.config.sessions = SimpleNamespace(
+        client_idle_timeout_minutes=60, bg_task_stale_minutes=360,
+    )
     engine.sessions = SimpleNamespace(
         get_idle_client_ids=lambda _timeout: ["busy", "free"],
         _clients={"busy": object(), "free": object()},

--- a/tests/test_bg_task_registry.py
+++ b/tests/test_bg_task_registry.py
@@ -16,6 +16,7 @@ Two complementary defences are tested here:
 """
 
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -223,3 +224,97 @@ async def test_normal_completion_settles_and_prunes(db, tmp_path):
         assert engine._has_live_background_tasks(sid) is False
         engine._prune_bg_tasks(sid)
         assert engine._bg_task_registry.get(sid) in (None, {})
+
+
+# --------------------------------------------------------------------------- #
+#  Client-replacement / error paths reconcile too (#2)                        #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_teardown_live_client_reconciles_and_detaches(db, tmp_path):
+    """_teardown_live_client (used by the dead-client/model-switch/transport
+    error paths) terminalizes orphaned entries and fully detaches the client —
+    so an entry can't be left running with no client for the sweep to reach."""
+    sid = "replace"
+    engine = await _make_engine(db, tmp_path, sid)
+    fake_client = SimpleNamespace(disconnect=AsyncMock())
+    engine.sessions.set_client(sid, fake_client)
+    engine._session_backends[sid] = object()
+    engine._session_models[sid] = "m"
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await _feed(engine, sid, "task_started", task_id="t1", description="build")
+        assert engine._has_live_background_tasks(sid) is True
+
+        await engine._teardown_live_client(sid, fake_client, drop_bindings=True)
+
+        assert engine._has_live_background_tasks(sid) is False
+        assert engine.sessions.get_client(sid) is None
+        assert sid not in engine._session_backends
+        fake_client.disconnect.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+#  Idle-sweep teardown never disconnects a reused client (#3)                 #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_discard_only_if_idle_aborts_when_turn_resumes(db, tmp_path):
+    """With only_if_idle, if a new turn is running on the client by the time
+    teardown reaches removal, the discard aborts — the active client survives."""
+    sid = "reused"
+    engine = await _make_engine(db, tmp_path, sid)
+    engine._memorize_session = AsyncMock()
+    engine.schedule_memorize = AsyncMock()
+    fake_client = SimpleNamespace(disconnect=AsyncMock())
+    engine.sessions.set_client(sid, fake_client)
+    engine.sessions.is_running = lambda _sid: True  # a turn reused the client
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await engine._discard_client(sid, only_if_idle=True)
+
+    assert engine.sessions.get_client(sid) is fake_client  # not torn down
+    fake_client.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discard_only_if_idle_proceeds_when_idle(db, tmp_path):
+    """Control: with only_if_idle and a genuinely idle session, the discard
+    proceeds and removes the client."""
+    sid = "still-idle"
+    engine = await _make_engine(db, tmp_path, sid)
+    engine._memorize_session = AsyncMock()
+    fake_client = SimpleNamespace(disconnect=AsyncMock())
+    engine.sessions.set_client(sid, fake_client)
+    engine.sessions.is_running = lambda _sid: False
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await engine._discard_client(sid, only_if_idle=True)
+
+    assert engine.sessions.get_client(sid) is None
+    fake_client.disconnect.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+#  Orphaned Workflow snapshots settle too (#4)                                #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_reconcile_settles_orphaned_workflow(db, tmp_path):
+    """A still-running Workflow snapshot is settled (stopped), persisted,
+    broadcast, and pruned on teardown — the panel spinner clears."""
+    sid = "wf"
+    engine = await _make_engine(db, tmp_path, sid)
+    engine.db.merge_workflow_into_call = AsyncMock()
+    engine._workflows[sid] = {
+        "tuid1": {"name": "WF", "snapshot": {"name": "WF", "status": "running"}},
+    }
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        bc.broadcast_workflow_progress = AsyncMock()
+        await engine._reconcile_bg_tasks_on_teardown(sid)
+
+    bc.broadcast_workflow_progress.assert_awaited_once()
+    engine.db.merge_workflow_into_call.assert_awaited_once()
+    # settled snapshot pruned from the live registry
+    assert engine._workflows.get(sid) in (None, {})

--- a/tests/test_bg_task_registry.py
+++ b/tests/test_bg_task_registry.py
@@ -1,0 +1,225 @@
+"""Regression tests for the background-task registry lifecycle
+(``AgentEngine._bg_task_registry``) — specifically the reconciliation that
+prevents a session from being stuck showing a permanent "parked" dot.
+
+The registry is event-driven: an entry goes "running" on ``task_started`` and
+only becomes terminal on a ``task_updated``/``task_notification`` completion
+event. If that terminal event never arrives (a detached ``&`` child the CLI
+stops observing, a dropped event, a client torn down before completion) the
+entry would otherwise stay "running" forever — the idle sweep keeps skipping
+the session, so its client is never reaped and the sidebar dot never clears.
+
+Two complementary defences are tested here:
+  1. reconcile on client teardown (``_reconcile_bg_tasks_on_teardown``), and
+  2. a staleness window in ``_has_live_background_tasks`` that lets the idle
+     sweep proceed for an entry that has gone silent (the trap-breaker).
+"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nerve.agent.backends import events as ev
+from nerve.agent.engine import AgentEngine
+from nerve.config import NerveConfig
+
+
+async def _make_engine(db, tmp_path, session_id, *, stale_minutes=None):
+    """A bare AgentEngine with one live session and no SDK client."""
+    workspace = tmp_path / f"ws-{session_id}"
+    workspace.mkdir(parents=True, exist_ok=True)
+    conf: dict = {"workspace": str(workspace), "agent": {"backend": "claude"}}
+    if stale_minutes is not None:
+        conf["sessions"] = {"bg_task_stale_minutes": stale_minutes}
+    cfg = NerveConfig.from_dict(conf)
+    engine = AgentEngine(cfg, db)
+    await engine.sessions.get_or_create(
+        session_id, title="t", source="web", backend="claude",
+    )
+    return engine
+
+
+async def _feed(engine, session_id, subtype, **data):
+    """Drive one CLI background-task lifecycle event into the engine."""
+    await engine._handle_system_event(
+        session_id, ev.SystemEvent(subtype=subtype, data=data),
+    )
+
+
+# --------------------------------------------------------------------------- #
+#  Fix #1 — reconcile on teardown                                             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_teardown_reconcile_clears_running_entry(db, tmp_path):
+    """A still-"running" entry is terminalized, pruned, and broadcast when
+    the client is reconciled on teardown."""
+    sid = "reconcile"
+    engine = await _make_engine(db, tmp_path, sid)
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await _feed(engine, sid, "task_started", task_id="t1", description="build")
+        assert engine._has_live_background_tasks(sid) is True
+
+        await engine._reconcile_bg_tasks_on_teardown(sid)
+
+        # No live task, entry pruned, and the UI was told (both the task
+        # panel update and the global session_running that drives the dot).
+        assert engine._has_live_background_tasks(sid) is False
+        assert engine._bg_task_registry.get(sid) in (None, {})
+        types = [c.args[1]["type"] for c in bc.broadcast.await_args_list]
+        assert "background_tasks_update" in types
+        assert "session_running" in types
+        running_evt = next(
+            c.args[1] for c in bc.broadcast.await_args_list
+            if c.args[1]["type"] == "session_running"
+        )
+        assert running_evt["has_background_tasks"] is False
+
+
+@pytest.mark.asyncio
+async def test_teardown_reconcile_noop_without_running(db, tmp_path):
+    """Reconcile is a no-op (no broadcast) when nothing is running — a
+    normally-completed task must not trigger a spurious update."""
+    sid = "noop"
+    engine = await _make_engine(db, tmp_path, sid)
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await _feed(engine, sid, "task_started", task_id="t1", description="x")
+        await _feed(engine, sid, "task_notification", task_id="t1", status="completed")
+        bc.broadcast.reset_mock()
+
+        await engine._reconcile_bg_tasks_on_teardown(sid)
+        bc.broadcast.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discard_client_invokes_reconcile(db, tmp_path):
+    """End-to-end: _discard_client (the shared teardown entrypoint) clears a
+    stuck entry even with no terminal event."""
+    sid = "discard"
+    engine = await _make_engine(db, tmp_path, sid)
+    engine._memorize_session = AsyncMock()  # skip the memU round-trip
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await _feed(engine, sid, "task_started", task_id="t1", description="build")
+        assert engine._has_live_background_tasks(sid) is True
+
+        await engine._discard_client(sid)
+
+        assert engine._has_live_background_tasks(sid) is False
+
+
+# --------------------------------------------------------------------------- #
+#  Fix #2 — staleness trap-breaker                                            #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_stale_running_entry_not_live(db, tmp_path):
+    """An entry silent beyond the window reads as not-live — without any
+    teardown and without mutating the registry (pure predicate)."""
+    sid = "stale"
+    engine = await _make_engine(db, tmp_path, sid, stale_minutes=360)
+    await _feed(engine, sid, "task_started", task_id="t1", description="build")
+    # Backdate its last event well past the 6h window.
+    engine._bg_task_registry[sid]["t1"]["last_event_at"] = (
+        time.monotonic() - 7 * 3600
+    )
+
+    assert engine._has_live_background_tasks(sid) is False
+    # Pure: the entry is untouched (still "running") — the teardown reconcile
+    # remains responsible for terminalizing + broadcasting.
+    assert engine._bg_task_registry[sid]["t1"]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_fresh_running_entry_is_live(db, tmp_path):
+    """A freshly-started task is live and protected from the idle sweep."""
+    sid = "fresh"
+    engine = await _make_engine(db, tmp_path, sid, stale_minutes=360)
+    await _feed(engine, sid, "task_started", task_id="t1", description="build")
+    assert engine._has_live_background_tasks(sid) is True
+
+
+@pytest.mark.asyncio
+async def test_progress_refreshes_liveness(db, tmp_path):
+    """A no-op-for-UI task_progress (label already set) still refreshes the
+    liveness stamp, so a long, actively-progressing workflow never goes
+    stale."""
+    sid = "progress"
+    engine = await _make_engine(db, tmp_path, sid, stale_minutes=360)
+    await _feed(engine, sid, "task_started", task_id="t1", description="wf")
+    # Simulate a long silence, then a fresh progress ping.
+    engine._bg_task_registry[sid]["t1"]["last_event_at"] = (
+        time.monotonic() - 7 * 3600
+    )
+    assert engine._has_live_background_tasks(sid) is False  # would be reaped
+    await _feed(engine, sid, "task_progress", task_id="t1", description="wf")
+    assert engine._has_live_background_tasks(sid) is True   # revived by event
+
+
+@pytest.mark.asyncio
+async def test_stale_window_disabled_is_legacy(db, tmp_path):
+    """bg_task_stale_minutes=0 disables the window (any running = live)."""
+    sid = "legacy"
+    engine = await _make_engine(db, tmp_path, sid, stale_minutes=0)
+    await _feed(engine, sid, "task_started", task_id="t1", description="build")
+    engine._bg_task_registry[sid]["t1"]["last_event_at"] = (
+        time.monotonic() - 100 * 3600
+    )
+    assert engine._has_live_background_tasks(sid) is True
+
+
+# --------------------------------------------------------------------------- #
+#  Idle-sweep integration — the trap and its break                           #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_idle_sweep_skips_live_task(db, tmp_path):
+    """Regression guard: the sweep must NOT discard a session with a genuine
+    live background task (the keepalive the parked-skip exists for)."""
+    sid = "keepalive"
+    engine = await _make_engine(db, tmp_path, sid, stale_minutes=360)
+    await _feed(engine, sid, "task_started", task_id="t1", description="build")
+    engine.sessions.get_idle_client_ids = lambda _secs: [sid]
+    engine._discard_client = AsyncMock()
+
+    await engine.run_idle_client_sweep()
+    engine._discard_client.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idle_sweep_reaps_stale_task(db, tmp_path):
+    """The trap is broken: once the entry is stale the sweep proceeds to
+    discard the session's client (which then reconciles the entry)."""
+    sid = "trap"
+    engine = await _make_engine(db, tmp_path, sid, stale_minutes=360)
+    await _feed(engine, sid, "task_started", task_id="t1", description="build")
+    engine._bg_task_registry[sid]["t1"]["last_event_at"] = (
+        time.monotonic() - 7 * 3600
+    )
+    engine.sessions.get_idle_client_ids = lambda _secs: [sid]
+    engine._discard_client = AsyncMock()
+
+    await engine.run_idle_client_sweep()
+    engine._discard_client.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+#  Normal completion is unchanged                                             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_normal_completion_settles_and_prunes(db, tmp_path):
+    """A task that completes normally settles and prunes as before —
+    the fix does not disturb the happy path."""
+    sid = "happy"
+    engine = await _make_engine(db, tmp_path, sid)
+    with patch("nerve.agent.engine.broadcaster") as bc:
+        bc.broadcast = AsyncMock()
+        await _feed(engine, sid, "task_started", task_id="t1", description="x")
+        await _feed(engine, sid, "task_notification", task_id="t1", status="completed")
+        assert engine._has_live_background_tasks(sid) is False
+        engine._prune_bg_tasks(sid)
+        assert engine._bg_task_registry.get(sid) in (None, {})

--- a/tests/test_memorize_background.py
+++ b/tests/test_memorize_background.py
@@ -23,6 +23,7 @@ def _make_engine() -> AgentEngine:
     """AgentEngine with mocked config/db — no initialize(), no IO."""
     config = MagicMock()
     config.sessions.sticky_period_minutes = 5
+    config.sessions.bg_task_stale_minutes = 360
     config.agent.max_concurrent = 3
     config.mcp_servers = []
     db = AsyncMock()

--- a/tests/test_parked_sessions.py
+++ b/tests/test_parked_sessions.py
@@ -102,6 +102,9 @@ class TestEnginePendingWork:
         eng = AgentEngine.__new__(AgentEngine)
         eng.db = db
         eng._bg_task_registry = {}
+        eng.config = SimpleNamespace(
+            sessions=SimpleNamespace(bg_task_stale_minutes=360),
+        )
         await db.create_session("s1", source="web")
         return eng
 


### PR DESCRIPTION
## What this fixes

A session sometimes shows a permanent pulsing **violet "parked"** dot in the sidebar even though it is idle with nothing running. It never clears on its own — a page refresh doesn't help (the flag is server-side); only a daemon restart does.

## Why it happens

The daemon tracks a session's background tasks (`run_in_background` Bash/Agent, Monitor, Workflow) in an in-memory registry built from the CLI's event stream: an entry goes **running** on `task_started` and only clears when a matching completion event arrives. `has_background_tasks` — which lights the dot — is "any entry still running".

If that completion event never arrives, the entry is stuck **running** forever. That happens when the CLI stops observing a task it started (e.g. a `nohup … &` child detached inside a `run_in_background` call, or a dropped event), or when the client is torn down before the task finishes.

It is self-perpetuating: the idle-client sweep deliberately **skips** sessions that have a live background task (so it doesn't kill the watcher that delivers a real task's completion turn). A stuck entry makes the sweep skip the session forever → its client is never torn down → nothing ever reconciles the entry. The registry is in-memory, so only a restart clears it.

Impact is cosmetic (the dot) plus a CLI subprocess that is never reaped — no effect on routing or replies.

## The fix

- **Reconcile on teardown.** When a session's client goes away, any entry still "running" is marked done and the UI is refreshed — its completion can never arrive once the client is gone. This runs on every client-removal path (idle sweep, idle-stream watcher, one-shot runs, and the dead-client / model-switch / transport-retry / crash / cancel / error paths), so an entry can't be left orphaned with no client behind it.
- **Time-box a silent entry.** An entry that has produced no event for longer than `sessions.bg_task_stale_minutes` (default **24h**; `0` disables) is treated as no-longer-live, so the sweep stops skipping the session and reconciles it. The window sits far above any real silent job — a from-scratch build or a long test/fuzzer run can emit nothing for hours — so a genuinely-running task is never reaped early (which would kill its watcher and drop the completion turn).
- **Never disconnect a busy client.** The idle sweep re-checks at teardown and backs off if a new turn started on — or replaced — the client while it was working.

Orphaned Workflow-panel state settles the same way. No frontend change: the existing `session_running` broadcast already carries the flag that drives the dot.

## Testing

`tests/test_bg_task_registry.py` (14 cases) covers teardown reconcile + broadcast, the staleness cutoff (stale / fresh / disabled), the sweep's skip-vs-reap behaviour, event-refresh liveness, the busy-client guard, Workflow settling, and unchanged normal completion. Full suite passes.

## Not in scope (pre-existing)

Two lifecycle weaknesses are left as-is (can follow up separately): the idle sweep isn't under a global lifecycle lock (only the targeted busy-client guard added here), and on a *normal* completion the sidebar flag refreshes on the next turn/refresh rather than on the terminal event.
